### PR TITLE
backends/nix: explicitly call forceValue with noPos argument

### DIFF
--- a/backends/nix/nix-lib-plus.cc
+++ b/backends/nix/nix-lib-plus.cc
@@ -142,7 +142,7 @@ bool createUserEnv(EvalState & state, DrvInfos & elems,
 
     /* Evaluate it. */
     debug("evaluating user environment builder");
-    state.forceValue(topLevel);
+    state.forceValue(topLevel, noPos);
     PathSet context;
     Attr & aDrvPath(*topLevel.attrs->find(state.sDrvPath));
     auto topLevelDrv = state.store->parseStorePath(state.coerceToPath(*aDrvPath.pos, *aDrvPath.value, context));


### PR DESCRIPTION
* backends/nix/nix-lib-plus.cc: fix compatibility with Nix 2.7.0 which drops
default value of 'noPos' in 'forceValue' function

Nix 2.7.0 changes the declaration of forceValue, removing a default parameter which PackageKit previously relied on. This causes PackageKit builds using Nix 2.7.0 to fail during compilation.

This patch simply adds the old default value explicitly to the use of forceValue to match the legacy behavior, and fix compilation failures with Nix 2.7.0.

This change is backwards compatible with Nix < 2.7.0 - and will produce identical calls to forceValue in a version agnostic manner.
