### PR TITLE
aptcc: Detect if apt system settings specify --force-conf* options

### DIFF
--- a/backends/aptcc/apt-intf.cpp
+++ b/backends/aptcc/apt-intf.cpp
@@ -163,8 +163,13 @@ bool AptIntf::init(gchar **localDebs)
     m_interactive = pk_backend_job_get_interactive(m_job);
     if (!m_interactive) {
         // Do not ask about config updates if we are not interactive
-        _config->Set("Dpkg::Options::", "--force-confdef");
-        _config->Set("Dpkg::Options::", "--force-confold");
+        if (!isSystemDpkgConf()) {
+            _config->Set("Dpkg::Options::", "--force-confdef");
+            _config->Set("Dpkg::Options::", "--force-confold");
+        } else {
+            // If any option is set we should not change anything
+            cout << "Using system settings for --force-conf*" << endl;
+        }
         // Ensure nothing interferes with questions
         g_setenv("APT_LISTCHANGES_FRONTEND", "none", TRUE);
         g_setenv("APT_LISTBUGS_FRONTEND", "none", TRUE);
@@ -172,6 +177,22 @@ bool AptIntf::init(gchar **localDebs)
 
     // Check if there are half-installed packages and if we can fix them
     return m_cache->CheckDeps(AllowBroken);
+}
+
+bool AptIntf::isSystemDpkgConf() {
+    std::vector<std::string> dpkg_options = _config->FindVector("Dpkg::Options");
+
+    bool is_set = false;
+    const std::string forced_options[]{"--force-confdef", "--force-confold", "--force-confnew"};
+
+    for (auto setting : forced_options) {
+        if (std::find(dpkg_options.begin(), dpkg_options.end(), setting) != dpkg_options.end()) {
+            is_set = true;
+            break;
+        }
+    }
+
+    return is_set;
 }
 
 AptIntf::~AptIntf()

--- a/backends/aptcc/apt-intf.h
+++ b/backends/aptcc/apt-intf.h
@@ -248,6 +248,7 @@ private:
     bool packageIsSupported(const pkgCache::VerIterator &verIter, string component);
     bool isApplication(const pkgCache::VerIterator &verIter);
     bool matchesQueries(const vector<string> &queries, string s);
+    bool isSystemDpkgConf();
 
     /**
      *  interprets dpkg status fd


### PR DESCRIPTION
This refers to #571 .
As suggested by @ximion, I created a patch that detects if the --force-conf* option is set and if it is, PackageKit does not change it.

This allows the admin to set a system-wide default behavior for config file updates, which is also used by PackageKit.

I also looked  at the [dpkg code](https://github.com/guillemj/dpkg/blob/1e61d9416719b628ec0e93ced10fe4c1f38ef105/src/main/configure.c#L123)  to find out what these options really do, because the documentation on them is confusing.
First of all, these settings are not affected by "DEBIAN_FRONTEND=noninteractive", which is only used for (post install) configuration prompts (accept eula, setup database...).

All three options disable the interactive prompt for configuration files.
--force-confdef **ignores confold/confnew** and keeps the old config files and installs new ones
--force-confold is only applied if confdef is **not** set and does the same as confdef
--force-confnew is only applied if confdef is **not** set and installs the files from the new package

If both --force-confdef and --force-confnew are specified, the latter is ignored, which is quite confusing.
--force-confmiss and --force-confask are not relevant if any of the other options are set.