### PR TITLE
dnf: Use 'hy_query_get_advisory_pkgs', if available

### DIFF
--- a/backends/dnf/meson.build
+++ b/backends/dnf/meson.build
@@ -1,6 +1,11 @@
 appstream_dep = dependency('appstream-glib')
 dnf_dep = dependency('libdnf', version: '>=0.43.1')
 rpm_dep = dependency('rpm')
+c_args = ['-DG_LOG_DOMAIN="PackageKit-DNF"']
+
+if meson.get_compiler('c').has_function('hy_query_get_advisory_pkgs', prefix: '#include <libdnf/hy-query.h>', dependencies: dnf_dep)
+   c_args += ['-DHAVE_HY_QUERY_GET_ADVISORY_PKGS']
+endif
 
 shared_module(
   'pk_backend_dnf',
@@ -18,7 +23,7 @@ shared_module(
     gmodule_dep,
   ],
   c_args: [
-    '-DG_LOG_DOMAIN="PackageKit-DNF"',
+    c_args
   ],
   install: true,
   install_dir: pk_plugin_dir,

--- a/backends/dnf/pk-backend-dnf.c
+++ b/backends/dnf/pk-backend-dnf.c
@@ -912,19 +912,66 @@ pk_backend_what_provides_decompose (gchar **values, GError **error)
 	return (gchar **) g_ptr_array_free (array, FALSE);
 }
 
-static DnfAdvisory *
-dnf_package_get_advisory (DnfPackage *package)
+static GHashTable *
+pk_backend_dnf_cache_advisories (DnfSack *sack)
 {
+#ifdef HAVE_HY_QUERY_GET_ADVISORY_PKGS
+	g_autoptr(GPtrArray) array = NULL;
+	GHashTable *hash;
+	HyQuery query;
+	guint ii;
+
+	hash = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, (GDestroyNotify) dnf_advisory_free);
+	query = hy_query_create (sack);
+	array = hy_query_get_advisory_pkgs (query, HY_EQ);
+
+	for (ii = 0; ii < array->len; ii++) {
+		DnfAdvisoryPkg *advpkg = g_ptr_array_index (array, ii);
+		gchar *id;
+
+		id = g_strdup_printf ("%s;%s;%s",
+			dnf_advisorypkg_get_name (advpkg),
+			dnf_advisorypkg_get_evr (advpkg),
+			dnf_advisorypkg_get_arch (advpkg));
+
+		g_hash_table_insert (hash, id, dnf_advisorypkg_get_advisory (advpkg));
+	}
+
+	hy_query_free (query);
+	return hash;
+#else
+	return NULL;
+#endif
+}
+
+static DnfAdvisory *
+pk_backend_dnf_get_advisory (GHashTable *advisories_hash,
+			     DnfPackage *pkg)
+{
+#ifdef HAVE_HY_QUERY_GET_ADVISORY_PKGS
+	g_autofree gchar *id = NULL;
+
+	if (pkg == NULL)
+		return NULL;
+
+	id = g_strdup_printf ("%s;%s;%s",
+		dnf_package_get_name (pkg),
+		dnf_package_get_evr (pkg),
+		dnf_package_get_arch (pkg));
+
+	return g_hash_table_lookup (advisories_hash, id);
+#else
 	GPtrArray *advisorylist;
 	DnfAdvisory *advisory = NULL;
 
-	advisorylist = dnf_package_get_advisories (package, HY_EQ);
+	advisorylist = dnf_package_get_advisories (pkg, HY_EQ);
 
 	if (advisorylist->len > 0)
 		advisory = g_steal_pointer (&g_ptr_array_index (advisorylist, 0));
 	g_ptr_array_unref (advisorylist);
 
 	return advisory;
+#endif
 }
 
 static void
@@ -1088,14 +1135,17 @@ pk_backend_search_thread (PkBackendJob *job, GVariant *params, gpointer user_dat
 		DnfAdvisory *advisory;
 		DnfAdvisoryKind kind;
 		PkInfoEnum info_enum;
+		g_autoptr(GHashTable) advisories_hash = pk_backend_dnf_cache_advisories (sack);
 		for (i = 0; i < pkglist->len; i++) {
 			pkg = g_ptr_array_index (pkglist, i);
-			advisory = dnf_package_get_advisory (pkg);
+			advisory = pk_backend_dnf_get_advisory (advisories_hash, pkg);
 			if (advisory != NULL) {
 				kind = dnf_advisory_get_kind (advisory);
 				g_object_set_data (G_OBJECT (pkg), PK_DNF_UPDATE_SEVERITY_KEY,
 					GUINT_TO_POINTER (dnf_update_severity_to_enum (dnf_advisory_get_severity (advisory))));
+#ifndef HAVE_HY_QUERY_GET_ADVISORY_PKGS
 				dnf_advisory_free (advisory);
+#endif
 				info_enum = dnf_advisory_kind_to_info_enum (kind);
 				dnf_package_set_info (pkg, info_enum);
 			}
@@ -3684,6 +3734,7 @@ pk_backend_get_update_detail_thread (PkBackendJob *job, GVariant *params, gpoint
 	g_autoptr(DnfSack) sack = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GHashTable) hash = NULL;
+	g_autoptr(GHashTable) advisories_hash = NULL;
 
 	/* set state */
 	ret = dnf_state_set_steps (job_data->state, NULL,
@@ -3726,6 +3777,8 @@ pk_backend_get_update_detail_thread (PkBackendJob *job, GVariant *params, gpoint
 		return;
 	}
 
+	advisories_hash = pk_backend_dnf_cache_advisories (sack);
+
 	/* emit details for each */
 	for (i = 0; package_ids[i] != NULL; i++) {
 		g_autoptr(GPtrArray) vendor_urls = NULL;
@@ -3735,7 +3788,7 @@ pk_backend_get_update_detail_thread (PkBackendJob *job, GVariant *params, gpoint
 		pkg = g_hash_table_lookup (hash, package_ids[i]);
 		if (pkg == NULL)
 			continue;
-		advisory = dnf_package_get_advisory (pkg);
+		advisory = pk_backend_dnf_get_advisory (advisories_hash, pkg);
 		if (advisory == NULL)
 			continue;
 
@@ -3787,7 +3840,9 @@ pk_backend_get_update_detail_thread (PkBackendJob *job, GVariant *params, gpoint
 					      NULL /* updated */);
 
 		g_ptr_array_unref (references);
+#ifndef HAVE_HY_QUERY_GET_ADVISORY_PKGS
 		dnf_advisory_free (advisory);
+#endif
 	}
 
 	/* done */


### PR DESCRIPTION
This provides significant performance improvement when checking
package advisories.

Do not bump version dependency on libdnf, rather check during
the configure phase whether the function exists and conditional-compile
related code accordingly.

This depends on https://github.com/rpm-software-management/libdnf/pull/1252