### PR TITLE
trivial: aptcc: copy a string directly to std::string, which is expec…

### DIFF
--- a/backends/aptcc/apt-intf.cpp
+++ b/backends/aptcc/apt-intf.cpp
@@ -1743,7 +1743,7 @@ void AptIntf::updateInterface(int fd, int writeFd, bool *errorEmitted)
             const gchar *status   = g_strstrip(split[0]);
             const gchar *pkg      = g_strstrip(split[1]);
             const gchar *percent  = g_strstrip(split[2]);
-            g_autofree gchar *str = g_strdup(g_strstrip(split[3]));
+            const std::string str = g_strstrip(split[3]);
 
             // major problem here, we got unexpected input. should _never_ happen
             if(pkg == nullptr && status == nullptr)
@@ -1766,7 +1766,7 @@ void AptIntf::updateInterface(int fd, int writeFd, bool *errorEmitted)
                 pk_backend_job_error_code(m_job,
                                           PK_ERROR_ENUM_PACKAGE_FAILED_TO_INSTALL,
                                           "Error while installing package: %s",
-                                          str);
+                                          str.c_str());
                 if (errorEmitted != nullptr)
                     *errorEmitted = true;
             } else if (strstr(status, "pmconffile") != NULL) {


### PR DESCRIPTION
…ted below

Below, each of the many invocations of starts_with(str, ...) takes
std::string as the argument, so str would anyway be converted to
std::string each time (and even copied again each time).

Improves: 323cc7483 trivial: aptcc: Some trivial cosmetic changes

(What really caused me to do this change was a non-GCC compiler having
troubles with that implicit conversion after the type of str was
annotated with g_autofree, which in its turn we had to change to
g_autofree_edg as another workaround. But nevertheless, this change can
be justified on its own, as at the top of this commit message.)