### PR TITLE
Fix #342 by ignoring the HookDir directive and updating meson version to prevent a minor warning

### DIFF
--- a/backends/alpm/pk-alpm-config.c
+++ b/backends/alpm/pk-alpm-config.c
@@ -598,6 +598,11 @@ pk_alpm_config_parse (PkAlpmConfig *config, const gchar *filename,
 			/* Ignore "Usage" key instead of crashing */
 			continue;
 		}
+		
+		if (g_strcmp0 (key, "HookDir") == 0 && str != NULL) {
+			/* Ignore "HookDir" key instead of crashing */
+			continue;
+		}
 
 		/* report errors from above */
 		g_set_error (&e, PK_ALPM_ERROR, PK_ALPM_ERR_CONFIG_INVALID,

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('PackageKit', 'c',
   version : '1.2.1',
   license : 'LGPL-2.1+',
-  meson_version : '>=0.47.0',
+  meson_version : '>=0.50.0',
   default_options : ['warning_level=2', 'c_std=c99'],
 )
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('PackageKit', 'c',
   version : '1.2.1',
   license : 'LGPL-2.1+',
-  meson_version : '>=0.50.0',
+  meson_version : '>=0.47.0',
   default_options : ['warning_level=2', 'c_std=c99'],
 )
 


### PR DESCRIPTION
This provides one possible solution for the crashes when using pacman by ignoring the "HookDir" directive. Another possible solution would be to ignore all unknown directives but having atleast some control over it is probably preferred.
Also the minimum required meson version is updated to 0.50.0 to prevent a warning thrown during the build.