### PR TITLE
pk-engine: Always allow user interaction for offline update/upgrade

### DIFF
--- a/client/pk-console.c
+++ b/client/pk-console.c
@@ -2283,14 +2283,14 @@ main (int argc, char *argv[])
 	} else if (strcmp (mode, "offline-trigger") == 0) {
 
 		run_mainloop = FALSE;
-		ret = pk_offline_trigger (PK_OFFLINE_ACTION_REBOOT, NULL, &error);
+		ret = pk_offline_trigger_with_flags (PK_OFFLINE_ACTION_REBOOT, PK_OFFLINE_FLAGS_INTERACTIVE, NULL, &error);
 		if (!ret)
 			ctx->retval = error->code;
 
 	} else if (strcmp (mode, "offline-cancel") == 0) {
 
 		run_mainloop = FALSE;
-		ret = pk_offline_cancel (NULL, &error);
+		ret = pk_offline_cancel_with_flags (PK_OFFLINE_FLAGS_INTERACTIVE, NULL, &error);
 		if (!ret)
 			ctx->retval = error->code;
 

--- a/docs/api/PackageKit-sections.txt
+++ b/docs/api/PackageKit-sections.txt
@@ -525,9 +525,13 @@ pk_offline_get_action_monitor
 pk_offline_get_results
 pk_offline_get_results_mtime
 pk_offline_cancel
+pk_offline_cancel_with_flags
 pk_offline_clear_results
+pk_offline_clear_results_with_flags
 pk_offline_trigger
+pk_offline_trigger_with_flags
 pk_offline_trigger_upgrade
+pk_offline_trigger_upgrade_with_flags
 </SECTION>
 
 <SECTION>

--- a/lib/packagekit-glib2/pk-offline.c
+++ b/lib/packagekit-glib2/pk-offline.c
@@ -95,8 +95,37 @@ pk_offline_action_from_string (const gchar *action)
 	return PK_OFFLINE_ACTION_UNKNOWN;
 }
 
+static GDBusCallFlags
+pk_offline_flags_to_gdbus_call_flags (PkOfflineFlags flags)
+{
+	if ((flags & PK_OFFLINE_FLAGS_INTERACTIVE) != 0)
+		return G_DBUS_CALL_FLAGS_ALLOW_INTERACTIVE_AUTHORIZATION;
+	return G_DBUS_CALL_FLAGS_NONE;
+}
+
 /**
  * pk_offline_cancel:
+ * @cancellable: A #GCancellable or %NULL
+ * @error: A #GError or %NULL
+ *
+ * Cancels the offline operation that has been scheduled. If there is no
+ * scheduled offline operation then this method returns with success.
+ * The function always allows user interaction. To change the behavior,
+ * use pk_offline_cancel_with_flags().
+ *
+ * Return value: %TRUE for success, else %FALSE and @error set
+ *
+ * Since: 0.9.6
+ **/
+gboolean
+pk_offline_cancel (GCancellable *cancellable, GError **error)
+{
+	return pk_offline_cancel_with_flags (PK_OFFLINE_FLAGS_INTERACTIVE, cancellable, error);
+}
+
+/**
+ * pk_offline_cancel_with_flags:
+ * @flags: bit-or of #PkOfflineFlags
  * @cancellable: A #GCancellable or %NULL
  * @error: A #GError or %NULL
  *
@@ -105,10 +134,10 @@ pk_offline_action_from_string (const gchar *action)
  *
  * Return value: %TRUE for success, else %FALSE and @error set
  *
- * Since: 0.9.6
+ * Since: 1.2.5
  **/
 gboolean
-pk_offline_cancel (GCancellable *cancellable, GError **error)
+pk_offline_cancel_with_flags (PkOfflineFlags flags, GCancellable *cancellable, GError **error)
 {
 	g_autoptr(GDBusConnection) connection = NULL;
 	g_autoptr(GVariant) res = NULL;
@@ -125,7 +154,7 @@ pk_offline_cancel (GCancellable *cancellable, GError **error)
 					   "Cancel",
 					   NULL,
 					   NULL,
-					   G_DBUS_CALL_FLAGS_NONE,
+					   pk_offline_flags_to_gdbus_call_flags (flags),
 					   -1,
 					   cancellable,
 					   error);
@@ -139,8 +168,10 @@ pk_offline_cancel (GCancellable *cancellable, GError **error)
  * @cancellable: A #GCancellable or %NULL
  * @error: A #GError or %NULL
  *
- * Crears the last offline operation report, which may be success or failure.
+ * Clears the last offline operation report, which may be success or failure.
  * If the report does not exist then this method returns success.
+ * The function always allows user interaction. To change the behavior,
+ * use pk_offline_clear_results_with_flags().
  *
  * Return value: %TRUE for success, else %FALSE and @error set
  *
