### PR TITLE
Fix documentation of package-install policy

### DIFF
--- a/policy/org.freedesktop.packagekit.policy.in
+++ b/policy/org.freedesktop.packagekit.policy.in
@@ -85,7 +85,7 @@
   <action id="org.freedesktop.packagekit.package-downgrade">
     <!-- SECURITY
           - Normal users require admin authentication to downgrade packages.
-          - User authorized to dowgrade signed packages is authorized to install
+          - User authorized to downgrade signed packages is authorized to install
             them as well.
           - If a package in question is not trusted, user's permission to install
             untrusted package will be checked as well.

--- a/policy/org.freedesktop.packagekit.policy.in
+++ b/policy/org.freedesktop.packagekit.policy.in
@@ -31,10 +31,10 @@
 
   <action id="org.freedesktop.packagekit.package-install">
     <!-- SECURITY:
-          - Normal users do not need authentication to install signed packages
-            from signed repositories, as this cannot exploit a system.
-          - Paranoid users (or parents!) can change this to 'auth_admin' or
-            'auth_admin_keep'.
+          - Normal users need authentication to install signed packages
+            from signed repositories, because otherwise the system is
+            only as secure as the least-secure package available in the
+            repositories.
      -->
     <description>Install signed package</description>
     <message>Authentication is required to install software</message>


### PR DESCRIPTION
The documentation says that unprivileged users can install signed packages. This has not been true since d462e2e62d700d0d29c41a8d9c4bbffbe99339ff from 2007. The comment is extremely stale. Fix it to match reality.