### PR TITLE
aptcc: Link against -lutil for forkpty

### DIFF
--- a/backends/aptcc/Makefile.am
+++ b/backends/aptcc/Makefile.am
@@ -17,7 +17,7 @@ libpk_backend_aptcc_la_SOURCES = PkgList.cpp \
                                  AptCacheFile.cpp \
 				 apt-intf.cpp \
 				 pk-backend-aptcc.cpp
-libpk_backend_aptcc_la_LIBADD = -lcrypt -lapt-pkg -lapt-inst $(PK_PLUGIN_LIBS)
+libpk_backend_aptcc_la_LIBADD = -lcrypt -lapt-pkg -lapt-inst -lutil $(PK_PLUGIN_LIBS)
 libpk_backend_aptcc_la_LDFLAGS = -module -avoid-version $(APTCC_LIBS) $(GSTREAMER_LIBS)
 libpk_backend_aptcc_la_CFLAGS = $(PK_PLUGIN_CFLAGS) $(AM_CPPFLAGS)
 libpk_backend_aptcc_la_CPPFLAGS = $(PK_PLUGIN_CFLAGS) $(APTCC_CFLAGS) $(GSTREAMER_CFLAGS) \


### PR DESCRIPTION
Commit 223ae57d468fdcac451209a095047a07a5698212 in apt causes libapt-pkg
to no longer be linked against -lutil, which means that aptcc's
reference to forkpty is no longer satisfied.  An explicit use should
have an explicit link.

Resolves: https://bugs.launchpad.net/bugs/1368246
