### PR TITLE
pk-main: Add newline on g_printerr() calls

### DIFF
--- a/src/pk-main.c
+++ b/src/pk-main.c
@@ -165,13 +165,13 @@ main (int argc, char *argv[])
 	conf = g_key_file_new ();
 	conf_filename = pk_util_get_config_filename ();
 	if (conf_filename == NULL) {
-		g_printerr ("Config file was not found.");
+		g_printerr ("Config file was not found.\n");
 		goto out;
 	}
 	ret = g_key_file_load_from_file (conf, conf_filename,
 					 G_KEY_FILE_NONE, &error);
 	if (!ret) {
-		g_printerr ("Failed to load config file: %s", error->message);
+		g_printerr ("Failed to load config file: %s\n", error->message);
 		goto out;
 	}
 	g_key_file_set_boolean (conf, "Daemon", "KeepEnvironment", keep_environment);
@@ -196,7 +196,7 @@ main (int argc, char *argv[])
 	if (backend_name == NULL || g_strcmp0 (backend_name, "auto") == 0) {
 		ret  = pk_util_set_auto_backend (conf, &error);
 		if (!ret) {
-			g_printerr ("Failed to resolve auto: %s", error->message);
+			g_printerr ("Failed to resolve auto: %s\n", error->message);
 			goto out;
 		}
 	}
@@ -219,7 +219,7 @@ main (int argc, char *argv[])
 	ret = pk_engine_load_backend (engine, &error);
 	if (!ret) {
 		/* TRANSLATORS: cannot load the backend the user specified */
-		g_printerr ("Failed to load the backend: %s", error->message);
+		g_printerr ("Failed to load the backend: %s\n", error->message);
 		goto out;
 	}
 


### PR DESCRIPTION
It doesn’t add one itself (by contrast, `g_message()` and friends do add
one).

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>