### PR TITLE
alpm: Support replaces with version expressions

### DIFF
--- a/backends/alpm/pk-alpm-sync.c
+++ b/backends/alpm/pk-alpm-sync.c
@@ -61,6 +61,11 @@ pk_alpm_transaction_sync_targets (PkBackendJob *job, const gchar **packages, gbo
 		}
 
 		pkg = alpm_db_get_pkg (i->data, name);
+		alpm_pkg_t *dep_to_remove = pk_alpm_pkg_replaces(priv->localdb, pkg);
+		if (dep_to_remove) {
+			g_debug("scheduling to remove %s for %s", alpm_pkg_get_name(dep_to_remove), name);
+			alpm_remove_pkg(priv->alpm, dep_to_remove);
+		}
 
 		if (update) { // libalpm only checks for ignorepkgs on an update
 			const alpm_list_t *ignorepkgs, *ignoregroups, *group_iter;

--- a/backends/alpm/pk-alpm-update.h
+++ b/backends/alpm/pk-alpm-update.h
@@ -25,3 +25,6 @@
 
 gboolean pk_alpm_refresh_databases (PkBackendJob *job, gint force,
 					alpm_list_t *dbs, GError **error);
+
+alpm_pkg_t *
+pk_alpm_pkg_replaces (alpm_db_t *db, alpm_pkg_t *pkg);


### PR DESCRIPTION
We were just checking filenames, now using alpm_dep_from_string() we
make follow the pkgname<1.0 kind of notation.