### PR TITLE
pk-transaction: Add UpdateDetails signal

### DIFF
--- a/lib/packagekit-glib2/pk-client.c
+++ b/lib/packagekit-glib2/pk-client.c
@@ -1159,6 +1159,58 @@ pk_client_signal_finished (PkClientState *state,
 	pk_client_state_finish (state, NULL);
 }
 
+static void
+results_add_update_detail_from_variant (PkResults   *results,
+                                        GVariant    *update_variant,
+                                        PkRoleEnum   role,
+                                        const gchar *transaction_id)
+{
+	g_autoptr(PkUpdateDetail) item = NULL;
+	const gchar *package_id;
+	g_autofree gchar **updates_strv = NULL;
+	g_autofree gchar **obsoletes_strv = NULL;
+	g_autofree gchar **vendor_urls_strv = NULL;
+	g_autofree gchar **bugzilla_urls_strv = NULL;
+	g_autofree gchar **cve_urls_strv = NULL;
+	guint restart, state;
+	const gchar *update_text, *changelog, *issued, *updated;
+
+	g_variant_get (update_variant,
+		       "(&s^a&s^a&s^a&s^a&s^a&su&s&su&s&s)",
+		       &package_id,
+		       &updates_strv,
+		       &obsoletes_strv,
+		       &vendor_urls_strv,
+		       &bugzilla_urls_strv,
+		       &cve_urls_strv,
+		       &restart,
+		       &update_text,
+		       &changelog,
+		       &state,
+		       &issued,
+		       &updated);
+
+	item = pk_update_detail_new ();
+	g_object_set (item,
+		      "package-id", package_id,
+		      "updates", updates_strv[0] != NULL ? updates_strv : NULL,
+		      "obsoletes", obsoletes_strv[0] != NULL ? obsoletes_strv : NULL,
+		      "vendor-urls", vendor_urls_strv[0] != NULL ? vendor_urls_strv : NULL,
+		      "bugzilla-urls", bugzilla_urls_strv[0] != NULL ? bugzilla_urls_strv : NULL,
+		      "cve-urls", cve_urls_strv[0] != NULL ? cve_urls_strv : NULL,
+		      "restart", restart,
+		      "update-text", update_text,
+		      "changelog", changelog,
+		      "state", state,
+		      "issued", issued,
+		      "updated", updated,
+		      "role", role,
+		      "transaction-id", transaction_id,
+		      NULL);
+
+	pk_results_add_update_detail (results, item);
+}
+
 /*
  * pk_client_signal_cb:
  **/
