### PR TITLE
aptcc: Keep automatic state from previously resolved transactions when applying them

### DIFF
--- a/backends/aptcc/apt-cache-file.cpp
+++ b/backends/aptcc/apt-cache-file.cpp
@@ -1,5 +1,5 @@
 /* apt-cache-file.cpp
- * 
+ *
  * Copyright (c) 2012 Daniel Nicoletti <dantti12@gmail.com>
  * Copyright (c) 2012 Matthias Klumpp <matthias@tenstral.net>
  * Copyright (c) 2016 Harald Sitter <sitter@kde.org>
@@ -357,35 +357,27 @@ bool AptCacheFile::isRemovingEssentialPackages()
 
 pkgCache::VerIterator AptCacheFile::resolvePkgID(const gchar *packageId)
 {
-    gchar **parts;
+    g_auto(GStrv) parts = nullptr;
     pkgCache::PkgIterator pkg;
 
     parts = pk_package_id_split(packageId);
     pkg = (*this)->FindPkg(parts[PK_PACKAGE_ID_NAME], parts[PK_PACKAGE_ID_ARCH]);
 
     // Ignore packages that could not be found or that exist only due to dependencies.
-    if (pkg.end() || (pkg.VersionList().end() && pkg.ProvidesList().end())) {
-        g_strfreev(parts);
+    if (pkg.end() || (pkg.VersionList().end() && pkg.ProvidesList().end()))
         return pkgCache::VerIterator();
-    }
 
     const pkgCache::VerIterator &ver = findVer(pkg);
     // check to see if the provided package isn't virtual too
     if (ver.end() == false &&
-            strcmp(ver.VerStr(), parts[PK_PACKAGE_ID_VERSION]) == 0) {
-        g_strfreev(parts);
+            strcmp(ver.VerStr(), parts[PK_PACKAGE_ID_VERSION]) == 0)
         return ver;
-    }
 
     const pkgCache::VerIterator &candidateVer = findCandidateVer(pkg);
     // check to see if the provided package isn't virtual too
     if (candidateVer.end() == false &&
-            strcmp(candidateVer.VerStr(), parts[PK_PACKAGE_ID_VERSION]) == 0) {
-        g_strfreev(parts);
+            strcmp(candidateVer.VerStr(), parts[PK_PACKAGE_ID_VERSION]) == 0)
         return candidateVer;
-    }
-
-    g_strfreev (parts);
 
     return ver;
 }

--- a/backends/aptcc/apt-cache-file.h
+++ b/backends/aptcc/apt-cache-file.h
@@ -27,6 +27,8 @@
 #include <apt-pkg/progress.h>
 #include <pk-backend.h>
 
+#include "pkg-list.h"
+
 class pkgProblemResolver;
 class AptCacheFile : public pkgCacheFile
 {
@@ -102,9 +104,15 @@ public:
 
     /**
      * Tries to find a package with the given packageId
-     * @returns pkgCache::VerIterator, if .end() is true the package could not be found
+     * @returns PkgInfo containing a pkgCache::VerIterator. If PkgInfo::ver::end() is true, the package could not be found
      */