@@ -148,6 +179,25 @@ pk_offline_cancel (GCancellable *cancellable, GError **error)
  **/
 gboolean
 pk_offline_clear_results (GCancellable *cancellable, GError **error)
+{
+	return pk_offline_clear_results_with_flags (PK_OFFLINE_FLAGS_INTERACTIVE, cancellable, error);
+}
+
+/**
+ * pk_offline_clear_results_with_flags:
+ * @flags: bit-or of #PkOfflineFlags
+ * @cancellable: A #GCancellable or %NULL
+ * @error: A #GError or %NULL
+ *
+ * Clears the last offline operation report, which may be success or failure.
+ * If the report does not exist then this method returns success.
+ *
+ * Return value: %TRUE for success, else %FALSE and @error set
+ *
+ * Since: 1.2.5
+ **/
+gboolean
+pk_offline_clear_results_with_flags (PkOfflineFlags flags, GCancellable *cancellable, GError **error)
 {
 	g_autoptr(GDBusConnection) connection = NULL;
 	g_autoptr(GVariant) res = NULL;
@@ -164,7 +214,7 @@ pk_offline_clear_results (GCancellable *cancellable, GError **error)
 					   "ClearResults",
 					   NULL,
 					   NULL,
-					   G_DBUS_CALL_FLAGS_NONE,
+					   pk_offline_flags_to_gdbus_call_flags (flags),
 					   -1,
 					   cancellable,
 					   error);
@@ -181,6 +231,8 @@ pk_offline_clear_results (GCancellable *cancellable, GError **error)
  *
  * Triggers the offline update so that the next reboot will perform the
  * pending transaction.
+ * The function always allows user interaction. To change the behavior,
+ * use pk_offline_trigger_with_flags().
  *
  * Return value: %TRUE for success, else %FALSE and @error set
  *
@@ -188,6 +240,26 @@ pk_offline_clear_results (GCancellable *cancellable, GError **error)
  **/
 gboolean
 pk_offline_trigger (PkOfflineAction action, GCancellable *cancellable, GError **error)
