### PR TITLE
lib: Notify when installed database changed

### DIFF
--- a/client/pk-monitor.c
+++ b/client/pk-monitor.c
@@ -30,6 +30,12 @@
 static PkClient *client = NULL;
 
 static void
+pk_monitor_installed_changed_cb (PkControl *control, gpointer data)
+{
+	g_print ("installed-changed\n");
+}
+
+static void
 pk_monitor_repo_list_changed_cb (PkControl *control, gpointer data)
 {
 	g_print ("repo-list-changed\n");
@@ -368,6 +374,8 @@ main (int argc, char *argv[])
 	loop = g_main_loop_new (NULL, FALSE);
 
 	control = pk_control_new ();
+	g_signal_connect (control, "installed-changed",
+			  G_CALLBACK (pk_monitor_installed_changed_cb), NULL);
 	g_signal_connect (control, "repo-list-changed",
 			  G_CALLBACK (pk_monitor_repo_list_changed_cb), NULL);
 	g_signal_connect (control, "updates-changed",

--- a/docs/html/pk-matrix.html
+++ b/docs/html/pk-matrix.html
@@ -368,6 +368,17 @@
 <td><img src="img/status-good.png" alt="[yes]"/></td><!-- dnf -->
 <td><img src="img/status-bad.png" alt="[no]"/></td><!-- zypp -->
 </tr>
+<tr>
+<td><b>InstalledChanged</b></td>
+<td><img src="img/status-bad.png" alt="[no]"/></td><!-- apt -->
+<td><img src="img/status-good.png" alt="[yes]"/></td><!-- alpm -->
+<td><img src="img/status-bad.png" alt="[no]"/></td><!-- entropy -->
+<td><img src="img/status-bad.png" alt="[no]"/></td><!-- poldek -->
+<td><img src="img/status-bad.png" alt="[no]"/></td><!-- portage -->
+<td><img src="img/status-bad.png" alt="[no]"/></td><!-- slapt -->
+<td><img src="img/status-good.png" alt="[yes]"/></td><!-- dnf -->
+<td><img src="img/status-bad.png" alt="[no]"/></td><!-- zypp -->
+</tr>
 </table>
 
 <h4>Filters</h4>

--- a/lib/packagekit-glib2/pk-control.c
+++ b/lib/packagekit-glib2/pk-control.c
@@ -75,6 +75,7 @@ struct _PkControlPrivate
 enum {
 	SIGNAL_TRANSACTION_LIST_CHANGED,
 	SIGNAL_RESTART_SCHEDULE,
+	SIGNAL_INSTALLED_CHANGED,
 	SIGNAL_UPDATES_CHANGED,
 	SIGNAL_REPO_LIST_CHANGED,
 	SIGNAL_LAST
@@ -339,6 +340,11 @@ pk_control_signal_cb (GDBusProxy *proxy,
 		g_signal_emit (control,
 			       signals[SIGNAL_TRANSACTION_LIST_CHANGED], 0,
 			       ids);
+	}
+	if (g_strcmp0 (signal_name, "InstalledChanged") == 0) {
+		g_debug ("emit installed-changed");
+		g_signal_emit (control, signals[SIGNAL_INSTALLED_CHANGED], 0);
+		return;
 	}
 	if (g_strcmp0 (signal_name, "UpdatesChanged") == 0) {
 		g_debug ("emit updates-changed");
@@ -1896,6 +1902,21 @@ pk_control_class_init (PkControlClass *klass)
 				      G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_CONNECTED, pspec);
 
+	/**
+	 * PkControl::installed-changed:
+	 * @control: the #PkControl instance that emitted the signal
+	 *
+	 * The ::installed-changed signal is emitted when the list of installed apps may have
+	 * changed and the control program may have to update some UI.
+	 *
+	 * Since: 1.2.9
+	 **/
+	signals[SIGNAL_INSTALLED_CHANGED] =
+		g_signal_new ("installed-changed",
+			      G_TYPE_FROM_CLASS (object_class), G_SIGNAL_RUN_LAST,
+			      G_STRUCT_OFFSET (PkControlClass, installed_changed),
+			      NULL, NULL, g_cclosure_marshal_VOID__VOID,
+			      G_TYPE_NONE, 0);
 	/**
 	 * PkControl::updates-changed:
 	 * @control: the #PkControl instance that emitted the signal

--- a/lib/packagekit-glib2/pk-control.h
+++ b/lib/packagekit-glib2/pk-control.h
@@ -84,12 +84,12 @@ struct _PkControlClass
 							 gboolean	 is_locked);
 	void		(* connection_changed)		(PkControl	*control,
 							 gboolean	 connected);
+	void		(* installed_changed)		(PkControl	*control);
 	/* padding for future expansion */
 	void (*_pk_reserved1) (void);
 	void (*_pk_reserved2) (void);
 	void (*_pk_reserved3) (void);
 	void (*_pk_reserved4) (void);
-	void (*_pk_reserved5) (void);
 };
 
 GQuark		 pk_control_error_quark			(void);

--- a/src/org.freedesktop.PackageKit.xml
+++ b/src/org.freedesktop.PackageKit.xml
@@ -477,6 +477,17 @@
     </signal>
 
     <!--*********************************************************************-->
+    <signal name="InstalledChanged">
+      <doc:doc>
+        <doc:description>
+          <doc:para>
+            This signal is emitted when the set of installed apps has potentially changed.
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+    </signal>
+
+    <!--*********************************************************************-->
     <signal name="RepoListChanged">
       <doc:doc>
         <doc:description>

--- a/src/pk-backend.c
+++ b/src/pk-backend.c
@@ -208,6 +208,7 @@ struct PkBackendPrivate
 G_DEFINE_TYPE (PkBackend, pk_backend, G_TYPE_OBJECT)
 
 enum {
+	SIGNAL_INSTALLED_CHANGED,
 	SIGNAL_REPO_LIST_CHANGED,
 	SIGNAL_UPDATES_CHANGED,
 	SIGNAL_LAST
@@ -680,6 +681,8 @@ pk_backend_installed_db_changed_cb (gpointer user_data)
 			g_warning ("failed to invalidate: %s", error->message);
 	}
 	backend->priv->installed_db_changed_id = 0;
+	g_debug ("emitting installed-changed");
+	g_signal_emit (backend, signals [SIGNAL_INSTALLED_CHANGED], 0);
 	return FALSE;
 }
 
@@ -1094,6 +1097,11 @@ pk_backend_class_init (PkBackendClass *klass)
 	GObjectClass *object_class = G_OBJECT_CLASS (klass);
 	object_class->finalize = pk_backend_finalize;
 
+	signals [SIGNAL_INSTALLED_CHANGED] =
+		g_signal_new ("installed-changed",
+			      G_TYPE_FROM_CLASS (object_class), G_SIGNAL_RUN_LAST,
+			      0, NULL, NULL, g_cclosure_marshal_VOID__VOID,
+			      G_TYPE_NONE, 0);
 	signals [SIGNAL_REPO_LIST_CHANGED] =
 		g_signal_new ("repo-list-changed",
 			      G_TYPE_FROM_CLASS (object_class), G_SIGNAL_RUN_LAST,

--- a/src/pk-engine.c
+++ b/src/pk-engine.c
@@ -329,6 +329,21 @@ pk_engine_set_locked (PkEngine *engine, gboolean is_locked)
 }
 
 static void
+pk_engine_backend_installed_changed_cb (PkBackend *backend, PkEngine *engine)
+{
+	g_return_if_fail (PK_IS_ENGINE (engine));
+
+	g_debug ("emitting InstalledChanged");
+	g_dbus_connection_emit_signal (engine->priv->connection,
+				       NULL,
+				       PK_DBUS_PATH,
+				       PK_DBUS_INTERFACE,
+				       "InstalledChanged",
+				       NULL,
+				       NULL);
+}
+
+static void
 pk_engine_backend_repo_list_changed_cb (PkBackend *backend, PkEngine *engine)
 {
 	g_return_if_fail (PK_IS_ENGINE (engine));
@@ -1942,6 +1957,8 @@ pk_engine_new (GKeyFile *conf)
 	engine = g_object_new (PK_TYPE_ENGINE, NULL);
 	engine->priv->conf = g_key_file_ref (conf);
 	engine->priv->backend = pk_backend_new (engine->priv->conf);
+	g_signal_connect (engine->priv->backend, "installed-changed",
+			  G_CALLBACK (pk_engine_backend_installed_changed_cb), engine);
 	g_signal_connect (engine->priv->backend, "repo-list-changed",
 			  G_CALLBACK (pk_engine_backend_repo_list_changed_cb), engine);
 	g_signal_connect (engine->priv->backend, "updates-changed",


### PR DESCRIPTION
Similar to the "updates-changed" signal emit "installed-changed" when
the backend notifies about changes in the installed apps, thus the library
user can update its UI accordingly. The signal only means it's possible
something changed, it doesn't mean there changed anything.

In case of the libdnf backend this may require https://github.com/rpm-software-management/libdnf/pull/1542 on some systems.