### PR TITLE
GitHub URL fixes

### DIFF
--- a/backends/aptcc/apt-intf.cpp
+++ b/backends/aptcc/apt-intf.cpp
@@ -1320,7 +1320,7 @@ PkgList AptIntf::getUpdates(PkgList &blocked, PkgList &downgrades, PkgList &inst
         if (pkg->SelectedState == pkgCache::State::Hold) {
             // We pretend held packages are not upgradable at all since we can't represent
             // the concept of holds in PackageKit.
-            // https://github.com/hughsie/PackageKit/issues/120
+            // https://github.com/PackageKit/PackageKit/issues/120
             continue;
         } else if (state.Upgrade() == true && state.NewInstall() == false) {
             const pkgCache::VerIterator &ver = m_cache->findCandidateVer(pkg);

--- a/docs/api/PackageKit-docs.sgml
+++ b/docs/api/PackageKit-docs.sgml
@@ -55,7 +55,7 @@
         PackageKit daemon. The machine-readable specifications are
         available as XML documents for both the PackageKit interface
         and the PackageKit.Transaction interface.
-        <xref href="https://github.com/hughsie/PackageKit/blob/master/src/org.freedesktop.PackageKit.xml" scope="external" role="friend" format="html"> XML specification of the org.freedesktop.PackageKit interface</xref>
+        <xref href="https://github.com/PackageKit/PackageKit/blob/main/src/org.freedesktop.PackageKit.xml" scope="external" role="friend" format="html"> XML specification of the org.freedesktop.PackageKit interface</xref>
       </para>
     </partintro>
     <xi:include href="dbus/org.freedesktop.PackageKit.ref.xml"/>

--- a/docs/html/pk-bugs.html
+++ b/docs/html/pk-bugs.html
@@ -20,11 +20,11 @@
 <h1>Reporting Bugs</h1>
 
 <p>
-First, please look at the <a href="https://github.com/hughsie/PackageKit/issues">list of PackageKit bugs</a>,
+First, please look at the <a href="https://github.com/PackageKit/PackageKit/issues">list of PackageKit bugs</a>,
 so that you are sure the bug you are reporting isn't a duplicate bug that
 someone else has fixed or reported.
 If not present, then please create a new bug attaching all the information
-to this <a href="https://github.com/hughsie/PackageKit/issues/new">new bug</a>.
+to this <a href="https://github.com/PackageKit/PackageKit/issues/new">new bug</a>.
 </p>
 
 <h2>General Bugs</h2>

--- a/docs/html/pk-download.html
+++ b/docs/html/pk-download.html
@@ -35,10 +35,10 @@ http://www.freedesktop.org/software/PackageKit/releases/</a>.
 <h2>Compiling the latest code</h2>
 <p>
 You can get the latest PackageKit daemon from the
-<a href="https://github.com/hughsie/PackageKit">public git repositories</a>.
+<a href="https://github.com/PackageKit/PackageKit">public git repositories</a>.
 </p>
 <pre>
-git clone https://github.com/hughsie/PackageKit.git
+git clone https://github.com/PackageKit/PackageKit.git
 </pre>
 <p>
 If you want to commit changes or a add a new backend, then please email the


### PR DESCRIPTION
This PR contains a couple of minor URL fixes in the source tree to account for the move of the PackageKit repository to its own GitHub organization.