### PR TITLE
Update documentation URL in README

### DIFF
--- a/README
+++ b/README
@@ -4,4 +4,4 @@
 PackageKit is a DBUS abstraction layer that allows the session user to manage
 packages in a secure way using a cross-distro, cross-architecture API.
 
-For more information, please see http://www.packagekit.org
+For more information, please see https://www.freedesktop.org/software/PackageKit/


### PR DESCRIPTION
As I was able to gather from #411 the website used to be a redirect to https://www.freedesktop.org/software/PackageKit/. As the website at packagekit.org is now defunct and just shows a Google Domains expiry notice, I think it would be beneficial to change the URL referenced in the README file.