### PR TITLE
pk-main: Mark some early-start error messages as translatable

### DIFF
--- a/src/pk-main.c
+++ b/src/pk-main.c
@@ -165,13 +165,15 @@ main (int argc, char *argv[])
 	conf = g_key_file_new ();
 	conf_filename = pk_util_get_config_filename ();
 	if (conf_filename == NULL) {
-		g_printerr ("Config file was not found.\n");
+		g_printerr ("%s\n", _("Config file was not found."));
 		goto out;
 	}
 	ret = g_key_file_load_from_file (conf, conf_filename,
 					 G_KEY_FILE_NONE, &error);
 	if (!ret) {
-		g_printerr ("Failed to load config file: %s\n", error->message);
+		/* TRANSLATORS: The placeholder is an error message */
+		g_autofree gchar *message = g_strdup_printf (_("Failed to load config file: %s"), error->message);
+		g_printerr ("%s\n", message);
 		goto out;
 	}
 	g_key_file_set_boolean (conf, "Daemon", "KeepEnvironment", keep_environment);
@@ -196,7 +198,10 @@ main (int argc, char *argv[])
 	if (backend_name == NULL || g_strcmp0 (backend_name, "auto") == 0) {
 		ret  = pk_util_set_auto_backend (conf, &error);
 		if (!ret) {
-			g_printerr ("Failed to resolve auto: %s\n", error->message);
+			/* TRANSLATORS: The placeholder is an error message.
+			 * `auto` is a potential value of the DefaultBackend= configuration key. */
+			g_autofree gchar *message = g_strdup_printf (_("Failed to resolve auto: %s"), error->message);
+			g_printerr ("%s\n", message);
 			goto out;
 		}
 	}
@@ -219,7 +224,8 @@ main (int argc, char *argv[])
 	ret = pk_engine_load_backend (engine, &error);
 	if (!ret) {
 		/* TRANSLATORS: cannot load the backend the user specified */
-		g_printerr ("Failed to load the backend: %s\n", error->message);
+		g_autofree gchar *message = g_strdup_printf (_("Failed to load the backend: %s"), error->message);
+		g_printerr ("%s\n", message);
 		goto out;
 	}
 


### PR DESCRIPTION
As suggested by Matthias on
https://github.com/PackageKit/PackageKit/pull/559#issuecomment-1173005774

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>