### PR TITLE
Allow admin users to remove packages without password prompt

### DIFF
--- a/policy/org.freedesktop.packagekit.rules
+++ b/policy/org.freedesktop.packagekit.rules
@@ -1,5 +1,6 @@
 polkit.addRule(function(action, subject) {
-    if (action.id == "org.freedesktop.packagekit.package-install" &&
+    if ((action.id == "org.freedesktop.packagekit.package-install" ||
+         action.id == "org.freedesktop.packagekit.package-remove") &&
         subject.active == true && subject.local == true &&
         subject.isInGroup("wheel")) {
             return polkit.Result.YES;


### PR DESCRIPTION
A local, active admin user can install packages without a password
prompt, but has to enter the admin password to remove packages. This
doesn't make much sense. It should be parallel.

Note that this change has no effect on what users are able to do,
because it only applies to admin users. The password only protects
against unlocked workstation attackers, where an attacker gains physical
access to an unlocked desktop. It's pretty weird to prevent such an
attacker from removing software, but allow installing new stuff.

https://pagure.io/fedora-workstation/issue/137#comment-640697