### PR TITLE
PkPackage: Add update severity property

### DIFF
--- a/backends/dnf/dnf-backend.c
+++ b/backends/dnf/dnf-backend.c
@@ -32,15 +32,20 @@
 void
 dnf_emit_package (PkBackendJob *job, PkInfoEnum info, DnfPackage *pkg)
 {
+	PkInfoEnum update_severity;
+
+	update_severity = GPOINTER_TO_UINT (g_object_get_data (G_OBJECT (pkg), PK_DNF_UPDATE_SEVERITY_KEY));
+
 	/* detect */
 	if (info == PK_INFO_ENUM_UNKNOWN)
 		info = dnf_package_get_info (pkg);
 	if (info == PK_INFO_ENUM_UNKNOWN)
 		info = dnf_package_installed (pkg) ? PK_INFO_ENUM_INSTALLED : PK_INFO_ENUM_AVAILABLE;
-	pk_backend_job_package (job,
-				info,
-				dnf_package_get_package_id (pkg),
-				dnf_package_get_summary (pkg));
+	pk_backend_job_package_full (job,
+				     info,
+				     dnf_package_get_package_id (pkg),
+				     dnf_package_get_summary (pkg),
+				     update_severity);
 }
 
 void
@@ -196,6 +201,27 @@ dnf_advisory_kind_to_info_enum (DnfAdvisoryKind kind)
 		break;
 	}
 	return info_enum;
+}
+
+PkInfoEnum
+dnf_update_severity_to_enum (const gchar *severity)
+{
+	if (severity == NULL || severity[0] == '\0')
+		return PK_INFO_ENUM_UNKNOWN;
+	if (g_ascii_strcasecmp (severity, "None") == 0)
+		return PK_INFO_ENUM_UNKNOWN;
+	if (g_ascii_strcasecmp (severity, "Low") == 0)
+		return PK_INFO_ENUM_LOW;
+	if (g_ascii_strcasecmp (severity, "Moderate") == 0)
+		return PK_INFO_ENUM_NORMAL;
+	if (g_ascii_strcasecmp (severity, "Important") == 0)
+		return PK_INFO_ENUM_IMPORTANT;
+	if (g_ascii_strcasecmp (severity, "Critical") == 0)
+		return PK_INFO_ENUM_CRITICAL;
+
+	g_warning ("Failed to map update severity '%s', returning Unknown", severity);
+
+	return PK_INFO_ENUM_UNKNOWN;
 }
 
 PkBitfield

--- a/backends/dnf/dnf-backend.h
+++ b/backends/dnf/dnf-backend.h
@@ -29,9 +29,12 @@
 
 #include <pk-backend.h>
 
+#define PK_DNF_UPDATE_SEVERITY_KEY	"pk-dnf-update-severity"
+
 G_BEGIN_DECLS
 
 PkInfoEnum	 dnf_advisory_kind_to_info_enum	(DnfAdvisoryKind	 kind);
+PkInfoEnum	 dnf_update_severity_to_enum	(const gchar		*severity);
 void		 dnf_emit_package		(PkBackendJob		*job,
 						 PkInfoEnum		 info,
 						 DnfPackage		*pkg);

--- a/backends/dnf/pk-backend-dnf.c
+++ b/backends/dnf/pk-backend-dnf.c
@@ -1082,7 +1082,6 @@ pk_backend_search_thread (PkBackendJob *job, GVariant *params, gpointer user_dat
 		goto out;
 	}
 