+{
+	return pk_offline_trigger_with_flags (action, PK_OFFLINE_FLAGS_INTERACTIVE, cancellable, error);
+}
+
+/**
+ * pk_offline_trigger_with_flags:
+ * @action: a #PkOfflineAction, e.g. %PK_OFFLINE_ACTION_REBOOT
+ * @flags: bit-or of #PkOfflineFlags
+ * @cancellable: A #GCancellable or %NULL
+ * @error: A #GError or %NULL
+ *
+ * Triggers the offline update so that the next reboot will perform the
+ * pending transaction.
+ *
+ * Return value: %TRUE for success, else %FALSE and @error set
+ *
+ * Since: 1.2.5
+ **/
+gboolean
+pk_offline_trigger_with_flags (PkOfflineAction action, PkOfflineFlags flags, GCancellable *cancellable, GError **error)
 {
 	const gchar *tmp;
 	g_autoptr(GDBusConnection) connection = NULL;
@@ -206,7 +278,7 @@ pk_offline_trigger (PkOfflineAction action, GCancellable *cancellable, GError **
 					   "Trigger",
 					   g_variant_new ("(s)", tmp),
 					   NULL,
-					   G_DBUS_CALL_FLAGS_NONE,
+					   pk_offline_flags_to_gdbus_call_flags (flags),
 					   -1,
 					   cancellable,
 					   error);
@@ -223,6 +295,8 @@ pk_offline_trigger (PkOfflineAction action, GCancellable *cancellable, GError **
  *
  * Triggers the offline system upgrade so that the next reboot will perform the
  * pending transaction.
+ * The function always allows user interaction. To change the behavior,
+ * use pk_offline_trigger_upgrade_with_flags().
  *
  * Return value: %TRUE for success, else %FALSE and @error set
  *
@@ -230,6 +304,26 @@ pk_offline_trigger (PkOfflineAction action, GCancellable *cancellable, GError **
  **/
 gboolean
 pk_offline_trigger_upgrade (PkOfflineAction action, GCancellable *cancellable, GError **error)
+{
+	return pk_offline_trigger_upgrade_with_flags (action, PK_OFFLINE_FLAGS_INTERACTIVE, cancellable, error);
+}
+
+/**
+ * pk_offline_trigger_upgrade_with_flags:
+ * @action: a #PkOfflineAction, e.g. %PK_OFFLINE_ACTION_REBOOT
+ * @flags: bit-or of #PkOfflineFlags
+ * @cancellable: A #GCancellable or %NULL
+ * @error: A #GError or %NULL
+ *
+ * Triggers the offline system upgrade so that the next reboot will perform the
+ * pending transaction.
+ *
+ * Return value: %TRUE for success, else %FALSE and @error set
+ *
+ * Since: 1.2.5
+ **/
+gboolean
+pk_offline_trigger_upgrade_with_flags (PkOfflineAction action, PkOfflineFlags flags, GCancellable *cancellable, GError **error)
 {
 	const gchar *tmp;
 	g_autoptr(GDBusConnection) connection = NULL;
@@ -248,7 +342,7 @@ pk_offline_trigger_upgrade (PkOfflineAction action, GCancellable *cancellable, G
 					   "TriggerUpgrade",
 					   g_variant_new ("(s)", tmp),
 					   NULL,
-					   G_DBUS_CALL_FLAGS_NONE,
+					   pk_offline_flags_to_gdbus_call_flags (flags),
 					   -1,
 					   cancellable,
 					   error);

--- a/lib/packagekit-glib2/pk-offline.h
+++ b/lib/packagekit-glib2/pk-offline.h
@@ -71,6 +71,21 @@ typedef enum
 	PK_OFFLINE_ERROR_LAST
 } PkOfflineError;
 
+/**
+ * PkOfflineFlags:
+ * @PK_OFFLINE_FLAGS_NONE:		No specific flag
+ * @PK_OFFLINE_FLAGS_INTERACTIVE:	Run the action in an interactive mode, allowing polkit authentication dialogs
+ *
+ * Flags to be used for the method invocations.
+ *
+ * Since: 1.2.5
+ */
+typedef enum
+{
+	PK_OFFLINE_FLAGS_NONE		= 0,
+	PK_OFFLINE_FLAGS_INTERACTIVE	= 1 << 0
+} PkOfflineFlags;
+
 GQuark			 pk_offline_error_quark		(void);
 const gchar		*pk_offline_action_to_string	(PkOfflineAction	 action);
 PkOfflineAction		 pk_offline_action_from_string	(const gchar		*action);
@@ -92,12 +107,28 @@ PkResults		*pk_offline_get_results		(GError			**error);
 guint64			 pk_offline_get_results_mtime	(GError			**error);
 gboolean		 pk_offline_cancel		(GCancellable		*cancellable,
 							 GError			**error);
+gboolean		 pk_offline_cancel_with_flags	(PkOfflineFlags		 flags,
+							 GCancellable		*cancellable,
+							 GError			**error);
 gboolean		 pk_offline_clear_results	(GCancellable		*cancellable,
+							 GError			**error);
+gboolean		 pk_offline_clear_results_with_flags
+							(PkOfflineFlags		 flags,
+							 GCancellable		*cancellable,
 							 GError			**error);
 gboolean		 pk_offline_trigger		(PkOfflineAction	 action,
 							 GCancellable		*cancellable,
 							 GError			**error);
+gboolean		 pk_offline_trigger_with_flags	(PkOfflineAction	 action,
+							 PkOfflineFlags		 flags,
+							 GCancellable		*cancellable,
+							 GError			**error);
 gboolean		 pk_offline_trigger_upgrade	(PkOfflineAction	 action,
+							 GCancellable		*cancellable,
+							 GError			**error);
+gboolean		 pk_offline_trigger_upgrade_with_flags
+							(PkOfflineAction	 action,
+							 PkOfflineFlags		 flags,
 							 GCancellable		*cancellable,
 							 GError			**error);
 

--- a/lib/packagekit-glib2/pk-test-daemon.c
+++ b/lib/packagekit-glib2/pk-test-daemon.c
@@ -154,7 +154,7 @@ pk_test_offline_func (void)
 	g_assert_cmpstr (data, ==, "powertop;1.8-1.fc8;i386;fedora");
 
 	/* trigger */
-	ret = pk_offline_trigger (PK_OFFLINE_ACTION_REBOOT, NULL, &error);
+	ret = pk_offline_trigger_with_flags (PK_OFFLINE_ACTION_REBOOT, PK_OFFLINE_FLAGS_INTERACTIVE, NULL, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 	g_assert (g_file_test (PK_OFFLINE_PREPARED_FILENAME, G_FILE_TEST_EXISTS));
@@ -163,7 +163,7 @@ pk_test_offline_func (void)
 	g_assert (!g_file_test (PK_OFFLINE_RESULTS_FILENAME, G_FILE_TEST_EXISTS));
 
 	/* cancel the trigger */
-	ret = pk_offline_cancel (NULL, &error);
+	ret = pk_offline_cancel_with_flags (PK_OFFLINE_FLAGS_INTERACTIVE, NULL, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 	g_assert (g_file_test (PK_OFFLINE_PREPARED_FILENAME, G_FILE_TEST_EXISTS));


### PR DESCRIPTION
This partly reverts commit 9b7e083cf849c4ed4d66fe32250f1615ab577d94.
The offline update/upgrade triggers do need the user interaction, to
get the credentials from the polkit, otherwise the trigger cannot
do its job.

Closes https://github.com/PackageKit/PackageKit/issues/504