-    pkgCache::VerIterator resolvePkgID(const gchar *packageId);
+    PkgInfo resolvePkgID(const gchar *packageId);
+
+    /**
+      * Build a package id from the given package version
+      * The caller must g_free the returned value
+      */
+    gchar* buildPackageId(const pkgCache::VerIterator &ver);
 
     /**
      * Tries to find the candidate version of a package
@@ -136,11 +144,11 @@ public:
     std::string getLongDescriptionParsed(const pkgCache::VerIterator &ver);
 
     bool tryToInstall(pkgProblemResolver &Fix,
-                      const pkgCache::VerIterator &ver,
+                      const PkgInfo &pki,
                       bool BrokenFix, bool autoInst, bool preserveAuto);
 
     void tryToRemove(pkgProblemResolver &Fix,
-                     const pkgCache::VerIterator &ver);
+                     const PkgInfo &pki);
 
 private:
     void buildPkgRecords();

--- a/backends/aptcc/apt-intf.cpp
+++ b/backends/aptcc/apt-intf.cpp
@@ -2544,7 +2544,8 @@ bool AptIntf::installPackages(PkBitfield flags)
         _exit(res);
     }
 
-    cout << "PARENT process running..." << endl;
+    cout << "APTcc parent process running..." << endl;
+
     // make it nonblocking, verry important otherwise
     // when the child finish we stay stuck.
     fcntl(readFromChildFD[0], F_SETFL, O_NONBLOCK);
@@ -2568,6 +2569,6 @@ bool AptIntf::installPackages(PkBitfield flags)
     close(pty_master);
     _system->LockInner();
 
-    cout << "Parent finished..." << endl;
+    cout << "APTcc Parent finished..." << endl;
     return true;
 }

--- a/backends/aptcc/apt-intf.cpp
+++ b/backends/aptcc/apt-intf.cpp
@@ -429,7 +429,7 @@ void AptIntf::emitPackage(const pkgCache::VerIterator &ver, PkInfoEnum state)
     }
 
     gchar *package_id;
-    package_id = utilBuildPackageId(ver);
+    package_id = utilBuildPackageId(m_cache, ver);
     pk_backend_job_package(m_job,
                            state,
                            package_id,
@@ -440,7 +440,7 @@ void AptIntf::emitPackage(const pkgCache::VerIterator &ver, PkInfoEnum state)
 void AptIntf::emitPackageProgress(const pkgCache::VerIterator &ver, PkStatusEnum status, uint percentage)
 {
     gchar *package_id;
-    package_id = utilBuildPackageId(ver);
+    package_id = utilBuildPackageId(m_cache, ver);
     pk_backend_job_set_item_progress(m_job, package_id, status, percentage);
     g_free(package_id);
 }
@@ -473,7 +473,7 @@ void AptIntf::emitRequireRestart(PkgList &output)
 
     for (const pkgCache::VerIterator &verIt : output) {
         gchar *package_id;
-        package_id = utilBuildPackageId(verIt);
+        package_id = utilBuildPackageId(m_cache, verIt);
         pk_backend_job_require_restart(m_job, PK_RESTART_ENUM_SYSTEM, package_id);
         g_free(package_id);
     }
@@ -756,7 +756,7 @@ void AptIntf::emitPackageDetail(const pkgCache::VerIterator &ver)
     }
 
     gchar *package_id;
-    package_id = utilBuildPackageId(ver);
+    package_id = utilBuildPackageId(m_cache, ver);
     pk_backend_job_details(m_job,
                            package_id,
                            m_cache->getShortDescription(ver).c_str(),
@@ -801,7 +801,7 @@ void AptIntf::emitUpdateDetail(const pkgCache::VerIterator &candver)
     const pkgCache::VerIterator &currver = m_cache->findVer(pkg);
 
     // Build a package_id from the current version
-    gchar *current_package_id = utilBuildPackageId(currver);
+    gchar *current_package_id = utilBuildPackageId(m_cache, currver);
 
     pkgCache::VerFileIterator vf = candver.FileList();
     string origin = vf.File().Origin() == NULL ? "" : vf.File().Origin();
@@ -846,7 +846,7 @@ void AptIntf::emitUpdateDetail(const pkgCache::VerIterator &candver)
     // Build a package_id from the update version
     string archive = vf.File().Archive() == NULL ? "" : vf.File().Archive();
     gchar *package_id;
-    package_id = utilBuildPackageId(candver);
+    package_id = utilBuildPackageId(m_cache, candver);
 
     PkUpdateStateEnum updateState = PK_UPDATE_STATE_ENUM_UNKNOWN;
     if (archive.compare("stable") == 0) {

--- a/backends/aptcc/apt-intf.cpp
+++ b/backends/aptcc/apt-intf.cpp
@@ -2510,13 +2510,15 @@ bool AptIntf::installPackages(PkBitfield flags)
         if ((m_interactive) && (socket != NULL)) {
             g_setenv("DEBIAN_FRONTEND", "passthrough", TRUE);
             g_setenv("DEBCONF_PIPE", socket, TRUE);
+
+            // Set the LANGUAGE so debconf messages get localization
+            // NOTE: This will cause dpkg messages to be localized and APTcc's string matching
+            // to fail, so progress information may no longer be accurate in these cases.
+            setEnvLocaleFromJob();
         } else {
             // we don't have a socket set or are not interactive, let's fallback to noninteractive
             g_setenv("DEBIAN_FRONTEND", "noninteractive", TRUE);
         }
-
-        // Set the LANGUAGE so debconf messages get localization
-        setEnvLocaleFromJob();
 
         // apt will record this in its history.log
         guint uid = pk_backend_job_get_uid(m_job);

--- a/backends/aptcc/apt-utils.cpp
+++ b/backends/aptcc/apt-utils.cpp
@@ -393,11 +393,11 @@ bool utilRestartRequired(const string &packageName)
 
 string utilBuildPackageOriginId(pkgCache::VerFileIterator vf)
 {
-    if (vf.File().Origin() == NULL)
+    if (vf.File().Origin() == nullptr)
         return string("local");
-    if (vf.File().Archive() == NULL)
+    if (vf.File().Archive() == nullptr)
         return string("local");
-    if (vf.File().Component() == NULL)
+    if (vf.File().Component() == nullptr)
         return string("invalid");
 
     // https://wiki.debian.org/DebianRepository/Format

--- a/backends/aptcc/apt-utils.cpp
+++ b/backends/aptcc/apt-utils.cpp
@@ -1,7 +1,7 @@
 /* apt-utils.cpp
  *
  * Copyright (c) 2009 Daniel Nicoletti <dantti12@gmail.com>
- * Copyright (c) 2014 Matthias Klumpp <mak@debian.org>
+ * Copyright (c) 2014-2022 Matthias Klumpp <mak@debian.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -426,38 +426,6 @@ string utilBuildPackageOriginId(pkgCache::VerFileIterator vf)
 
     string res = origin + "-" + suite + "-" + component;
     return res;
-}
-
-gchar* utilBuildPackageId(AptCacheFile *cacheFile, const pkgCache::VerIterator &ver)
-{
-    pkgCache::VerFileIterator vf = ver.FileList();
-    const pkgCache::PkgIterator &pkg = ver.ParentPkg();
-    pkgDepCache::StateCache &State = (*cacheFile)[pkg];
-
-    const bool isInstalled = (pkg->CurrentState == pkgCache::State::Installed && pkg.CurrentVer() == ver);
-    const bool isAuto = (State.CandidateVer != 0) && (State.Flags & pkgCache::Flag::Auto);
-
-    // when a package is installed manually, the data part of a package-id is "manual:<repo-id>",
-    // otherwise it is "auto:<repo-id>". Available (not installed) packages have no prefix, unless
-    // a pending installation is marked, in which case we prefix the desired new mode of the installed
-    // package (auto/manual) with a plus sign (+).
-    string data;
-    if (isInstalled) {
-        data = isAuto? "auto:" : "manual:";
-        data += utilBuildPackageOriginId(vf);
-    } else {
-        if (State.NewInstall()) {
-            data = isAuto? "+auto:" : "+manual:";
-            data += utilBuildPackageOriginId(vf);
-        } else {
-            data = utilBuildPackageOriginId(vf);
-        }
-    }
-
-    return pk_package_id_build(ver.ParentPkg().Name(),
-                               ver.VerStr(),
-                               ver.Arch(),
-                               data.c_str());
 }
 
 const char *utf8(const char *str)

--- a/backends/aptcc/apt-utils.h
+++ b/backends/aptcc/apt-utils.h
@@ -75,7 +75,8 @@ bool utilRestartRequired(const string &packageName);
   * Build a package id from the given package version
   * The caller must g_free the returned value
   */
