### PR TITLE
zypp: ignore locked packages

### DIFF
--- a/backends/zypp/pk-backend-zypp.cpp
+++ b/backends/zypp/pk-backend-zypp.cpp
@@ -1244,7 +1244,7 @@ zypp_get_package_updates (string repo, set<PoolItem> &pks)
 			// We pretend locked packages are not upgradable at all since
 			// we can't represent the concept of holds in PackageKit.
 			// https://github.com/PackageKit/PackageKit/issues/325
-			continue;	
+			continue;
 		} else if (it->status().isToBeInstalled()) {
 			ui::Selectable::constPtr s =
 				ui::Selectable::get((*it)->kind(), (*it)->name());

--- a/backends/zypp/pk-backend-zypp.cpp
+++ b/backends/zypp/pk-backend-zypp.cpp
@@ -1239,13 +1239,19 @@ zypp_get_package_updates (string repo, set<PoolItem> &pks)
 		resolver->doUpdate ();
 	}
 
-	for (; it != e; ++it)
-		if (it->status().isToBeInstalled()) {
+	for (; it != e; ++it) {
+		if (it->status().isLocked()) {
+			// We pretend locked packages are not upgradable at all since
+			// we can't represent the concept of holds in PackageKit.
+			// https://github.com/PackageKit/PackageKit/issues/325
+			continue;	
+		} else if (it->status().isToBeInstalled()) {
 			ui::Selectable::constPtr s =
 				ui::Selectable::get((*it)->kind(), (*it)->name());
 			if (s->hasInstalledObj())
 				pks.insert(*it);
 		}
+	}
 
 	if (is_tumbleweed ()) {
 		resolver->setUpgradeMode (FALSE);


### PR DESCRIPTION
Closes #325 

Currently if a package is locked on ZYpp PackageKit ignores the lock and silently updates or installs it.

This PR adds a check if a package is locked a before adding it to the packages to be updated list.

Implementation and comment in code was inspired by the one in aptcc backend

https://github.com/PackageKit/PackageKit/blob/9339249866d44f06d713e92f2abf90b470b5deb3/backends/aptcc/apt-intf.cpp#L1303-L1308