### PR TITLE
alpm: Offer the database we create when updating

### DIFF
--- a/backends/alpm/pk-alpm-packages.c
+++ b/backends/alpm/pk-alpm-packages.c
@@ -82,7 +82,7 @@ pk_alpm_find_pkg (PkBackendJob *job, const gchar *package_id, GError **error)
 	if (g_strcmp0 (repo_id, "installed") == 0) {
 		db = priv->localdb;
 	} else {
-		const alpm_list_t *i = alpm_get_syncdbs (priv->alpm);
+		const alpm_list_t *i = alpm_get_syncdbs (priv->alpm_check ? priv->alpm_check : priv->alpm);
 		for (; i != NULL; i = i->next) {
 			const gchar *repo = alpm_db_get_name (i->data);
 

--- a/backends/alpm/pk-alpm-search.c
+++ b/backends/alpm/pk-alpm-search.c
@@ -414,7 +414,7 @@ pk_backend_search_thread (PkBackendJob *job, GVariant* params, gpointer p)
 	if (skip_remote)
 		goto out;
 
-	for (i = alpm_get_syncdbs (priv->alpm); i != NULL; i = i->next) {
+	for (i = alpm_get_syncdbs (priv->alpm_check ? priv->alpm_check : priv->alpm); i != NULL; i = i->next) {
 		if (pk_backend_job_is_cancelled (job))
 			break;
 

--- a/backends/alpm/pk-backend-alpm.c
+++ b/backends/alpm/pk-backend-alpm.c
@@ -86,6 +86,7 @@ pk_alpm_initialize (PkBackend *backend, GError **error)
 		return FALSE;
 	}
 
+	priv->alpm_check = NULL;
 	alpm_option_set_logcb (priv->alpm, pk_alpm_logcb, NULL);
 
 	priv->localdb = alpm_get_localdb (priv->alpm);

--- a/backends/alpm/pk-backend-alpm.h
+++ b/backends/alpm/pk-backend-alpm.h
@@ -30,6 +30,7 @@ typedef struct {
 	alpm_list_t	*syncfirsts;
 	alpm_list_t	*holdpkgs;
 	alpm_handle_t	*alpm;
+	alpm_handle_t	*alpm_check;
 	GFileMonitor    *monitor;
 	alpm_list_t     *configured_repos; /* list of configured repos */
 	gboolean	localdb_changed;


### PR DESCRIPTION
We create a separate database when we refresh to make sure we don't
leave the system's at an odd state. In turn, this leaves the current
database at an odd state.

This makes our query operations use our database instead of the system's
while it's alive, so other transactions also can know about the
information we fetched from our remotes.

Also stop leaking the temporary database.

Fixes #491