-gchar* utilBuildPackageId(const pkgCache::VerIterator &ver);
+gchar* utilBuildPackageId(AptCacheFile *cacheFile,
+			  const pkgCache::VerIterator &ver);
 
 /**
  * Build a unique repository origin, in the form of

--- a/backends/aptcc/apt-utils.h
+++ b/backends/aptcc/apt-utils.h
@@ -72,13 +72,6 @@ bool starts_with(const string &str, const char *end);
 bool utilRestartRequired(const string &packageName);
 
 /**
-  * Build a package id from the given package version
-  * The caller must g_free the returned value
-  */
-gchar* utilBuildPackageId(AptCacheFile *cacheFile,
-			  const pkgCache::VerIterator &ver);
-
-/**
  * Build a unique repository origin, in the form of
  * {distro}-{suite}-{component}
  */

--- a/backends/aptcc/pk-backend-aptcc.cpp
+++ b/backends/aptcc/pk-backend-aptcc.cpp
@@ -352,13 +352,12 @@ void pk_backend_get_details_local(PkBackend *backend, PkBackendJob *job, gchar *
 
 static void backend_get_files_local_thread(PkBackendJob *job, GVariant *params, gpointer user_data)
 {
-    gchar **files = nullptr;
+    g_autofree gchar **files = nullptr;
     g_variant_get(params, "(^a&s)",
                   &files);
-
     AptIntf *apt = static_cast<AptIntf*>(pk_backend_job_get_user_data(job));
 
-    for (guint i = 0; i < g_strv_length(files); ++i)
+    for (guint i = 0; files[i] != nullptr; ++i)
         apt->emitPackageFilesLocal(files[i]);
 }
 

--- a/backends/aptcc/pkg-list.h
+++ b/backends/aptcc/pkg-list.h
@@ -1,6 +1,7 @@
 /* pkg-list.h
  *
- * Copyright (c) 2012 Daniel Nicoletti <dantti12@gmail.com>
+ * Copyright (c) 2012-2016 Daniel Nicoletti <dantti12@gmail.com>
+ * Copyright (c) 2015-2022 Matthias Klumpp <matthias@tenstral.net>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,11 +28,48 @@
 using std::vector;
 
 /**
- * This class is meant to show Operation Progress using PackageKit
+ * A designated action to perform on a package.
  */
-class PkgList : public vector<pkgCache::VerIterator>
+enum class PkgAction
+{
+    NONE,
+    INSTALL_AUTO,
+    INSTALL_MANUAL
+};
+
+/**
+ * Information about a package, mainly containing its VerIterator
+ * and some information about the intended action on a package
+ * extracted from a PackageKit package-ID.
+ */
+class PkgInfo
 {
 public:
+    explicit PkgInfo(const pkgCache::VerIterator &verIter)
+        : ver(verIter),
+          action(PkgAction::NONE) {};
+    explicit PkgInfo(const pkgCache::VerIterator &verIter, PkgAction a)
+        : ver(verIter),
+          action(a) {};
+    pkgCache::VerIterator ver;
+    PkgAction action;
+};
+
+/**
+ * This class is meant to show Operation Progress using PackageKit
+ */
+class PkgList : public vector<PkgInfo>
+{
+public:
+    /**
+     * Add a new package to the list
+     * @param verIter The pkgCache::VerIterator assoicated with this package.
+     * @param action An optional action that should be performed on this package in future.
+     */
+    void append(const pkgCache::VerIterator &verIter, PkgAction action = PkgAction::NONE);
+
+    void append(const PkgInfo &pi) { this->push_back(pi); };
+
     /**
      * Return if the given vector contain a package
      */


### PR DESCRIPTION
Hi!
As far as I could test, this patchset, which features quite a bit of annoying refactoring, resolves the issue outlined in https://github.com/PackageKit/PackageKit/issues/450 (kernel updates marked as manually installed while they were in fact dragged in by an update).

While looking into the aptcc code after such a long time, I also quickly discovered why doing that is not at all my favourite activity ;-)

In all my tests the new code behaved correctly when updating as well as performing any other package management activities, but of course, more testing is helpful.

@dantti Can you maybe have a look at this?