@@ -1172,7 +1224,6 @@ pk_client_signal_cb (GDBusProxy *proxy,
 	GWeakRef *weak_ref = user_data;
 	g_autoptr(PkClientState) state = g_weak_ref_get (weak_ref);
 	gchar *tmp_str[12];
-	gchar **tmp_strv[5];
 	gboolean tmp_bool;
 	gboolean ret;
 	guint tmp_uint;
@@ -1277,44 +1328,8 @@ pk_client_signal_cb (GDBusProxy *proxy,
 		return;
 	}
 	if (g_strcmp0 (signal_name, "UpdateDetail") == 0) {
-		g_autoptr(PkUpdateDetail) item = NULL;
-		g_variant_get (parameters,
-			       "(&s^a&s^a&s^a&s^a&s^a&su&s&su&s&s)",
-			       &tmp_str[0],
-			       &tmp_strv[0],
-			       &tmp_strv[1],
-			       &tmp_strv[2],
-			       &tmp_strv[3],
-			       &tmp_strv[4],
-			       &tmp_uint,
-			       &tmp_str[7],
-			       &tmp_str[8],
-			       &tmp_uint2,
-			       &tmp_str[10],
-			       &tmp_str[11]);
-		item = pk_update_detail_new ();
-		g_object_set (item,
-			      "package-id", tmp_str[0],
-			      "updates", tmp_strv[0][0] != NULL ? tmp_strv[0] : NULL,
-			      "obsoletes", tmp_strv[1][0] != NULL ? tmp_strv[1] : NULL,
-			      "vendor-urls", tmp_strv[2][0] != NULL ? tmp_strv[2] : NULL,
-			      "bugzilla-urls", tmp_strv[3][0] != NULL ? tmp_strv[3] : NULL,
-			      "cve-urls", tmp_strv[4][0] != NULL ? tmp_strv[4] : NULL,
-			      "restart", tmp_uint,
-			      "update-text", tmp_str[7],
-			      "changelog", tmp_str[8],
-			      "state", tmp_uint2,
-			      "issued", tmp_str[10],
-			      "updated", tmp_str[11],
-			      "role", state->role,
-			      "transaction-id", state->transaction_id,
-			      NULL);
-		pk_results_add_update_detail (state->results, item);
-		g_free (tmp_strv[0]);
-		g_free (tmp_strv[1]);
-		g_free (tmp_strv[2]);
-		g_free (tmp_strv[3]);
-		g_free (tmp_strv[4]);
+		results_add_update_detail_from_variant (state->results, parameters,
+							state->role, state->transaction_id);
 		return;
 	}
 	if (g_strcmp0 (signal_name, "Transaction") == 0) {

--- a/lib/packagekit-glib2/pk-client.c
+++ b/lib/packagekit-glib2/pk-client.c
@@ -1332,6 +1332,20 @@ pk_client_signal_cb (GDBusProxy *proxy,
 							state->role, state->transaction_id);
 		return;
 	}
+	if (g_strcmp0 (signal_name, "UpdateDetails") == 0) {
+		g_autoptr(GVariantIter) iter = NULL;
+		g_autoptr(GVariant) update_detail = NULL;
+
+		g_variant_get (parameters, "(a(sasasasasasussuss))", &iter);
+
+		while ((update_detail = g_variant_iter_next_value (iter))) {
+			results_add_update_detail_from_variant (state->results, update_detail,
+								state->role, state->transaction_id);
+			g_clear_pointer (&update_detail, g_variant_unref);
+		}
+
+		return;
+	}
 	if (g_strcmp0 (signal_name, "Transaction") == 0) {
 		g_autoptr(PkTransactionPast) item = NULL;
 		g_variant_get (parameters,

--- a/src/org.freedesktop.PackageKit.Transaction.xml
+++ b/src/org.freedesktop.PackageKit.Transaction.xml
@@ -2398,6 +2398,40 @@
     </signal>
 
     <!--*********************************************************************-->
+    <signal name="UpdateDetails">
+      <doc:doc>
+        <doc:description>
+          <doc:para>
+            This signal allows the backend to communicate specific details for
+            multiple updates to the session. It is equivalent to the sequential
+            emission of N <doc:tt>UpdateDetail</doc:tt> signals.
+          </doc:para>
+          <doc:para>
+            This signal was added to the API in PackageKit 1.2.6. It will only be emitted
+            by the daemon if the client sets the <doc:tt>supports-plural-signals=true</doc:tt>
+            hint on the transaction using <doc:tt>SetHints()</doc:tt>.
+          </doc:para>
+          <doc:para>
+            Even if this signal is used by the transaction, it may also still emit
+            <doc:tt>UpdateDetail</doc:tt> signals at other times. The content of one signal will
+            never duplicate the content of another. Clients must be prepared to handle both
+            signals within the same transaction.
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+      <arg type="a(sasasasasasussuss)" name="details" direction="out">
+        <doc:doc>
+          <doc:summary>
+            <doc:para>
+              An array of update details. Each array element is one update,
+              as documented for the <doc:tt>UpdateDetail</doc:tt> signal.
+            </doc:para>
+          </doc:summary>
+        </doc:doc>
+      </arg>
+    </signal>
+
+    <!--*********************************************************************-->
     <signal name="DistroUpgrade">
       <doc:doc>
         <doc:description>

--- a/src/org.freedesktop.PackageKit.Transaction.xml
+++ b/src/org.freedesktop.PackageKit.Transaction.xml
@@ -197,6 +197,17 @@
                   Most transactions will not have this value set.
                 </doc:definition>
               </doc:item>
+              <doc:item>
+                <doc:term>supports-plural-signals</doc:term>
+                <doc:definition>
+                  This allows the frontend to tell the daemon that it supports the
+                  new <doc:tt>Packages</doc:tt> signal for receiving information about
+                  multiple packages at once, rather than just the original
+                  <doc:tt>Package</doc:tt> signal.
+                  If this is set, and the daemon supports the signal, it will be used.
+                  If present, this must always be set to <doc:tt>true</doc:tt>.
+                </doc:definition>
+              </doc:item>
             </doc:list>
             <doc:para>
               Other values will cause a verbose warning in the daemon, but will
@@ -1855,6 +1866,47 @@
           <doc:summary>
             <doc:para>
               The one line package summary, e.g. Clipart for OpenOffice
+            </doc:para>
+          </doc:summary>
+        </doc:doc>
+      </arg>
+    </signal>
+
+    <!--*********************************************************************-->
+    <signal name="Packages">
+      <doc:doc>
+        <doc:description>
+          <doc:para>
+            This signal allows the backend to communicate multiple packages to the session.
+          </doc:para>
+          <doc:para>
+            If updating, as packages are updated then emit them to the screen.
+            This allows a summary to be presented after the transaction.
+          </doc:para>
+          <doc:para>
+            When returning results from a search always return
+            <doc:tt>installed</doc:tt> before <doc:tt>available</doc:tt> for
+            the same package name.
+          </doc:para>
+          <doc:para>
+            This signal was added to the API in PackageKit 1.2.6. It will only be emitted
+            by the daemon if the client sets the <doc:tt>supports-plural-signals=true</doc:tt>
+            hint on the transaction using <doc:tt>SetHints()</doc:tt>.
+          </doc:para>
+          <doc:para>
+            Even if this signal is used by the transaction, it may also still emit
+            <doc:tt>Package</doc:tt> signals at other times. The content of one signal will
+            never duplicate the content of another. Clients must be prepared to handle both
+            signals within the same transaction.
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+      <arg type="a(uss)" name="packages" direction="out">
+        <doc:doc>
+          <doc:summary>
+            <doc:para>
+              An array of package details. Each array element is one package,
+              as documented for the <doc:tt>Package</doc:tt> signal.
             </doc:para>
           </doc:summary>
         </doc:doc>

--- a/src/pk-backend-job.c
+++ b/src/pk-backend-job.c
@@ -564,6 +564,8 @@ pk_backend_job_signal_to_string (PkBackendJobSignal id)
 		return "LockedChanged";
 	if (id == PK_BACKEND_SIGNAL_UPDATE_DETAIL)
 		return "UpdateDetail";
+	if (id == PK_BACKEND_SIGNAL_UPDATE_DETAILS)
+		return "UpdateDetails";
 	if (id == PK_BACKEND_SIGNAL_CATEGORY)
 		return "Category";
 	return NULL;
@@ -1154,6 +1156,29 @@ pk_backend_job_update_detail (PkBackendJob *job,
 				   PK_BACKEND_SIGNAL_UPDATE_DETAIL,
 				   g_object_ref (item),
 				   g_object_unref);
+}
+
+void
+pk_backend_job_update_details (PkBackendJob *job,
+                               GPtrArray    *update_details  /* (element-type PkUpdateDetail) */)
+{
+	g_return_if_fail (PK_IS_BACKEND_JOB (job));
+	g_return_if_fail (update_details != NULL);
+
+	/* have we already set an error? */
+	if (job->priv->set_error) {
+		g_warning ("already set error: update_details");
+		return;
+	}
+
+	/* emit; this relies on the @update_details array having ownership of
+	 * all its elements, as the job is asynchronous so they may be freed in
+	 * their original calling context */
+	if (update_details->len > 0)
+		pk_backend_job_call_vfunc (job,
+					   PK_BACKEND_SIGNAL_UPDATE_DETAILS,
+					   g_ptr_array_ref (update_details),
+					   (GDestroyNotify) g_ptr_array_unref);
 }
 
 void

--- a/src/pk-backend-job.h
+++ b/src/pk-backend-job.h
@@ -46,6 +46,7 @@ typedef enum {
 	PK_BACKEND_SIGNAL_DISTRO_UPGRADE,
 	PK_BACKEND_SIGNAL_FINISHED,
 	PK_BACKEND_SIGNAL_PACKAGE,
+	PK_BACKEND_SIGNAL_PACKAGES,
 	PK_BACKEND_SIGNAL_ITEM_PROGRESS,
 	PK_BACKEND_SIGNAL_FILES,
 	PK_BACKEND_SIGNAL_PERCENTAGE,
@@ -178,6 +179,8 @@ void		 pk_backend_job_package_full		(PkBackendJob	*job,
 							 const gchar	*package_id,
 							 const gchar	*summary,
 							 PkInfoEnum	 update_severity);
+void		 pk_backend_job_packages		(PkBackendJob	*job,
+							 GPtrArray	*packages);
 void		 pk_backend_job_repo_detail		(PkBackendJob	*job,
 							 const gchar	*repo_id,
 							 const gchar	*description,

--- a/src/pk-backend-job.h
+++ b/src/pk-backend-job.h
@@ -60,6 +60,7 @@ typedef enum {
 	PK_BACKEND_SIGNAL_STATUS_CHANGED,
 	PK_BACKEND_SIGNAL_LOCKED_CHANGED,
 	PK_BACKEND_SIGNAL_UPDATE_DETAIL,
+	PK_BACKEND_SIGNAL_UPDATE_DETAILS,
 	PK_BACKEND_SIGNAL_CATEGORY,
 	PK_BACKEND_SIGNAL_LAST
 } PkBackendJobSignal;
@@ -198,6 +199,8 @@ void		 pk_backend_job_update_detail		(PkBackendJob	*job,
 							 PkUpdateStateEnum state,
 							 const gchar	*issued,
 							 const gchar	*updated);
+void		 pk_backend_job_update_details		(PkBackendJob	*job,
+							 GPtrArray	*update_details);
 void		 pk_backend_job_require_restart		(PkBackendJob	*job,
 							 PkRestartEnum	 restart,
 							 const gchar	*package_id);

--- a/src/pk-backend.h
+++ b/src/pk-backend.h
@@ -30,6 +30,7 @@
 #include <packagekit-glib2/pk-enum.h>
 #include <packagekit-glib2/pk-common.h>
 #include <packagekit-glib2/pk-bitfield.h>
+#include <packagekit-glib2/pk-package.h>
 #include <packagekit-glib2/pk-package-id.h>
 #include <packagekit-glib2/pk-package-ids.h>
 #include <packagekit-glib2/pk-bitfield.h>

--- a/src/pk-backend.h
+++ b/src/pk-backend.h
@@ -34,6 +34,7 @@
 #include <packagekit-glib2/pk-package-id.h>
 #include <packagekit-glib2/pk-package-ids.h>
 #include <packagekit-glib2/pk-bitfield.h>
+#include <packagekit-glib2/pk-update-detail.h>
 
 #include "pk-backend.h"
 #include "pk-backend-job.h"

--- a/src/pk-direct.c
+++ b/src/pk-direct.c
@@ -357,6 +357,20 @@ pk_direct_package_cb (PkBackendJob *job, gpointer object, gpointer user_data)
 }
 
 static void
+pk_direct_packages_cb (PkBackendJob *job, gpointer object, gpointer user_data)
+{
+	GPtrArray *package_array = object;
+
+	for (guint i = 0; i < package_array->len; i++) {
+		PkPackage *pkg = g_ptr_array_index (package_array, i);
+
+		g_print ("Package: %s\t%s\n",
+			 pk_info_enum_to_string (pk_package_get_info (pkg)),
+			 pk_package_get_id (pkg));
+	}
+}
+
+static void
 pk_direct_error_cb (PkBackendJob *job, gpointer object, gpointer user_data)
 {
 	PkError *err = PK_ERROR_CODE (object);
@@ -515,6 +529,8 @@ main (int argc, char *argv[])
 				  pk_direct_status_changed_cb, priv);
 	pk_backend_job_set_vfunc (priv->job, PK_BACKEND_SIGNAL_PACKAGE,
 				  pk_direct_package_cb, priv);
+	pk_backend_job_set_vfunc (priv->job, PK_BACKEND_SIGNAL_PACKAGES,
+				  pk_direct_packages_cb, priv);
 	pk_backend_job_set_vfunc (priv->job, PK_BACKEND_SIGNAL_ERROR_CODE,
 				  pk_direct_error_cb, priv);
 	pk_backend_job_set_vfunc (priv->job, PK_BACKEND_SIGNAL_ITEM_PROGRESS,

--- a/src/pk-self-test.c
+++ b/src/pk-self-test.c
@@ -140,6 +140,17 @@ pk_test_backend_package_cb (PkBackend *backend, PkPackage *package, gpointer use
 }
 
 static void
+pk_test_backend_packages_cb (PkBackend *backend, GPtrArray *package_array, gpointer user_data)
+{
+	for (guint i = 0; i < package_array->len; i++) {
+		PkPackage *package = g_ptr_array_index (package_array, i);
+
+		g_debug ("package:%s", pk_package_get_id (package));
+		number_packages++;
+	}
+}
+
+static void
 pk_test_backend_func (void)
 {
 	const gchar *text;
@@ -184,6 +195,10 @@ pk_test_backend_func (void)
 	pk_backend_job_set_vfunc (job,
 				  PK_BACKEND_SIGNAL_PACKAGE,
 				  PK_BACKEND_JOB_VFUNC (pk_test_backend_package_cb),
+				  NULL);
+	pk_backend_job_set_vfunc (job,
+				  PK_BACKEND_SIGNAL_PACKAGES,
+				  PK_BACKEND_JOB_VFUNC (pk_test_backend_packages_cb),
 				  NULL);
 	pk_backend_job_set_vfunc (job,
 				  PK_BACKEND_SIGNAL_FINISHED,
@@ -301,6 +316,13 @@ pk_test_backend_spawn_package_cb (PkBackend *backend, PkInfoEnum info,
 				  PkBackendSpawn *backend_spawn)
 {
 	_backend_spawn_number_packages++;
+}
+
+static void
+pk_test_backend_spawn_packages_cb (PkBackend *backend, GPtrArray *package_array,
+				   PkBackendSpawn *backend_spawn)
+{
+	_backend_spawn_number_packages += package_array->len;
 }
 
 static void
@@ -435,6 +457,10 @@ pk_test_backend_spawn_func (void)
 	pk_backend_job_set_vfunc (job,
 				  PK_BACKEND_SIGNAL_PACKAGE,
 				  PK_BACKEND_JOB_VFUNC (pk_test_backend_spawn_package_cb),
+				  backend_spawn);
+	pk_backend_job_set_vfunc (job,
+				  PK_BACKEND_SIGNAL_PACKAGES,
+				  PK_BACKEND_JOB_VFUNC (pk_test_backend_spawn_packages_cb),
 				  backend_spawn);
 
 	/* test search-name.sh running */

--- a/src/pk-transaction.c
+++ b/src/pk-transaction.c
@@ -83,6 +83,7 @@ struct PkTransactionPrivate
 	PkTransactionState	 state;
 	guint			 percentage;
 	guint			 elapsed_time;
+	guint			 remaining_time;
 	guint			 speed;
 	guint			 download_size_remaining;
 	gboolean		 finished;
@@ -104,6 +105,10 @@ struct PkTransactionPrivate
 	GCancellable		*cancellable;
 	gboolean		 skip_auth_check;
 	gboolean		 client_supports_plural_signals;
+
+	/* Rate limiting of progress reporting */
+	gboolean		 progress_changed;
+	GSource			*progress_timeout_source;  /* (nullable) (owned) */
 
 	/* needed for gui coldplugging */
 	gchar			*last_package_id;
@@ -352,6 +357,89 @@ pk_transaction_emit_property_changed (PkTransaction *transaction,
 						NULL);
 }
 
+/* If any progress-related properties have changed since the last
+ * `PropertiesChanged` emission, immediately emit that D-Bus signal with the
+ * latest values and clear the pending changes flag.
+ *
+ * See schedule_progress_changed().
+ */
+static void
+flush_progress_changed (PkTransaction *transaction)
+{
+	PkTransactionPrivate *priv = transaction->priv;
+
+	if (!priv->progress_changed)
+		return;
+
+	/* Emit a D-Bus signal to notify of the progress changes. */
+	pk_transaction_emit_properties_changed (transaction,
+						"Percentage", g_variant_new_uint32 (priv->percentage),
+						"ElapsedTime", g_variant_new_uint32 (priv->elapsed_time),
+						"RemainingTime", g_variant_new_uint32 (priv->remaining_time),
+						"Speed", g_variant_new_uint32 (priv->speed),
+						"DownloadSizeRemaining", g_variant_new_uint64 (priv->download_size_remaining),
+						NULL);
+
+	priv->progress_changed = FALSE;
+}
+
+static gboolean
+progress_timeout_cb (gpointer user_data)
+{
+	PkTransaction *transaction = PK_TRANSACTION (user_data);
+
+	flush_progress_changed (transaction);
+
+	return G_SOURCE_CONTINUE;
+}
+
+/* Aggregate progress-related property notifications so that the transaction
+ * doesn’t emit multiple D-Bus signals every millisecond for fast-progressing
+ * operations (which are quite common).
+ *
+ * Instead, emit signals on a timer, set to 100ms (which should be fast enough
+ * for users to not notice the quantisation).
+ *
+ * This significantly reduces the context switching overhead between
+ * packagekitd, dbus-daemon, and the PackageKit clients.
+ *
+ * If the transaction reaches a point where property notifications need to be
+ * synced up with other externally-visible transaction state (such as if another
+ * progress calls `org.freedesktop.DBus.Properties.Get()`), call
+ * flush_progress_changed().
+ */
+static void
+schedule_progress_changed (PkTransaction *transaction)
+{
+	transaction->priv->progress_changed = TRUE;
+
+	if (transaction->priv->progress_timeout_source == NULL) {
+		g_autoptr(GSource) source = NULL;
+
+		source = g_timeout_source_new (100  /* ms */);
+		g_source_set_callback (source, G_SOURCE_FUNC (progress_timeout_cb), transaction, NULL);
+
+#if GLIB_CHECK_VERSION(2, 70, 0)
+		g_source_set_static_name (source, "PkTransaction progress timeout");
+#endif
+
+		g_source_attach (source, g_main_context_get_thread_default ());
+		transaction->priv->progress_timeout_source = g_steal_pointer (&source);
+	}
+}
+
+/* Remove the @progress_timeout_source, if set. */
+static void
+unschedule_progress_changed (PkTransaction *transaction)
+{
+	flush_progress_changed (transaction);
+
+	if (transaction->priv->progress_timeout_source != NULL) {
+		g_source_destroy (transaction->priv->progress_timeout_source);
+		g_clear_pointer (&transaction->priv->progress_timeout_source, g_source_unref);
+	}
+}
+
 static void
 pk_transaction_progress_changed_emit (PkTransaction *transaction,
 				     guint percentage,
@@ -360,16 +448,16 @@ pk_transaction_progress_changed_emit (PkTransaction *transaction,
 {
 	g_return_if_fail (PK_IS_TRANSACTION (transaction));
 
-	/* save so we can do GetProgress on a queued or finished transaction */
+	if (transaction->priv->percentage == percentage &&
+	    transaction->priv->elapsed_time == elapsed &&
+	    transaction->priv->remaining_time == remaining)
+		return;
+
 	transaction->priv->percentage = percentage;
 	transaction->priv->elapsed_time = elapsed;
+	transaction->priv->remaining_time = remaining;
 
-	/* emit */
-	pk_transaction_emit_properties_changed (transaction,
-						"Percentage", g_variant_new_uint32 (percentage),
-						"ElapsedTime", g_variant_new_uint32 (elapsed),
-						"RemainingTime", g_variant_new_uint32 (remaining),
-						NULL);
+	schedule_progress_changed (transaction);
 }
 
 static void
@@ -404,7 +492,10 @@ pk_transaction_status_changed_emit (PkTransaction *transaction, PkStatusEnum sta
 
 	transaction->priv->status = status;
 
-	/* emit */
+	/* Emit the status change, and also flush out any pending progress updates,
+	 * since the client will want to know the latest values of those
+	 * alongside the status. */
+	flush_progress_changed (transaction);
 	pk_transaction_emit_property_changed (transaction,
 					      "Status",
 					      g_variant_new_uint32 (status));
@@ -1051,6 +1142,10 @@ pk_transaction_finished_cb (PkBackendJob *job, PkExitEnum exit_enum, PkTransacti
 		g_warning ("Already finished");
 		return;
 	}
+
+	/* Ensure any pending progress has been emitted and remove the progress
+	 * timer since it’s unlikely to be used again. */
+	unschedule_progress_changed (transaction);
 
 	/* save this so we know if the cache is valid */
 	pk_results_set_exit_code (transaction->priv->results, exit_enum);
@@ -1768,11 +1863,12 @@ pk_transaction_speed_cb (PkBackendJob *job,
 			 guint speed,
 			 PkTransaction *transaction)
 {
-	/* emit */
+	if (transaction->priv->speed == speed)
+		return;
+
 	transaction->priv->speed = speed;
-	pk_transaction_emit_property_changed (transaction,
-					      "Speed",
-					      g_variant_new_uint32 (speed));
+
+	schedule_progress_changed (transaction);
 }
 
 static void
@@ -1780,11 +1876,12 @@ pk_transaction_download_size_remaining_cb (PkBackendJob *job,
 					   guint64 *download_size_remaining,
 					   PkTransaction *transaction)
 {
-	/* emit */
+	if (transaction->priv->download_size_remaining == *download_size_remaining)
+		return;
+
 	transaction->priv->download_size_remaining = *download_size_remaining;
-	pk_transaction_emit_property_changed (transaction,
-					      "DownloadSizeRemaining",
-					      g_variant_new_uint64 (*download_size_remaining));
+
+	schedule_progress_changed (transaction);
 }
 
 static void
@@ -1792,11 +1889,12 @@ pk_transaction_percentage_cb (PkBackendJob *job,
 			      guint percentage,
 			      PkTransaction *transaction)
 {
-	/* emit */
+	if (transaction->priv->percentage == percentage)
+		return;
+
 	transaction->priv->percentage = percentage;
-	pk_transaction_emit_property_changed (transaction,
-					      "Percentage",
-					      g_variant_new_uint32 (percentage));
+
+	schedule_progress_changed (transaction);
 }
 
 gboolean
@@ -4946,6 +5044,10 @@ pk_transaction_get_property (GDBusConnection *connection_, const gchar *sender,
 	PkTransaction *transaction = PK_TRANSACTION (user_data);
 	PkTransactionPrivate *priv = transaction->priv;
 
+	/* Ensure that progress signal emissions are done before we potentially
+	 * return more up-to-date property values. */
+	flush_progress_changed (transaction);
+
 	if (g_strcmp0 (property_name, "Role") == 0)
 		return g_variant_new_uint32 (priv->role);
 	if (g_strcmp0 (property_name, "Status") == 0)
@@ -5258,6 +5360,8 @@ pk_transaction_dispose (GObject *object)
 						     transaction->priv->registration_id);
 		transaction->priv->registration_id = 0;
 	}
+
+	unschedule_progress_changed (transaction);
 
 	/* send signal to clients that we are about to be destroyed */
 	if (transaction->priv->connection != NULL) {


### PR DESCRIPTION
Like the `Packages` signal added a few commits previously, the
`UpdateDetails` signal is a plural version of the existing
`UpdateDetail` signal.

This has reduced the number of signals emitted during starting up
gnome-software from 632 `UpdateDetail` signals (for a corresponding
number of pending dnf updates) to 1 `UpdateDetails` signal.

The new signal is only used if the client sets the
`supports-plural-signals=true` hint on a transaction. Otherwise the old
`UpdateDetail` signal will be used. This means the new signal is
backwards-compatible.

If the hint is set, the new signal will be used in parallel with the old
one, with some operations or backends using the old signal, and some
using the new one. The content of the signals will not be duplicated
(i.e. if `UpdateDetails` is emitted for N updates, there will not also
be N `UpdateDetail` signal emissions in parallel).

The new signal is currently only implemented for the dnf backend. Other
backends can implement it at their leisure.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>