### PR TITLE
aptcc: fix serveral bugs relating to installing and searching packages

### DIFF
--- a/backends/aptcc/apt-cache-file.cpp
+++ b/backends/aptcc/apt-cache-file.cpp
@@ -382,9 +382,12 @@ PkgInfo AptCacheFile::resolvePkgID(const gchar *packageId)
 
     const pkgCache::VerIterator &candidateVer = findCandidateVer(pkg);
     // check to see if the provided package isn't virtual too
-    if (candidateVer.end() == false &&
-            strcmp(candidateVer.VerStr(), parts[PK_PACKAGE_ID_VERSION]) == 0)
-        return PkgInfo(candidateVer, piAction);
+    // also iterate through all the available versions
+    for (auto candidate = candidateVer; !candidate.end(); candidate++) {
+        if (strcmp(candidate.VerStr(), parts[PK_PACKAGE_ID_VERSION]) == 0) {
+            return PkgInfo(ver, piAction);
+        }
+    }
 
     return PkgInfo(ver, piAction);
 }

--- a/backends/aptcc/apt-intf.cpp
+++ b/backends/aptcc/apt-intf.cpp
@@ -1679,7 +1679,7 @@ PkgList AptIntf::checkChangedPackages(bool emitChanged)
             }
         } else if ((*m_cache)[pkg].Downgrade() == true) {
             // downgrading
-            const pkgCache::VerIterator &ver = m_cache->findVer(pkg);
+            const pkgCache::VerIterator &ver = m_cache->findCandidateVer(pkg);
             if (!ver.end()) {
                 ret.append(ver);
                 downgrading.append(ver);

--- a/backends/aptcc/apt-intf.h
+++ b/backends/aptcc/apt-intf.h
@@ -163,7 +163,8 @@ public:
       */
     void emitPackages(PkgList &output,
                       PkBitfield filters = PK_FILTER_ENUM_NONE,
-                      PkInfoEnum state = PK_INFO_ENUM_UNKNOWN);
+                      PkInfoEnum state = PK_INFO_ENUM_UNKNOWN,
+                      bool multiversion = false);
 
     void emitRequireRestart(PkgList &output);
 

--- a/backends/aptcc/pk-backend-aptcc.cpp
+++ b/backends/aptcc/pk-backend-aptcc.cpp
@@ -607,7 +607,7 @@ static void pk_backend_resolve_thread(PkBackendJob *job, GVariant *params, gpoin
     PkgList pkgs = apt->resolvePackageIds(search);
 
     // It's faster to emit the packages here rather than in the matching part
-    apt->emitPackages(pkgs, filters);
+    apt->emitPackages(pkgs, filters, PK_INFO_ENUM_UNKNOWN, true);
 }
 
 void pk_backend_resolve(PkBackend *backend, PkBackendJob *job, PkBitfield filters, gchar **packages)
@@ -716,7 +716,7 @@ static void backend_search_package_thread(PkBackendJob *job, GVariant *params, g
     }
 
     // It's faster to emit the packages here than in the matching part
-    apt->emitPackages(output, filters);
+    apt->emitPackages(output, filters, PK_INFO_ENUM_UNKNOWN, true);
 
     pk_backend_job_set_percentage(job, 100);
 }


### PR DESCRIPTION
This Pull Request will fix a few bugs relating to installing and searching packages when using the `aptcc` backend, namely:

- When installing a package that is not the latest available version, the backend will either treat the package as does not exist or install a version that is different than requested
- When downgrading a package, the backend will incorrectly reinstall the package using the current version instead of performing a downgrade to the specified version
- When searching/resolving a package or package ID, the backend will fail to list all the available versions or just fail to list anything