### PR TITLE
wait until online to activate systemd service

### DIFF
--- a/data/packagekit.service.in
+++ b/data/packagekit.service.in
@@ -10,3 +10,4 @@ Type=dbus
 BusName=org.freedesktop.PackageKit
 User=@PACKAGEKIT_USER@
 ExecStart=@libexecdir@/packagekitd
+Wants=network-online.target


### PR DESCRIPTION
This commit keeps packagekitd from thinking the system is perpetually offline and instead waits for the network services to become available before it completely activates. This does not slow the boot process.

This is in reference to #336 