-	/* FIXME: actually get the right update severity */
 	if (pk_backend_job_get_role (job) == PK_ROLE_ENUM_GET_UPDATES) {
 		guint i;
 		DnfPackage *pkg;
@@ -1094,6 +1093,8 @@ pk_backend_search_thread (PkBackendJob *job, GVariant *params, gpointer user_dat
 			advisory = dnf_package_get_advisory (pkg);
 			if (advisory != NULL) {
 				kind = dnf_advisory_get_kind (advisory);
+				g_object_set_data (G_OBJECT (pkg), PK_DNF_UPDATE_SEVERITY_KEY,
+					GUINT_TO_POINTER (dnf_update_severity_to_enum (dnf_advisory_get_severity (advisory))));
 				dnf_advisory_free (advisory);
 				info_enum = dnf_advisory_kind_to_info_enum (kind);
 				dnf_package_set_info (pkg, info_enum);

--- a/lib/packagekit-glib2/pk-client.c
+++ b/lib/packagekit-glib2/pk-client.c
@@ -753,6 +753,7 @@ pk_client_properties_changed_cb (GDBusProxy *proxy,
 static void
 pk_client_signal_package (PkClientState *state,
 			  PkInfoEnum info_enum,
+			  PkInfoEnum update_severity,
 			  const gchar *package_id,
 			  const gchar *summary)
 {
@@ -769,6 +770,7 @@ pk_client_signal_package (PkClientState *state,
 	g_object_set (package,
 		      "info", info_enum,
 		      "summary", summary,
+		      "update-severity", update_severity,
 		      "role", state->role,
 		      "transaction-id", state->transaction_id,
 		      NULL);
@@ -1083,8 +1085,12 @@ pk_client_signal_cb (GDBusProxy *proxy,
 			       &tmp_uint,
 			       &tmp_str[1],
 			       &tmp_str[2]);
+		/* The 'info' and 'update-severity' are encoded in the single value */
+		tmp_uint2 = tmp_uint & 0xFFFF;
+		tmp_uint3 = (tmp_uint >> 16) & 0xFFFF;
 		pk_client_signal_package (state,
-					  tmp_uint,
+					  tmp_uint2,
+					  tmp_uint3,
 					  tmp_str[1],
 					  tmp_str[2]);
 		return;

--- a/lib/packagekit-glib2/pk-enum.c
+++ b/lib/packagekit-glib2/pk-enum.c
@@ -321,6 +321,7 @@ static const PkEnumMatch enum_info[] = {
 	{PK_INFO_ENUM_DECOMPRESSING,		"decompressing"},
 	{PK_INFO_ENUM_UNTRUSTED,			"untrusted"},
 	{PK_INFO_ENUM_TRUSTED,				"trusted"},
+	{PK_INFO_ENUM_CRITICAL,			"critical"},
 	{0, NULL}
 };
 

--- a/lib/packagekit-glib2/pk-enum.h
+++ b/lib/packagekit-glib2/pk-enum.h
@@ -642,6 +642,7 @@ typedef enum {
  * @PK_INFO_ENUM_UNTRUSTED:
  * @PK_INFO_ENUM_TRUSTED:
  * @PK_INFO_ENUM_UNAVAILABLE: Package is unavailable
+ * @PK_INFO_ENUM_CRITICAL: Update severity is critical; Since: 1.2.4
  * @PK_INFO_ENUM_LAST:
  *
  * The enumerated types used in Package() - these have to refer to a specific
@@ -674,6 +675,7 @@ typedef enum {
 	PK_INFO_ENUM_UNTRUSTED,
 	PK_INFO_ENUM_TRUSTED,
 	PK_INFO_ENUM_UNAVAILABLE,
+	PK_INFO_ENUM_CRITICAL,	/* Since: 1.2.4 */
 	PK_INFO_ENUM_LAST
 } PkInfoEnum;
 

--- a/lib/packagekit-glib2/pk-package.c
+++ b/lib/packagekit-glib2/pk-package.c
@@ -70,6 +70,7 @@ struct _PkPackagePrivate
 	PkUpdateStateEnum	 update_state;
 	gchar			*update_issued;
 	gchar			*update_updated;
+	PkInfoEnum	 	 update_severity;
 };
 
 enum {
@@ -98,6 +99,7 @@ enum {
 	PROP_UPDATE_STATE,
 	PROP_UPDATE_ISSUED,
 	PROP_UPDATE_UPDATED,
+	PROP_UPDATE_SEVERITY,
 	PROP_LAST
 };
 
@@ -479,6 +481,9 @@ pk_package_get_property (GObject *object, guint prop_id, GValue *value, GParamSp
 	case PROP_UPDATE_UPDATED:
 		g_value_set_string (value, priv->update_updated);
 		break;
+	case PROP_UPDATE_SEVERITY:
+		g_value_set_enum (value, priv->update_severity);
+		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
 		break;
@@ -560,6 +565,9 @@ pk_package_set_property (GObject *object, guint prop_id, const GValue *value, GP
 	case PROP_UPDATE_UPDATED:
 		g_free (priv->update_updated);
 		priv->update_updated = g_strdup (g_value_get_string (value));
+		break;
+	case PROP_UPDATE_SEVERITY:
+		pk_package_set_update_severity (package, g_value_get_enum (value));
 		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -789,6 +797,20 @@ pk_package_class_init (PkPackageClass *klass)
 	g_object_class_install_property (object_class, PROP_UPDATE_UPDATED, pspec);
 
 	/**
+	 * PkPackage:update-severity:
+	 *
+	 * Can be one of %PK_INFO_ENUM_UNKNOWN, %PK_INFO_ENUM_LOW, %PK_INFO_ENUM_NORMAL,
+	 * %PK_INFO_ENUM_IMPORTANT or %PK_INFO_ENUM_CRITICAL.
+	 *
+	 * Since: 1.2.4
+	 */
+	pspec = g_param_spec_enum ("update-severity", NULL,
+				   "Package update severity",
+				    PK_TYPE_INFO_ENUM, PK_INFO_ENUM_UNKNOWN,
+				    G_PARAM_READWRITE);
+	g_object_class_install_property (object_class, PROP_UPDATE_SEVERITY, pspec);
+
+	/**
 	 * PkPackage::changed:
 	 * @package: the #PkPackage instance that emitted the signal
 	 *
@@ -860,4 +882,54 @@ pk_package_new (void)
 	PkPackage *package;
 	package = g_object_new (PK_TYPE_PACKAGE, NULL);
 	return PK_PACKAGE (package);
+}
+
+/**
+ * pk_package_get_update_severity:
+ * @package: a #PkPackage
+ *
+ * Returns the @package update severity. Can be one of %PK_INFO_ENUM_UNKNOWN,
+ * %PK_INFO_ENUM_LOW, %PK_INFO_ENUM_NORMAL, %PK_INFO_ENUM_IMPORTANT or
+ * %PK_INFO_ENUM_CRITICAL.
+ *
+ * Returns: the @package update severity, if known.
+ *
+ * Since: 1.2.4
+ **/
+PkInfoEnum
+pk_package_get_update_severity (PkPackage *package)
+{
+	g_return_val_if_fail (PK_IS_PACKAGE (package), PK_INFO_ENUM_UNKNOWN);
+
+	return package->priv->update_severity;
+}
+
+/**
+ * pk_package_set_update_severity:
+ * @package: a #PkPackage
+ * @update_severity: a #PkInfoEnum
+ *
+ * Set an update severity for the @package. The @update_severity can be
+ * one of %PK_INFO_ENUM_UNKNOWN, %PK_INFO_ENUM_LOW, %PK_INFO_ENUM_NORMAL,
+ * %PK_INFO_ENUM_IMPORTANT or %PK_INFO_ENUM_CRITICAL.
+ *
+ * Since: 1.2.4
+ **/
+void
+pk_package_set_update_severity (PkPackage *package,
+				PkInfoEnum update_severity)
+{
+	g_return_if_fail (PK_IS_PACKAGE (package));
+	g_return_if_fail (update_severity == PK_INFO_ENUM_UNKNOWN ||
+			  update_severity == PK_INFO_ENUM_LOW ||
+			  update_severity == PK_INFO_ENUM_NORMAL ||
+			  update_severity == PK_INFO_ENUM_IMPORTANT ||
+			  update_severity == PK_INFO_ENUM_CRITICAL);
+
+	if (package->priv->update_severity == update_severity)
+		return;
+
+	package->priv->update_severity = update_severity;
+
+	g_object_notify (G_OBJECT (package), "update-severity");
 }

--- a/lib/packagekit-glib2/pk-package.h
+++ b/lib/packagekit-glib2/pk-package.h
@@ -96,7 +96,9 @@ const gchar	*pk_package_get_name			(PkPackage	*package);
 const gchar	*pk_package_get_version			(PkPackage	*package);
 const gchar	*pk_package_get_arch			(PkPackage	*package);
 const gchar	*pk_package_get_data			(PkPackage	*package);
-
+PkInfoEnum	 pk_package_get_update_severity		(PkPackage	*package);
+void		 pk_package_set_update_severity		(PkPackage	*package,
+							 PkInfoEnum	 update_severity);
 G_END_DECLS
 
 #endif /* __PK_PACKAGE_H */

--- a/src/pk-backend-job.c
+++ b/src/pk-backend-job.c
@@ -961,6 +961,16 @@ pk_backend_job_package (PkBackendJob *job,
 			const gchar *package_id,
 			const gchar *summary)
 {
+	pk_backend_job_package_full (job, info, package_id, summary, PK_INFO_ENUM_UNKNOWN);
+}
+
+void
+pk_backend_job_package_full (PkBackendJob *job,
+			     PkInfoEnum info,
+			     const gchar *package_id,
+			     const gchar *summary,
+			     PkInfoEnum update_severity)
+{
 	PkPackage *emitted_item;
 	gboolean ret;
 	g_autoptr(GError) error = NULL;
@@ -978,6 +988,7 @@ pk_backend_job_package (PkBackendJob *job,
 		return;
 	}
 	pk_package_set_info (item, info);
+	pk_package_set_update_severity (item, update_severity);
 	pk_package_set_summary (item, summary);
 
 	/* already emitted? */

--- a/src/pk-backend-job.h
+++ b/src/pk-backend-job.h
@@ -173,6 +173,11 @@ void		 pk_backend_job_package			(PkBackendJob	*job,
 							 PkInfoEnum	 info,
 							 const gchar	*package_id,
 							 const gchar	*summary);
+void		 pk_backend_job_package_full		(PkBackendJob	*job,
+							 PkInfoEnum	 info,
+							 const gchar	*package_id,
+							 const gchar	*summary,
+							 PkInfoEnum	 update_severity);
 void		 pk_backend_job_repo_detail		(PkBackendJob	*job,
 							 const gchar	*repo_id,
 							 const gchar	*description,

--- a/src/pk-transaction.c
+++ b/src/pk-transaction.c
@@ -1145,8 +1145,10 @@ pk_transaction_package_cb (PkBackend *backend,
 {
 	const gchar *role_text;
 	PkInfoEnum info;
+	PkInfoEnum update_severity;
 	const gchar *package_id;
 	const gchar *summary = NULL;
+	guint encoded_value;
 
 	g_return_if_fail (PK_IS_TRANSACTION (transaction));
 	g_return_if_fail (transaction->priv->tid != NULL);
@@ -1206,13 +1208,20 @@ pk_transaction_package_cb (PkBackend *backend,
 			 package_id,
 			 summary);
 	}
+
+	/* Safety checks, that the two values do not interleave, neither overflow */
+	g_assert ((PK_INFO_ENUM_LAST & (~0xFFFF)) == 0);
+
+	update_severity = pk_package_get_update_severity (item);
+	encoded_value = info | (((guint32) update_severity) << 16);
+
 	g_dbus_connection_emit_signal (transaction->priv->connection,
 				       NULL,
 				       transaction->priv->tid,
 				       PK_DBUS_INTERFACE_TRANSACTION,
 				       "Package",
 				       g_variant_new ("(uss)",
-						      info,
+						      encoded_value,
 						      package_id,
 						      summary ? summary : ""),
 				       NULL);


### PR DESCRIPTION
The DNF backend can read update severity, beside the update type.
This change passes the value to the PkPackage object, thus the caller
can read it. It's set when the caller asks for the updates.

----------------------------------------------------------------------

This change has incorporated notes from https://github.com/hughsie/PackageKit/pull/474