### PR TITLE
Fix issue #342 core-dump using alpm backend with hookdirs config set

### DIFF
--- a/backends/alpm/pk-alpm-config.c
+++ b/backends/alpm/pk-alpm-config.c
@@ -362,6 +362,7 @@ typedef struct
 /* keep this in alphabetical order */
 static const PkAlpmConfigList pk_alpm_config_list_options[] = {
 	{ "HoldPkg", G_STRUCT_OFFSET (PkAlpmConfig, holdpkgs) },
+	{ "HookDir", G_STRUCT_OFFSET (PkAlpmConfig, hookdirs) },
 	{ "IgnoreGroup", G_STRUCT_OFFSET (PkAlpmConfig, ignoregroups) },
 	{ "IgnorePkg", G_STRUCT_OFFSET (PkAlpmConfig, ignorepkgs) },
 	{ "LocalFileSigLevel", G_STRUCT_OFFSET (PkAlpmConfig,
@@ -370,7 +371,6 @@ static const PkAlpmConfigList pk_alpm_config_list_options[] = {
 	{ "NoUpgrade", G_STRUCT_OFFSET (PkAlpmConfig, noupgrades) },
 	{ "RemoteFileSigLevel", G_STRUCT_OFFSET (PkAlpmConfig,
 						 remotefilesiglevels) },
-	{ "HookDir", G_STRUCT_OFFSET (PkAlpmConfig, hookdirs) },
 	{ NULL, 0 }
 };
 
@@ -1014,7 +1014,9 @@ pk_alpm_config_configure_alpm (PkBackend *backend, PkAlpmConfig *config, GError 
 	config->noupgrades = NULL;
 
 	/* alpm takes ownership */
-	alpm_option_set_noupgrades (handle, config->hookdirs);
+	for(alpm_list_t *j = config->hookdirs; j; j = j->next) {
+		alpm_option_add_hookdir(handle, j->data);
+	}
 	config->hookdirs = NULL;
 
 	pk_alpm_config_configure_repos (backend, config, handle, error);


### PR DESCRIPTION
~Note that I have not tested this,~ just looked at 

https://github.com/PackageKit/PackageKit/blob/7e700e2177ca3f84ea5a2978cdf687179b3445a9/backends/alpm/pk-alpm-config.c#L1017
and 
https://github.com/devkitPro/pacman/blob/49b08fa9d14a9cc06f01c624c644cb987ce97642/lib/libalpm/alpm.h#L1732

and thought it was a copy paste error.