### PR TITLE
packagekit-direct: make backends that use pk-backend-spawn work (#477, but for PACKAGEKIT_1_1_X with autotools)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -87,7 +87,11 @@ packagekit_direct_SOURCES =				\
 	pk-backend-job.h				\
 	pk-direct.c					\
 	pk-shared.c					\
-	pk-shared.h
+	pk-shared.h					\
+	pk-spawn.c					\
+	pk-spawn.h					\
+	pk-backend-spawn.h				\
+	pk-backend-spawn.c
 
 packagekit_direct_CPPFLAGS =				\
 	$(AM_CPPFLAGS)					\


### PR DESCRIPTION
(This fixes the same issue as the cited commit, but for
PACKAGEKIT_1_1_X with autotools.)

In case you still accept fixes for PACKAGEKIT_1_1_X with autotools, here is the fix for the same issue (fixed in master). I have got it ready because it made my life simpler with a kind of bisect of previous versions and testing them with `packagekit-direct`.

commit 40cd9727d79683e85fcbd8e1ac74ce06a933d3cf
Author: Ivan Zakharyaschev <imz@altlinux.org>
Date:   Thu May 20 22:43:08 2021 +0300

    packagekit-direct: make backends that use pk-backend-spawn work (#477)

    The packagekit-direct executable couldn't use backends that use
    functions from pk-backend-spawn.h, e.g., the APT backend:

    # /usr/lib/packagekit-direct refresh
    Failed to load the backend: opening module aptcc failed : /usr/lib64/packagekit-backend/libpk_backend_aptcc.so: undefined symbol: pk_backend_spawn_set_name