### PR TITLE
D-Bus signal performance improvements

### DIFF
--- a/src/org.freedesktop.PackageKit.Transaction.xml
+++ b/src/org.freedesktop.PackageKit.Transaction.xml
@@ -197,6 +197,17 @@
                   Most transactions will not have this value set.
                 </doc:definition>
               </doc:item>
+              <doc:item>
+                <doc:term>supports-plural-signals</doc:term>
+                <doc:definition>
+                  This allows the frontend to tell the daemon that it supports the
+                  new <doc:tt>Packages</doc:tt> signal for receiving information about
+                  multiple packages at once, rather than just the original
+                  <doc:tt>Package</doc:tt> signal.
+                  If this is set, and the daemon supports the signal, it will be used.
+                  If present, this must always be set to <doc:tt>true</doc:tt>.
+                </doc:definition>
+              </doc:item>
             </doc:list>
             <doc:para>
               Other values will cause a verbose warning in the daemon, but will
@@ -1855,6 +1866,47 @@
           <doc:summary>
             <doc:para>
               The one line package summary, e.g. Clipart for OpenOffice
+            </doc:para>
+          </doc:summary>
+        </doc:doc>
+      </arg>
+    </signal>
+
+    <!--*********************************************************************-->
+    <signal name="Packages">
+      <doc:doc>
+        <doc:description>
+          <doc:para>
+            This signal allows the backend to communicate multiple packages to the session.
+          </doc:para>
+          <doc:para>
+            If updating, as packages are updated then emit them to the screen.
+            This allows a summary to be presented after the transaction.
+          </doc:para>
+          <doc:para>
+            When returning results from a search always return
+            <doc:tt>installed</doc:tt> before <doc:tt>available</doc:tt> for
+            the same package name.
+          </doc:para>
+          <doc:para>
+            This signal was added to the API in PackageKit 1.2.6. It will only be emitted
+            by the daemon if the client sets the <doc:tt>supports-plural-signals=true</doc:tt>
+            hint on the transaction using <doc:tt>SetHints()</doc:tt>.
+          </doc:para>
+          <doc:para>
+            Even if this signal is used by the transaction, it may also still emit
+            <doc:tt>Package</doc:tt> signals at other times. The content of one signal will
+            never duplicate the content of another. Clients must be prepared to handle both
+            signals within the same transaction.
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+      <arg type="a(uss)" name="packages" direction="out">
+        <doc:doc>
+          <doc:summary>
+            <doc:para>
+              An array of package details. Each array element is one package,
+              as documented for the <doc:tt>Package</doc:tt> signal.
             </doc:para>
           </doc:summary>
         </doc:doc>

