### PR TITLE
packagekit-direct: make backends that use pk-backend-spawn work (#477)

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -39,6 +39,10 @@ packagekit_direct_exec = executable(
   'pk-direct.c',
   'pk-shared.c',
   'pk-shared.h',
+  'pk-spawn.c',
+  'pk-spawn.h',
+  'pk-backend-spawn.h',
+  'pk-backend-spawn.c',
   dependencies: [
     packagekit_glib2_dep,
     libsystemd,


### PR DESCRIPTION
The packagekit-direct executable couldn't use backends that use
functions from pk-backend-spawn.h, e.g., the APT backend:

# /usr/lib/packagekit-direct refresh
Failed to load the backend: opening module aptcc failed : /usr/lib64/packagekit-backend/libpk_backend_aptcc.so: undefined symbol: pk_backend_spawn_set_name