### PR TITLE
pk-client: Fix default value of cache-age property

### DIFF
--- a/lib/packagekit-glib2/pk-client.c
+++ b/lib/packagekit-glib2/pk-client.c
@@ -4607,7 +4607,7 @@ pk_client_class_init (PkClientClass *klass)
 	 * Since: 0.6.10
 	 */
 	pspec = g_param_spec_uint ("cache-age", NULL, NULL,
-				   0, G_MAXUINT, 0,
+				   0, G_MAXUINT, G_MAXUINT,
 				   G_PARAM_READWRITE);
 	g_object_class_install_property (object_class, PROP_CACHE_AGE, pspec);
 }


### PR DESCRIPTION
`pk_client_init()` sets the default value to `G_MAXUINT` but the
`GParamSpec` setup didn’t also use that value.

This probably introduces no functional changes, but it makes the code
not contradict itself.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>