### PR TITLE
pk-task: Add specific error code when user declined interaction

### DIFF
--- a/lib/packagekit-glib2/pk-client.h
+++ b/lib/packagekit-glib2/pk-client.h
@@ -57,6 +57,7 @@ G_BEGIN_DECLS
  * @PK_CLIENT_ERROR_INVALID_FILE: the file is invalid
  * @PK_CLIENT_ERROR_NOT_SUPPORTED: the action is not supported
  * @PK_CLIENT_ERROR_DECLINED_SIMULATION: the simulation was declined by the user
+ * @PK_CLIENT_ERROR_DECLINED_INTERACTION: the user declined interaction on the task
  * @PK_CLIENT_ERROR_LAST:
  *
  * Errors that can be thrown
@@ -73,6 +74,7 @@ typedef enum
 	PK_CLIENT_ERROR_INVALID_FILE,
 	PK_CLIENT_ERROR_NOT_SUPPORTED,
 	PK_CLIENT_ERROR_DECLINED_SIMULATION,
+	PK_CLIENT_ERROR_DECLINED_INTERACTION,
 	/* we define this so we can punt the PkErrorEnums here at offset 0xff */
 	PK_CLIENT_ERROR_LAST
 } PkClientError;

--- a/lib/packagekit-glib2/pk-task.c
+++ b/lib/packagekit-glib2/pk-task.c
@@ -821,7 +821,7 @@ pk_task_user_declined_idle_cb (PkTaskState *state)
 	g_debug ("declined request %i", state->request);
 	g_set_error (&error,
 			     PK_CLIENT_ERROR,
-			     PK_CLIENT_ERROR_FAILED, "user declined interaction");
+			     PK_CLIENT_ERROR_DECLINED_INTERACTION, "user declined interaction");
 	pk_task_generic_state_finish (state, error);
 	return FALSE;
 }


### PR DESCRIPTION
To make it easier to know, in the code, that the user declined
the interaction on the task and react on it properly, rather than
checking a generic error code and the error message, which can
eventually change in the future.