--- a/src/pk-backend-job.h
+++ b/src/pk-backend-job.h
@@ -46,6 +46,7 @@ typedef enum {
 	PK_BACKEND_SIGNAL_DISTRO_UPGRADE,
 	PK_BACKEND_SIGNAL_FINISHED,
 	PK_BACKEND_SIGNAL_PACKAGE,
+	PK_BACKEND_SIGNAL_PACKAGES,
 	PK_BACKEND_SIGNAL_ITEM_PROGRESS,
 	PK_BACKEND_SIGNAL_FILES,
 	PK_BACKEND_SIGNAL_PERCENTAGE,
@@ -178,6 +179,8 @@ void		 pk_backend_job_package_full		(PkBackendJob	*job,
 							 const gchar	*package_id,
 							 const gchar	*summary,
 							 PkInfoEnum	 update_severity);
+void		 pk_backend_job_packages		(PkBackendJob	*job,
+							 GPtrArray	*packages);
 void		 pk_backend_job_repo_detail		(PkBackendJob	*job,
 							 const gchar	*repo_id,
 							 const gchar	*description,

--- a/src/pk-backend.h
+++ b/src/pk-backend.h
@@ -30,6 +30,7 @@
 #include <packagekit-glib2/pk-enum.h>
 #include <packagekit-glib2/pk-common.h>
 #include <packagekit-glib2/pk-bitfield.h>
+#include <packagekit-glib2/pk-package.h>
 #include <packagekit-glib2/pk-package-id.h>
 #include <packagekit-glib2/pk-package-ids.h>
 #include <packagekit-glib2/pk-bitfield.h>

--- a/src/pk-direct.c
+++ b/src/pk-direct.c
@@ -357,6 +357,20 @@ pk_direct_package_cb (PkBackendJob *job, gpointer object, gpointer user_data)
 }
 
 static void
+pk_direct_packages_cb (PkBackendJob *job, gpointer object, gpointer user_data)
+{
+	GPtrArray *package_array = object;
+
+	for (guint i = 0; i < package_array->len; i++) {
+		PkPackage *pkg = g_ptr_array_index (package_array, i);
+
+		g_print ("Package: %s\t%s\n",
+			 pk_info_enum_to_string (pk_package_get_info (pkg)),
+			 pk_package_get_id (pkg));
+	}
+}
+
+static void
 pk_direct_error_cb (PkBackendJob *job, gpointer object, gpointer user_data)
 {
 	PkError *err = PK_ERROR_CODE (object);
@@ -515,6 +529,8 @@ main (int argc, char *argv[])
 				  pk_direct_status_changed_cb, priv);
 	pk_backend_job_set_vfunc (priv->job, PK_BACKEND_SIGNAL_PACKAGE,
 				  pk_direct_package_cb, priv);
+	pk_backend_job_set_vfunc (priv->job, PK_BACKEND_SIGNAL_PACKAGES,
+				  pk_direct_packages_cb, priv);
 	pk_backend_job_set_vfunc (priv->job, PK_BACKEND_SIGNAL_ERROR_CODE,
 				  pk_direct_error_cb, priv);
 	pk_backend_job_set_vfunc (priv->job, PK_BACKEND_SIGNAL_ITEM_PROGRESS,

--- a/src/pk-self-test.c
+++ b/src/pk-self-test.c
@@ -140,6 +140,17 @@ pk_test_backend_package_cb (PkBackend *backend, PkPackage *package, gpointer use
 }
 
 static void
+pk_test_backend_packages_cb (PkBackend *backend, GPtrArray *package_array, gpointer user_data)
+{
+	for (guint i = 0; i < package_array->len; i++) {
+		PkPackage *package = g_ptr_array_index (package_array, i);
+
+		g_debug ("package:%s", pk_package_get_id (package));
+		number_packages++;
+	}
+}
+
+static void
 pk_test_backend_func (void)
 {
 	const gchar *text;
@@ -184,6 +195,10 @@ pk_test_backend_func (void)
 	pk_backend_job_set_vfunc (job,
 				  PK_BACKEND_SIGNAL_PACKAGE,
 				  PK_BACKEND_JOB_VFUNC (pk_test_backend_package_cb),
+				  NULL);
+	pk_backend_job_set_vfunc (job,
+				  PK_BACKEND_SIGNAL_PACKAGES,
+				  PK_BACKEND_JOB_VFUNC (pk_test_backend_packages_cb),
 				  NULL);
 	pk_backend_job_set_vfunc (job,
 				  PK_BACKEND_SIGNAL_FINISHED,
@@ -301,6 +316,13 @@ pk_test_backend_spawn_package_cb (PkBackend *backend, PkInfoEnum info,
 				  PkBackendSpawn *backend_spawn)
 {
 	_backend_spawn_number_packages++;
+}
+
+static void
+pk_test_backend_spawn_packages_cb (PkBackend *backend, GPtrArray *package_array,
+				   PkBackendSpawn *backend_spawn)
+{
+	_backend_spawn_number_packages += package_array->len;
 }
 
 static void
@@ -435,6 +457,10 @@ pk_test_backend_spawn_func (void)
 	pk_backend_job_set_vfunc (job,
 				  PK_BACKEND_SIGNAL_PACKAGE,
 				  PK_BACKEND_JOB_VFUNC (pk_test_backend_spawn_package_cb),
+				  backend_spawn);
+	pk_backend_job_set_vfunc (job,
+				  PK_BACKEND_SIGNAL_PACKAGES,
+				  PK_BACKEND_JOB_VFUNC (pk_test_backend_spawn_packages_cb),
 				  backend_spawn);
 
 	/* test search-name.sh running */

--- a/src/pk-transaction.c
+++ b/src/pk-transaction.c
@@ -83,6 +83,7 @@ struct PkTransactionPrivate
 	PkTransactionState	 state;
 	guint			 percentage;
 	guint			 elapsed_time;
+	guint			 remaining_time;
 	guint			 speed;
 	guint			 download_size_remaining;
 	gboolean		 finished;
@@ -104,6 +105,10 @@ struct PkTransactionPrivate
 	GCancellable		*cancellable;
 	gboolean		 skip_auth_check;
 	gboolean		 client_supports_plural_signals;
+
+	/* Rate limiting of progress reporting */
+	gboolean		 progress_changed;
+	GSource			*progress_timeout_source;  /* (nullable) (owned) */
 
 	/* needed for gui coldplugging */
 	gchar			*last_package_id;
@@ -352,6 +357,89 @@ pk_transaction_emit_property_changed (PkTransaction *transaction,
 						NULL);
 }
 
+/* If any progress-related properties have changed since the last
+ * `PropertiesChanged` emission, immediately emit that D-Bus signal with the
+ * latest values and clear the pending changes flag.
+ *
+ * See schedule_progress_changed().
+ */
+static void
+flush_progress_changed (PkTransaction *transaction)
+{
+	PkTransactionPrivate *priv = transaction->priv;
+
+	if (!priv->progress_changed)
+		return;
+
+	/* Emit a D-Bus signal to notify of the progress changes. */
+	pk_transaction_emit_properties_changed (transaction,
+						"Percentage", g_variant_new_uint32 (priv->percentage),
+						"ElapsedTime", g_variant_new_uint32 (priv->elapsed_time),
+						"RemainingTime", g_variant_new_uint32 (priv->remaining_time),
+						"Speed", g_variant_new_uint32 (priv->speed),
+						"DownloadSizeRemaining", g_variant_new_uint64 (priv->download_size_remaining),
+						NULL);
+
+	priv->progress_changed = FALSE;
+}
+
+static gboolean
+progress_timeout_cb (gpointer user_data)
+{
+	PkTransaction *transaction = PK_TRANSACTION (user_data);
+
+	flush_progress_changed (transaction);
+
+	return G_SOURCE_CONTINUE;
+}
+
+/* Aggregate progress-related property notifications so that the transaction
+ * doesn’t emit multiple D-Bus signals every millisecond for fast-progressing
+ * operations (which are quite common).
+ *
+ * Instead, emit signals on a timer, set to 100ms (which should be fast enough
+ * for users to not notice the quantisation).
+ *
+ * This significantly reduces the context switching overhead between
+ * packagekitd, dbus-daemon, and the PackageKit clients.
+ *
+ * If the transaction reaches a point where property notifications need to be
+ * synced up with other externally-visible transaction state (such as if another
+ * progress calls `org.freedesktop.DBus.Properties.Get()`), call
+ * flush_progress_changed().
+ */
+static void
+schedule_progress_changed (PkTransaction *transaction)
+{
+	transaction->priv->progress_changed = TRUE;
+
+	if (transaction->priv->progress_timeout_source == NULL) {
+		g_autoptr(GSource) source = NULL;
+
+		source = g_timeout_source_new (100  /* ms */);
+		g_source_set_callback (source, G_SOURCE_FUNC (progress_timeout_cb), transaction, NULL);
+
+#if GLIB_CHECK_VERSION(2, 70, 0)
+		g_source_set_static_name (source, "PkTransaction progress timeout");
+#endif
+
+		g_source_attach (source, g_main_context_get_thread_default ());
+		transaction->priv->progress_timeout_source = g_steal_pointer (&source);
+	}
+}
+
+/* Remove the @progress_timeout_source, if set. */
+static void
+unschedule_progress_changed (PkTransaction *transaction)
+{
+	flush_progress_changed (transaction);
+
+	if (transaction->priv->progress_timeout_source != NULL) {
+		g_source_destroy (transaction->priv->progress_timeout_source);
+		g_clear_pointer (&transaction->priv->progress_timeout_source, g_source_unref);
+	}
+}
+
 static void
 pk_transaction_progress_changed_emit (PkTransaction *transaction,
 				     guint percentage,
@@ -360,16 +448,16 @@ pk_transaction_progress_changed_emit (PkTransaction *transaction,
 {
 	g_return_if_fail (PK_IS_TRANSACTION (transaction));
 
-	/* save so we can do GetProgress on a queued or finished transaction */
+	if (transaction->priv->percentage == percentage &&
+	    transaction->priv->elapsed_time == elapsed &&
+	    transaction->priv->remaining_time == remaining)
+		return;
+
 	transaction->priv->percentage = percentage;
 	transaction->priv->elapsed_time = elapsed;
+	transaction->priv->remaining_time = remaining;
 
-	/* emit */
-	pk_transaction_emit_properties_changed (transaction,
-						"Percentage", g_variant_new_uint32 (percentage),
-						"ElapsedTime", g_variant_new_uint32 (elapsed),
-						"RemainingTime", g_variant_new_uint32 (remaining),
-						NULL);
+	schedule_progress_changed (transaction);
 }
 
 static void
@@ -404,7 +492,10 @@ pk_transaction_status_changed_emit (PkTransaction *transaction, PkStatusEnum sta
 
 	transaction->priv->status = status;
 
-	/* emit */
+	/* Emit the status change, and also flush out any pending progress updates,
+	 * since the client will want to know the latest values of those
+	 * alongside the status. */
+	flush_progress_changed (transaction);
 	pk_transaction_emit_property_changed (transaction,
 					      "Status",
 					      g_variant_new_uint32 (status));
@@ -1051,6 +1142,10 @@ pk_transaction_finished_cb (PkBackendJob *job, PkExitEnum exit_enum, PkTransacti
 		g_warning ("Already finished");
 		return;
 	}
+
+	/* Ensure any pending progress has been emitted and remove the progress
+	 * timer since it’s unlikely to be used again. */
+	unschedule_progress_changed (transaction);
 
 	/* save this so we know if the cache is valid */
 	pk_results_set_exit_code (transaction->priv->results, exit_enum);
@@ -1768,11 +1863,12 @@ pk_transaction_speed_cb (PkBackendJob *job,
 			 guint speed,
 			 PkTransaction *transaction)
 {
-	/* emit */
+	if (transaction->priv->speed == speed)
+		return;
+
 	transaction->priv->speed = speed;
-	pk_transaction_emit_property_changed (transaction,
-					      "Speed",
-					      g_variant_new_uint32 (speed));
+
+	schedule_progress_changed (transaction);
 }
 
 static void
@@ -1780,11 +1876,12 @@ pk_transaction_download_size_remaining_cb (PkBackendJob *job,
 					   guint64 *download_size_remaining,
 					   PkTransaction *transaction)
 {
-	/* emit */
+	if (transaction->priv->download_size_remaining == *download_size_remaining)
+		return;
+
 	transaction->priv->download_size_remaining = *download_size_remaining;
-	pk_transaction_emit_property_changed (transaction,
-					      "DownloadSizeRemaining",
-					      g_variant_new_uint64 (*download_size_remaining));
+
+	schedule_progress_changed (transaction);
 }
 
 static void
@@ -1792,11 +1889,12 @@ pk_transaction_percentage_cb (PkBackendJob *job,
 			      guint percentage,
 			      PkTransaction *transaction)
 {
-	/* emit */
+	if (transaction->priv->percentage == percentage)
+		return;
+
 	transaction->priv->percentage = percentage;
-	pk_transaction_emit_property_changed (transaction,
-					      "Percentage",
-					      g_variant_new_uint32 (percentage));
+
+	schedule_progress_changed (transaction);
 }
 
 gboolean
@@ -4946,6 +5044,10 @@ pk_transaction_get_property (GDBusConnection *connection_, const gchar *sender,
 	PkTransaction *transaction = PK_TRANSACTION (user_data);
 	PkTransactionPrivate *priv = transaction->priv;
 
+	/* Ensure that progress signal emissions are done before we potentially
+	 * return more up-to-date property values. */
+	flush_progress_changed (transaction);
+
 	if (g_strcmp0 (property_name, "Role") == 0)
 		return g_variant_new_uint32 (priv->role);
 	if (g_strcmp0 (property_name, "Status") == 0)
@@ -5258,6 +5360,8 @@ pk_transaction_dispose (GObject *object)
 						     transaction->priv->registration_id);
 		transaction->priv->registration_id = 0;
 	}
+
+	unschedule_progress_changed (transaction);
 
 	/* send signal to clients that we are about to be destroyed */
 	if (transaction->priv->connection != NULL) {


### PR DESCRIPTION
Here are a few changes to improve PackageKit’s use of D-Bus signals to improve performance.

They are basically complete, but I haven’t polished them yet as I’d like some feedback on whether the approach is acceptable before spending time on that.

The headline is that they reduce the number of D-Bus signal emissions from packagekitd → gnome-software when starting gnome-software by about a factor of 10, from roughly 5000. This reduces gnome-software’s startup time from about 13.0s to about 12.5s (with a warm `packagekitd` process and warm libxmlb caches).

The changes are as follows, but please see the commit messages for more details:
 * Add a new `Transaction.Packages` signal to go alongside `Transaction.Package`. Emit it when there’s more than one package to be sent to the client (which is often). This is the commit which needs more polishing (such as adding a flag to enable it so that we maintain backwards compatibility for older clients), but it works (for the dnf backend; I do not plan to implement it for other backends, but it will be easy enough for others to do so).
 * Combine multiple separate `PropertiesChanged` signal emissions, since the signal supports sending an array of changed properties.
 * Emit progress-related `PropertiesChanged` signals on a timer so that they are aggregated and rate-limited. Without this, packagekitd often sends multiple `Percentage` updates every millisecond.