### PR TITLE
Always check for invalidated dnf sacks and free them.

### DIFF
--- a/backends/dnf/pk-backend-dnf.c
+++ b/backends/dnf/pk-backend-dnf.c
@@ -727,7 +727,7 @@ dnf_utils_create_sack_for_filters (PkBackendJob *job,
 
 	/* do we have anything in the cache */
 	cache_key = dnf_utils_create_cache_key (dnf_context_get_release_ver (job_data->context), flags);
-	if ((create_flags & DNF_CREATE_SACK_FLAG_USE_CACHE) > 0) {
+	{
 		g_autoptr(GMutexLocker) locker = g_mutex_locker_new (&priv->sack_mutex);
 		cache_item = g_hash_table_lookup (priv->sack_cache, cache_key);
 		if (cache_item != NULL && cache_item->sack != NULL) {


### PR DESCRIPTION
While looking at packagekitd memory use on Fedora, I noticed that invalid dnf sacks are only freed if create_flags & DNF_CREATE_SACK_FLAG_USE_CACHE, but there are conditions in which that flag may be masked away.  If I'm not mistaken, this can prevent sacks from ever being freed and leads to indefinite memory growth.