### PR TITLE
Revert "Revert "Shutdown the daemon on idle by default""

### DIFF
--- a/src/pk-main.c
+++ b/src/pk-main.c
@@ -182,12 +182,14 @@ main (int argc, char *argv[])
 	syslog (LOG_DAEMON | LOG_DEBUG, "daemon start");
 
 	/* after how long do we timeout? */
-	exit_idle_time = g_key_file_get_integer (conf, "Daemon", "ShutdownTimeout", NULL);
+	exit_idle_time = g_key_file_get_integer (conf, "Daemon", "ShutdownTimeout", &error);
 	/* THIS COMMENT IS A TSUNAMI STONE
 	 * Before removing the default timeout, please study the git history and
 	 * be sure that you are not regressing Redhat bugzilla #1354074 (again). */
-	if (exit_idle_time == 0)
+	if (error != NULL) {
 		exit_idle_time = 300;
+		g_clear_error(&error);
+	}
 	g_debug ("daemon shutdown set to %i seconds", exit_idle_time);
 
 	/* override the backend name */

--- a/src/pk-main.c
+++ b/src/pk-main.c
@@ -183,9 +183,9 @@ main (int argc, char *argv[])
 
 	/* after how long do we timeout? */
 	exit_idle_time = g_key_file_get_integer (conf, "Daemon", "ShutdownTimeout", NULL);
-        /* THIS COMMENT IS A TSUNAMI STONE 
-         * Before removing the default timeout, please study the git history and
-         * be sure that you are not regressing Redhat bugzilla #1354074 (again). */
+	/* THIS COMMENT IS A TSUNAMI STONE
+	 * Before removing the default timeout, please study the git history and
+	 * be sure that you are not regressing Redhat bugzilla #1354074 (again). */
 	if (exit_idle_time == 0)
 		exit_idle_time = 300;
 	g_debug ("daemon shutdown set to %i seconds", exit_idle_time);

--- a/src/pk-main.c
+++ b/src/pk-main.c
@@ -190,7 +190,7 @@ main (int argc, char *argv[])
          * regressing Redhat bugzilla #1354074 (again). */
 	if (error != NULL) {
 		exit_idle_time = 300;
-		g_clear_error(&error);
+		g_clear_error (&error);
 	}
 	g_debug ("daemon shutdown set to %i seconds", exit_idle_time);
 

--- a/src/pk-main.c
+++ b/src/pk-main.c
@@ -184,8 +184,10 @@ main (int argc, char *argv[])
 	/* after how long do we timeout? */
 	exit_idle_time = g_key_file_get_integer (conf, "Daemon", "ShutdownTimeout", &error);
 	/* THIS COMMENT IS A TSUNAMI STONE
-	 * Before removing the default timeout, please study the git history and
-	 * be sure that you are not regressing Redhat bugzilla #1354074 (again). */
+         * The automatic shutdown timeout is necessary to avoid very high
+         * memory usage with the dnf backend.  If you want to remove this
+         * timeout, please study the git history and be sure that you are not
+         * regressing Redhat bugzilla #1354074 (again). */
 	if (error != NULL) {
 		exit_idle_time = 300;
 		g_clear_error(&error);

--- a/src/pk-main.c
+++ b/src/pk-main.c
@@ -183,6 +183,11 @@ main (int argc, char *argv[])
 
 	/* after how long do we timeout? */
 	exit_idle_time = g_key_file_get_integer (conf, "Daemon", "ShutdownTimeout", NULL);
+        /* THIS COMMENT IS A TSUNAMI STONE 
+         * Before removing the default timeout, please study the git history and
+         * be sure that you are not regressing Redhat bugzilla #1354074 (again). */
+	if (exit_idle_time == 0)
+		exit_idle_time = 300;
 	g_debug ("daemon shutdown set to %i seconds", exit_idle_time);
 
 	/* override the backend name */

--- a/src/pk-main.c
+++ b/src/pk-main.c
@@ -192,7 +192,10 @@ main (int argc, char *argv[])
 		exit_idle_time = 300;
 		g_clear_error (&error);
 	}
-	g_debug ("daemon shutdown set to %i seconds", exit_idle_time);
+	if (exit_idle_time > 0)
+		g_debug ("daemon shutdown set to %i seconds", exit_idle_time);
+	else
+		g_debug ("daemon will not shut down on idle");
 
 	/* override the backend name */
 	if (backend_name != NULL) {

--- a/src/pk-main.c
+++ b/src/pk-main.c
@@ -184,10 +184,10 @@ main (int argc, char *argv[])
 	/* after how long do we timeout? */
 	exit_idle_time = g_key_file_get_integer (conf, "Daemon", "ShutdownTimeout", &error);
 	/* THIS COMMENT IS A TSUNAMI STONE
-         * The automatic shutdown timeout is necessary to avoid very high
-         * memory usage with the dnf backend.  If you want to remove this
-         * timeout, please study the git history and be sure that you are not
-         * regressing Redhat bugzilla #1354074 (again). */
+	 * The automatic shutdown timeout prevents memory leaks in some
+	 * backends from getting out of hand.  If you want to remove this
+	 * timeout, please study the git history and be sure that you are not
+	 * regressing Redhat bugzilla #1354074 (again). */
 	if (error != NULL) {
 		exit_idle_time = 300;
 		g_clear_error (&error);

--- a/src/pk-main.c
+++ b/src/pk-main.c
@@ -186,8 +186,8 @@ main (int argc, char *argv[])
 	/* THIS COMMENT IS A TSUNAMI STONE
 	 * The automatic shutdown timeout prevents memory leaks in some
 	 * backends from getting out of hand.  If you want to remove this
-	 * timeout, please study the git history and be sure that you are not
-	 * regressing Redhat bugzilla #1354074 (again). */
+	 * timeout, please study the Git history and be sure that you are not
+	 * regressing Red Hat bugzilla #1354074 (again). */
 	if (error != NULL) {
 		exit_idle_time = 300;
 		g_clear_error (&error);


### PR DESCRIPTION
This reverts commit dca1f5b2508a4632d0b9fefab771a5a9caf83a5c.

Which reverted commit 0c84d71509e851db20445c747529bd7d3724f081, which reverted commit c6eb3555ec5b41e988c111d276764d55fb83bda3.

Fixes #460.  High memory usage was also reported on Redhat's bug tracker back in 2016, and a couple more times since:

https://bugzilla.redhat.com/show_bug.cgi?id=1354074 
https://bugzilla.redhat.com/show_bug.cgi?id=1854875 
https://bugzilla.redhat.com/show_bug.cgi?id=1896964

The memory usage of packagekitd without the timeout has been observed growing well beyond half a GiB. On two of my own machines running Fedora 36 as I write this, 537 MiB and 696 MiB. 

As I understand it, this timeout causes some slightly surprising behavior when users mix command line dnf upgades with GUI PackageKit upgrades, and do not manually run an update check before rebooting for update. But that is an edge case, and the price of not having it is too high.