### PR TITLE
Install size versus download size in PkDetails

### DIFF
--- a/backends/dnf/pk-backend-dnf.c
+++ b/backends/dnf/pk-backend-dnf.c
@@ -1916,14 +1916,15 @@ backend_get_details_thread (PkBackendJob *job, GVariant *params, gpointer user_d
 		pkg = g_hash_table_lookup (hash, package_ids[i]);
 		if (pkg == NULL)
 			continue;
-		pk_backend_job_details (job,
-					package_ids[i],
-					dnf_package_get_summary (pkg),
-					dnf_package_get_license (pkg),
-					PK_GROUP_ENUM_UNKNOWN,
-					dnf_package_get_description (pkg),
-					dnf_package_get_url (pkg),
-					(gulong) dnf_package_get_installsize (pkg));
+		pk_backend_job_details_full (job,
+					     package_ids[i],
+					     dnf_package_get_summary (pkg),
+					     dnf_package_get_license (pkg),
+					     PK_GROUP_ENUM_UNKNOWN,
+					     dnf_package_get_description (pkg),
+					     dnf_package_get_url (pkg),
+					     (gulong) dnf_package_get_installsize (pkg),
+					     dnf_package_is_downloaded (pkg) ? 0 : dnf_package_get_downloadsize (pkg));
 	}
 
 	/* done */
@@ -2004,14 +2005,15 @@ backend_get_details_local_thread (PkBackendJob *job, GVariant *params, gpointer 
 							   full_paths[i]);
 				return;
 			}
-			pk_backend_job_details (job,
-						dnf_package_get_package_id (pkg),
-						dnf_package_get_summary (pkg),
-						dnf_package_get_license (pkg),
-						PK_GROUP_ENUM_UNKNOWN,
-						dnf_package_get_description (pkg),
-						dnf_package_get_url (pkg),
-						(gulong) dnf_package_get_installsize (pkg));
+			pk_backend_job_details_full (job,
+						     dnf_package_get_package_id (pkg),
+						     dnf_package_get_summary (pkg),
+						     dnf_package_get_license (pkg),
+						     PK_GROUP_ENUM_UNKNOWN,
+						     dnf_package_get_description (pkg),
+						     dnf_package_get_url (pkg),
+						     (gulong) dnf_package_get_installsize (pkg),
+						     dnf_package_is_downloaded (pkg) ? 0 : dnf_package_get_downloadsize (pkg));
 		}
 	}
 

--- a/backends/dnf/pk-backend-dnf.c
+++ b/backends/dnf/pk-backend-dnf.c
@@ -1923,7 +1923,7 @@ backend_get_details_thread (PkBackendJob *job, GVariant *params, gpointer user_d
 					PK_GROUP_ENUM_UNKNOWN,
 					dnf_package_get_description (pkg),
 					dnf_package_get_url (pkg),
-					(gulong) dnf_package_get_size (pkg));
+					(gulong) dnf_package_get_installsize (pkg));
 	}
 
 	/* done */
@@ -2011,7 +2011,7 @@ backend_get_details_local_thread (PkBackendJob *job, GVariant *params, gpointer 
 						PK_GROUP_ENUM_UNKNOWN,
 						dnf_package_get_description (pkg),
 						dnf_package_get_url (pkg),
-						(gulong) dnf_package_get_size (pkg));
+						(gulong) dnf_package_get_installsize (pkg));
 		}
 	}
 

--- a/lib/packagekit-glib2/pk-client.c
+++ b/lib/packagekit-glib2/pk-client.c
@@ -1103,6 +1103,8 @@ pk_client_signal_cb (GDBusProxy *proxy,
 					g_object_set (item, "group", g_variant_get_uint32 (value), NULL);
 				else if (g_strcmp0 (key, "size") == 0)
 					g_object_set (item, "size", g_variant_get_uint64 (value), NULL);
+				else if (g_strcmp0 (key, "download-size") == 0)
+					g_object_set (item, "download-size", g_variant_get_uint64 (value), NULL);
 				else
 					g_object_set (item, key, g_variant_get_string (value, NULL), NULL);
 			}

--- a/lib/packagekit-glib2/pk-details.c
+++ b/lib/packagekit-glib2/pk-details.c
@@ -53,6 +53,7 @@ struct _PkDetailsPrivate
 	gchar				*url;
 	gchar                           *summary;
 	guint64				 size;
+	guint64				 download_size;
 };
 
 enum {
@@ -64,6 +65,7 @@ enum {
 	PROP_URL,
 	PROP_SIZE,
 	PROP_SUMMARY,
+	PROP_DOWNLOAD_SIZE,
 	PROP_LAST
 };
 
@@ -189,6 +191,23 @@ pk_details_get_size (PkDetails *details)
 	return details->priv->size;
 }
 
+/**
+ * pk_details_get_download_size:
+ * @details: a #PkDetails instance
+ *
+ * Gets the package download size.
+ *
+ * Returns: the package download size, 0 if already downloaded and G_MAXUINT64 when unknown
+ *
+ * Since: 1.2.4
+ **/
+guint64
+pk_details_get_download_size (PkDetails *details)
+{
+	g_return_val_if_fail (details != NULL, G_MAXUINT64);
+	return details->priv->download_size;
+}
+
 /*
  * pk_details_get_property:
  **/
