### PR TITLE
docs: Fix some XML typos in the Transaction interface documentation

### DIFF
--- a/src/org.freedesktop.PackageKit.Transaction.xml
+++ b/src/org.freedesktop.PackageKit.Transaction.xml
@@ -192,7 +192,7 @@
                   but means the frontend probably has to query the updates
                   check value and pass it this value for <doc:tt>GetUpdates</doc:tt>,
                   and choose something sane otherwise.
-                  Most interactive clients will set this to <doc:tt>intmax</doc:tt>doc:tt>
+                  Most interactive clients will set this to <doc:tt>intmax</doc:tt>
                   which means "never download new metadata, unless required to return results".
                   Most transactions will not have this value set.
                 </doc:definition>
@@ -1132,7 +1132,7 @@
               <doc:tt>Resolve('Packagekit')</doc:tt> would not match <doc:tt>PackageKit</doc:tt>.
             </doc:para>
             <doc:para>
-              As a special case, if <doc:tt>Resolve()</doc:tt>doc:tt> is called
+              As a special case, if <doc:tt>Resolve()</doc:tt> is called
               with a name prefixed with <doc:tt>@</doc:tt> then
               this should be treated as a category, for example:
               <doc:tt>@web-development</doc:tt>.


### PR DESCRIPTION
Signed-off-by: Philip Withnall <pwithnall@endlessos.org>