### PR TITLE
Nix: fix build with Nix 2.8.0

### DIFF
--- a/backends/nix/meson.build
+++ b/backends/nix/meson.build
@@ -1,9 +1,9 @@
 add_languages('cpp')
 
-nix_expr_dep = dependency('nix-expr', version: '>=2.6')
-nix_main_dep = dependency('nix-main', version: '>=2.6')
-nix_store_dep = dependency('nix-store', version: '>=2.6')
-nix_cmd_dep = dependency('nix-cmd', version: '>=2.6')
+nix_expr_dep = dependency('nix-expr', version: '>=2.7')
+nix_main_dep = dependency('nix-main', version: '>=2.7')
+nix_store_dep = dependency('nix-store', version: '>=2.7')
+nix_cmd_dep = dependency('nix-cmd', version: '>=2.7')
 
 shared_module(
   'pk_backend_nix',

--- a/backends/nix/meson.build
+++ b/backends/nix/meson.build
@@ -1,9 +1,9 @@
 add_languages('cpp')
 
-nix_expr_dep = dependency('nix-expr', version: '>=2.7')
-nix_main_dep = dependency('nix-main', version: '>=2.7')
-nix_store_dep = dependency('nix-store', version: '>=2.7')
-nix_cmd_dep = dependency('nix-cmd', version: '>=2.7')
+nix_expr_dep = dependency('nix-expr', version: '>=2.8')
+nix_main_dep = dependency('nix-main', version: '>=2.8')
+nix_store_dep = dependency('nix-store', version: '>=2.8')
+nix_cmd_dep = dependency('nix-cmd', version: '>=2.8')
 
 shared_module(
   'pk_backend_nix',

--- a/backends/nix/nix-lib-plus.cc
+++ b/backends/nix/nix-lib-plus.cc
@@ -45,14 +45,14 @@ DrvInfos queryInstalled(EvalState & state, const Path & userEnv)
 
 bool createUserEnv(EvalState & state, DrvInfos & elems,
     const Path & profile, bool keepDerivations,
-    const string & lockToken)
+    const std::string & lockToken)
 {
     /* Build the components in the user environment, if they don't
        exist already. */
     std::vector<StorePathWithOutputs> drvsToBuild;
     for (auto & i : elems)
-        if (i.queryDrvPath() != "")
-            drvsToBuild.push_back({state.store->parseStorePath(i.queryDrvPath()), {}});
+        if (auto drvPath = i.queryDrvPath())
+            drvsToBuild.push_back({*drvPath, {}});
 
     debug(format("building user environment dependencies"));
     state.store->buildPaths(
@@ -68,7 +68,7 @@ bool createUserEnv(EvalState & state, DrvInfos & elems,
         /* Create a pseudo-derivation containing the name, system,
            output paths, and optionally the derivation path, as well
            as the meta attributes. */
-        Path drvPath = keepDerivations ? i.queryDrvPath() : "";
+        std::optional<StorePath> drvPath = keepDerivations ? i.queryDrvPath() : std::nullopt;
         DrvInfo::Outputs outputs = i.queryOutputs(true);
         StringSet metaNames = i.queryMetaNames();
 
@@ -79,9 +79,9 @@ bool createUserEnv(EvalState & state, DrvInfos & elems,
         auto system = i.querySystem();
         if (!system.empty())
             attrs.alloc(state.sSystem).mkString(system);
-        attrs.alloc(state.sOutPath).mkString(i.queryOutPath());
-        if (drvPath != "")
-            attrs.alloc(state.sDrvPath).mkString(i.queryDrvPath());
+        attrs.alloc(state.sOutPath).mkString(state.store->printStorePath(i.queryOutPath()));
+        if (drvPath)
+            attrs.alloc(state.sDrvPath).mkString(state.store->printStorePath(*drvPath));
 
         // Copy each output meant for installation.
         auto & vOutputs = attrs.alloc(state.sOutputs);
@@ -89,15 +89,15 @@ bool createUserEnv(EvalState & state, DrvInfos & elems,
         for (const auto & [m, j] : enumerate(outputs)) {
             (vOutputs.listElems()[m] = state.allocValue())->mkString(j.first);
             auto outputAttrs = state.buildBindings(2);
-            outputAttrs.alloc(state.sOutPath).mkString(j.second);
+            outputAttrs.alloc(state.sOutPath).mkString(state.store->printStorePath(j.second));
             attrs.alloc(j.first).mkAttrs(outputAttrs);
 
             /* This is only necessary when installing store paths, e.g.,
                `nix-env -i /nix/store/abcd...-foo'. */
-            state.store->addTempRoot(state.store->parseStorePath(j.second));
-            state.store->ensurePath(state.store->parseStorePath(j.second));
+            state.store->addTempRoot(j.second);
+            state.store->ensurePath(j.second);
 
-            references.insert(state.store->parseStorePath(j.second));
+            references.insert(j.second);
         }
 
         // Copy the meta attributes.
@@ -112,7 +112,7 @@ bool createUserEnv(EvalState & state, DrvInfos & elems,
 
         (manifest.listElems()[n++] = state.allocValue())->mkAttrs(attrs);
 
-        if (drvPath != "") references.insert(state.store->parseStorePath(drvPath));
+        if (drvPath) references.insert(*drvPath);
     }
 
     /* Also write a copy of the list of user environment elements to
@@ -142,12 +142,12 @@ bool createUserEnv(EvalState & state, DrvInfos & elems,
 
     /* Evaluate it. */
     debug("evaluating user environment builder");
-    state.forceValue(topLevel, noPos);
+    state.forceValue(topLevel, [&]() { return topLevel.determinePos(noPos); });
     PathSet context;
     Attr & aDrvPath(*topLevel.attrs->find(state.sDrvPath));
-    auto topLevelDrv = state.store->parseStorePath(state.coerceToPath(*aDrvPath.pos, *aDrvPath.value, context));
+    auto topLevelDrv = state.coerceToStorePath(*aDrvPath.pos, *aDrvPath.value, context);
     Attr & aOutPath(*topLevel.attrs->find(state.sOutPath));
-    Path topLevelOut = state.coerceToPath(*aOutPath.pos, *aOutPath.value, context);
+    auto topLevelOut = state.coerceToStorePath(*aOutPath.pos, *aOutPath.value, context);
 
     /* Realise the resulting store expression. */
     debug("building user environment");
@@ -171,8 +171,7 @@ bool createUserEnv(EvalState & state, DrvInfos & elems,
         }
 
         debug(format("switching to new user environment"));
-        Path generation = createGeneration(ref<LocalFSStore>(store2), profile,
-            store2->parseStorePath(topLevelOut));
+        Path generation = createGeneration(ref<LocalFSStore>(store2), profile, topLevelOut);
         switchLink(profile, generation);
     }
 

--- a/backends/nix/nix-lib-plus.cc
+++ b/backends/nix/nix-lib-plus.cc
@@ -69,7 +69,7 @@ bool createUserEnv(EvalState & state, DrvInfos & elems,
            output paths, and optionally the derivation path, as well
            as the meta attributes. */
         std::optional<StorePath> drvPath = keepDerivations ? i.queryDrvPath() : std::nullopt;
-        DrvInfo::Outputs outputs = i.queryOutputs(true);
+        DrvInfo::Outputs outputs = i.queryOutputs(true, true);
         StringSet metaNames = i.queryMetaNames();
 
         auto attrs = state.buildBindings(7 + outputs.size());
@@ -89,15 +89,15 @@ bool createUserEnv(EvalState & state, DrvInfos & elems,
         for (const auto & [m, j] : enumerate(outputs)) {
             (vOutputs.listElems()[m] = state.allocValue())->mkString(j.first);
             auto outputAttrs = state.buildBindings(2);
-            outputAttrs.alloc(state.sOutPath).mkString(state.store->printStorePath(j.second));
+            outputAttrs.alloc(state.sOutPath).mkString(state.store->printStorePath(*j.second));
             attrs.alloc(j.first).mkAttrs(outputAttrs);
 
             /* This is only necessary when installing store paths, e.g.,
                `nix-env -i /nix/store/abcd...-foo'. */
-            state.store->addTempRoot(j.second);
-            state.store->ensurePath(j.second);
+            state.store->addTempRoot(*j.second);
+            state.store->ensurePath(*j.second);
 
-            references.insert(j.second);
+            references.insert(*j.second);
         }
 
         // Copy the meta attributes.
@@ -118,8 +118,10 @@ bool createUserEnv(EvalState & state, DrvInfos & elems,
     /* Also write a copy of the list of user environment elements to
        the store; we need it for future modifications of the
        environment. */
+    std::ostringstream str;
+    manifest.print(str, true);
     auto manifestFile = state.store->addTextToStore("env-manifest.nix",
-        fmt("%s", manifest), references);
+        str.str(), references);
 
     /* Get the environment builder expression. */
     Value envBuilder;

--- a/backends/nix/nix-lib-plus.hh
+++ b/backends/nix/nix-lib-plus.hh
@@ -17,7 +17,7 @@
 
 namespace nix {
 
-bool createUserEnv(EvalState & state, DrvInfos & elems, const Path & profile, bool keepDerivations, const string & lockToken);
+bool createUserEnv(EvalState & state, DrvInfos & elems, const Path & profile, bool keepDerivations, const std::string & lockToken);
 
 DrvInfos queryInstalled(EvalState & state, const Path & userEnv);
 

--- a/backends/nix/pk-backend-nix.cc
+++ b/backends/nix/pk-backend-nix.cc
@@ -133,7 +133,7 @@ pk_backend_get_mime_types (PkBackend* backend)
 	return g_strdupv ((gchar **) mime_types);
 }
 
-static std::shared_ptr<nix::eval_cache::AttrCursor>
+static nix::OrSuggestions<nix::ref<nix::eval_cache::AttrCursor>>
 nix_get_cursor (nix::EvalState & state, std::string flake, std::string attrPath)
 {
 	nix::flake::LockFlags lockFlags;
@@ -158,12 +158,13 @@ pk_backend_get_details_thread (PkBackendJob* job, GVariant* params, gpointer p)
 		std::string flake = std::string (parts[PK_PACKAGE_ID_DATA]);
 		g_strfreev (parts);
 
-		auto cursor = nix_get_cursor (*priv->state, flake, "legacyPackages." + nix::settings.thisSystem.get () + "." + attrPath);
+		auto attrOrSuggestions = nix_get_cursor (*priv->state, flake, "legacyPackages." + nix::settings.thisSystem.get () + "." + attrPath);
+		auto cursor = *attrOrSuggestions;
 
 		if (pk_backend_job_is_cancelled (job))
 			return;
 
-		if (cursor && cursor->isDerivation ()) {
+		if (attrOrSuggestions && cursor->isDerivation ()) {
 			auto aMeta = cursor->maybeGetAttr ("meta");
 
 			auto aDescription = aMeta ? aMeta->maybeGetAttr ("description") : NULL;
@@ -245,7 +246,8 @@ nix_search_thread (PkBackendJob* job, GVariant* params, gpointer p)
 	}
 
 	std::string attrPath = "legacyPackages." + nix::settings.thisSystem.get () + ".";
-	auto cursor = nix_get_cursor (*priv->state, priv->defaultFlake, attrPath);
+	auto attrOrSuggestions = nix_get_cursor (*priv->state, priv->defaultFlake, attrPath);
+	auto cursor = *attrOrSuggestions;
 
 	if (pk_backend_job_is_cancelled (job))
 		return;
@@ -467,9 +469,10 @@ nix_install_thread (PkBackendJob* job, GVariant* params, gpointer p)
 		std::string flake = std::string (parts[PK_PACKAGE_ID_DATA]);
 		g_strfreev (parts);
 
-		auto cursor = nix_get_cursor (*priv->state, flake, "legacyPackages." + nix::settings.thisSystem.get () + "." + attrPath);
+		auto attrOrSuggestions = nix_get_cursor (*priv->state, flake, "legacyPackages." + nix::settings.thisSystem.get () + "." + attrPath);
+		auto cursor = *attrOrSuggestions;
 
-		if (cursor && cursor->isDerivation ()) {
+		if (attrOrSuggestions && cursor->isDerivation ()) {
 			std::optional<nix::DrvInfo> drv;
 			drv = nix::getDerivation (*priv->state, cursor->forceValue(), false);
 			if (drv) {
@@ -597,8 +600,9 @@ nix_remove_thread (PkBackendJob* job, GVariant* params, gpointer p)
 		std::string flake = std::string (parts[PK_PACKAGE_ID_DATA]);
 		g_strfreev (parts);
 
-		auto cursor = nix_get_cursor (*priv->state, flake, "legacyPackages." + nix::settings.thisSystem.get () + "." + attrPath);
-		if (cursor && cursor->isDerivation ()) {
+		auto attrOrSuggestions = nix_get_cursor (*priv->state, flake, "legacyPackages." + nix::settings.thisSystem.get () + "." + attrPath);
+		auto cursor = *attrOrSuggestions;
+		if (attrOrSuggestions && cursor->isDerivation ()) {
 			auto drv = nix::getDerivation (*priv->state, cursor->forceValue(), false);
 			if (drv)
 				elemsToDelete.push_back (*drv);
@@ -695,8 +699,9 @@ nix_get_updates_thread (PkBackendJob* job, GVariant* params, gpointer p)
 	for (auto & i : installedElems) {
 		pk_backend_job_set_percentage (job, 100 * progress++ / installedElems.size());
 
-		auto cursor = nix_get_cursor (*priv->state, priv->defaultFlake, "legacyPackages." + nix::settings.thisSystem.get () + "." + i.attrPath);
-		if (cursor && cursor->isDerivation ()) {
+		auto attrOrSuggestions = nix_get_cursor (*priv->state, priv->defaultFlake, "legacyPackages." + nix::settings.thisSystem.get () + "." + i.attrPath);
+		auto cursor = *attrOrSuggestions;
+		if (attrOrSuggestions && cursor->isDerivation ()) {
 			auto drv = nix::getDerivation (*priv->state, cursor->forceValue(), false);
 			if (drv && drv->queryDrvPath () != i.queryDrvPath ()) {
 				nix::DrvName name (drv->queryName ());

--- a/backends/nix/pk-backend-nix.cc
+++ b/backends/nix/pk-backend-nix.cc
@@ -134,7 +134,7 @@ pk_backend_get_mime_types (PkBackend* backend)
 }
 
 static nix::OrSuggestions<nix::ref<nix::eval_cache::AttrCursor>>
-nix_get_cursor (nix::EvalState & state, std::string flake, std::string attrPath)
+nix_get_attr_or_suggestions (nix::EvalState & state, std::string flake, std::string attrPath)
 {
 	nix::flake::LockFlags lockFlags;
 	auto lockedFlake = std::make_shared<nix::flake::LockedFlake> (nix::flake::lockFlake (state, nix::parseFlakeRef(flake), lockFlags));
@@ -158,7 +158,7 @@ pk_backend_get_details_thread (PkBackendJob* job, GVariant* params, gpointer p)
 		std::string flake = std::string (parts[PK_PACKAGE_ID_DATA]);
 		g_strfreev (parts);
 
-		auto attrOrSuggestions = nix_get_cursor (*priv->state, flake, "legacyPackages." + nix::settings.thisSystem.get () + "." + attrPath);
+		auto attrOrSuggestions = nix_get_attr_or_suggestions (*priv->state, flake, "legacyPackages." + nix::settings.thisSystem.get () + "." + attrPath);
 		auto cursor = *attrOrSuggestions;
 
 		if (pk_backend_job_is_cancelled (job))
@@ -246,7 +246,7 @@ nix_search_thread (PkBackendJob* job, GVariant* params, gpointer p)
 	}
 
 	std::string attrPath = "legacyPackages." + nix::settings.thisSystem.get () + ".";
-	auto attrOrSuggestions = nix_get_cursor (*priv->state, priv->defaultFlake, attrPath);
+	auto attrOrSuggestions = nix_get_attr_or_suggestions (*priv->state, priv->defaultFlake, attrPath);
 	auto cursor = *attrOrSuggestions;
 
 	if (pk_backend_job_is_cancelled (job))
@@ -469,7 +469,7 @@ nix_install_thread (PkBackendJob* job, GVariant* params, gpointer p)
 		std::string flake = std::string (parts[PK_PACKAGE_ID_DATA]);
 		g_strfreev (parts);
 
-		auto attrOrSuggestions = nix_get_cursor (*priv->state, flake, "legacyPackages." + nix::settings.thisSystem.get () + "." + attrPath);
+		auto attrOrSuggestions = nix_get_attr_or_suggestions (*priv->state, flake, "legacyPackages." + nix::settings.thisSystem.get () + "." + attrPath);
 		auto cursor = *attrOrSuggestions;
 
 		if (attrOrSuggestions && cursor->isDerivation ()) {
@@ -600,7 +600,7 @@ nix_remove_thread (PkBackendJob* job, GVariant* params, gpointer p)
 		std::string flake = std::string (parts[PK_PACKAGE_ID_DATA]);
 		g_strfreev (parts);
 
-		auto attrOrSuggestions = nix_get_cursor (*priv->state, flake, "legacyPackages." + nix::settings.thisSystem.get () + "." + attrPath);
+		auto attrOrSuggestions = nix_get_attr_or_suggestions (*priv->state, flake, "legacyPackages." + nix::settings.thisSystem.get () + "." + attrPath);
 		auto cursor = *attrOrSuggestions;
 		if (attrOrSuggestions && cursor->isDerivation ()) {
 			auto drv = nix::getDerivation (*priv->state, cursor->forceValue(), false);
@@ -699,7 +699,7 @@ nix_get_updates_thread (PkBackendJob* job, GVariant* params, gpointer p)
 	for (auto & i : installedElems) {
 		pk_backend_job_set_percentage (job, 100 * progress++ / installedElems.size());
 
-		auto attrOrSuggestions = nix_get_cursor (*priv->state, priv->defaultFlake, "legacyPackages." + nix::settings.thisSystem.get () + "." + i.attrPath);
+		auto attrOrSuggestions = nix_get_attr_or_suggestions (*priv->state, priv->defaultFlake, "legacyPackages." + nix::settings.thisSystem.get () + "." + i.attrPath);
 		auto cursor = *attrOrSuggestions;
 		if (attrOrSuggestions && cursor->isDerivation ()) {
 			auto drv = nix::getDerivation (*priv->state, cursor->forceValue(), false);


### PR DESCRIPTION
Try to reflect the changes made before ~~https://github.com/NixOS/nix/commit/ffe155abd36366a870482625543f9bf924a58281~~ https://github.com/NixOS/nix/commit/69c6fb12eea414382f0b945c0d6c574c43c7c9a3. Without the change the build fails with:

```
In file included from ../backends/nix/nix-lib-plus.cc:27:
../backends/nix/nix-lib-plus.hh:20:107: error: 'string' does not name a type; did you mean 'nString'?
   20 | bool createUserEnv(EvalState & state, DrvInfos & elems, const Path & profile, bool keepDerivations, const string & lockToken);
      |                                                                                                           ^~~~~~
      |                                                                                                           nString
```

Tested compilation on ~~https://github.com/NixOS/nixpkgs/commit/eeab10bd54e2f6a25c27059290e7e7f2b3fd1cf0~~ https://github.com/NixOS/nixpkgs/commit/b57126a16e9a70fc763b517ad45bf5f16f9e4dab. See commit message for lists of related upstream changes.

@matthewbauer @jtojnar Please take a look if you have time, thanks! (we are currently pinning nix to 2.6 in https://github.com/NixOS/nixpkgs/pull/163500)