@@ -219,6 +238,9 @@ pk_details_get_property (GObject *object, guint prop_id, GValue *value, GParamSp
 		break;
 	case PROP_SUMMARY:
 		g_value_set_string (value, priv->summary);
+		break;
+	case PROP_DOWNLOAD_SIZE:
+		g_value_set_uint64 (value, priv->download_size);
 		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -261,6 +283,9 @@ pk_details_set_property (GObject *object, guint prop_id, const GValue *value, GP
 		break;
 	case PROP_SIZE:
 		priv->size = g_value_get_uint64 (value);
+		break;
+	case PROP_DOWNLOAD_SIZE:
+		priv->download_size = g_value_get_uint64 (value);
 		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -350,6 +375,16 @@ pk_details_class_init (PkDetailsClass *klass)
 				     G_PARAM_READWRITE);
 	g_object_class_install_property (object_class, PROP_SUMMARY, pspec);
 
+	/**
+	 * PkDetails:download-size:
+	 *
+	 * Since: 1.2.4
+	 */
+	pspec = g_param_spec_uint64 ("download-size", NULL, NULL,
+				     0, G_MAXUINT64, G_MAXUINT64,
+				     G_PARAM_READWRITE);
+	g_object_class_install_property (object_class, PROP_DOWNLOAD_SIZE, pspec);
+
 	g_type_class_add_private (klass, sizeof (PkDetailsPrivate));
 }
 
@@ -360,6 +395,7 @@ static void
 pk_details_init (PkDetails *details)
 {
 	details->priv = PK_DETAILS_GET_PRIVATE (details);
+	details->priv->download_size = G_MAXUINT64;
 }
 
 /*

--- a/lib/packagekit-glib2/pk-details.h
+++ b/lib/packagekit-glib2/pk-details.h
@@ -75,6 +75,7 @@ const gchar	*pk_details_get_description		(PkDetails	*details);
 const gchar	*pk_details_get_url			(PkDetails	*details);
 guint64		 pk_details_get_size			(PkDetails	*details);
 const gchar     *pk_details_get_summary                 (PkDetails      *details);
+guint64		 pk_details_get_download_size		(PkDetails      *details);
 
 G_END_DECLS
 

--- a/src/pk-backend-job.c
+++ b/src/pk-backend-job.c
@@ -1132,6 +1132,21 @@ pk_backend_job_details (PkBackendJob *job,
 			const gchar *url,
 			gulong size)
 {
+	pk_backend_job_details_full (job, package_id, summary, license, group,
+				     description, url, size, G_MAXUINT64);
+}
+
+void
+pk_backend_job_details_full (PkBackendJob *job,
+			     const gchar *package_id,
+			     const gchar *summary,
+			     const gchar *license,
+			     PkGroupEnum group,
+			     const gchar *description,
+			     const gchar *url,
+			     gulong size,
+			     guint64 download_size)
+{
 	g_autoptr(PkDetails) item = NULL;
 
 	g_return_if_fail (PK_IS_BACKEND_JOB (job));
@@ -1153,6 +1168,7 @@ pk_backend_job_details (PkBackendJob *job,
 		      "description", description,
 		      "url", url,
 		      "size", (guint64) size,
+		      "download-size", download_size,
 		      NULL);
 
 	/* emit */

--- a/src/pk-backend-job.h
+++ b/src/pk-backend-job.h
@@ -201,6 +201,15 @@ void		 pk_backend_job_details			(PkBackendJob	*job,
 							 const gchar	*description,
 							 const gchar	*url,
 							 gulong	  size);
+void		 pk_backend_job_details_full		(PkBackendJob	*job,
+							 const gchar	*package_id,
+							 const gchar    *summary,
+							 const gchar	*license,
+							 PkGroupEnum	 group,
+							 const gchar	*description,
+							 const gchar	*url,
+							 gulong		 size,
+							 guint64	 download_size);
 void	 	 pk_backend_job_files 			(PkBackendJob	*job,
 							 const gchar	*package_id,
 							 gchar	 	**files);

--- a/src/pk-transaction.c
+++ b/src/pk-transaction.c
@@ -497,6 +497,10 @@ pk_transaction_details_cb (PkBackendJob *job,
 	if (size != 0)
 		g_variant_builder_add (&builder, "{sv}", "size",
 				       g_variant_new_uint64 (size));
+	size = pk_details_get_download_size (item);
+	if (size != G_MAXUINT64)
+		g_variant_builder_add (&builder, "{sv}", "download-size",
+				       g_variant_new_uint64 (size));
 
 	g_dbus_connection_emit_signal (transaction->priv->connection,
 				       NULL,


### PR DESCRIPTION
This consists of two changes:
* the first changes the dnf backend to use the install size, instead of the package size, in the PkDetails; two reasons for it: a) the documentation mentions it'll be an install size for installed packages; b) the user is more interested in the install size than the package size;
* related to the previous point, add "download-size" into the PkDetails - that removes the ambiguity of the PkDetails::size whether it's installed or package size, because there's no property about it in the PkDetails (one can figure out whether the package is installed or not, but it means running additional commands, which are unnecessary). It also can provide an information whether the package is ready to be installed (its download size is 0).

--------------------------------------------------------------

This has incorporated a comment from https://github.com/hughsie/PackageKit/pull/474