### PR TITLE
Run pk_backend_refresh_repo in a new process

### DIFF
--- a/backends/dnf/meson.build
+++ b/backends/dnf/meson.build
@@ -26,6 +26,8 @@ shared_module(
   'dnf-backend-vendor.h',
   'dnf-backend.c',
   'dnf-backend.h',
+  'pk-backend-dnf-common.c',
+  'pk-backend-dnf-common.h',
   'pk-backend-dnf.c',
   include_directories: packagekit_src_include,
   dependencies: [
@@ -36,8 +38,31 @@ shared_module(
     gmodule_dep,
   ],
   c_args: [
-    c_args
+    c_args,
+    '-DLIBEXECDIR="@0@"'.format(join_paths(get_option('prefix'), get_option('libexecdir'))),
   ],
   install: true,
   install_dir: pk_plugin_dir,
+)
+
+packagekit_refresh_repo_exec = executable(
+  'packagekit-dnf-refresh-repo',
+  '../../src/pk-shared.c',
+  '../../src/pk-shared.h',
+  'pk-backend-dnf-common.c',
+  'pk-backend-dnf-common.h',
+  'pk-backend-dnf-refresh.c',
+  include_directories: packagekit_src_include,
+  dependencies: [
+    packagekit_glib2_dep,
+    appstream_dep,
+    dnf_dep,
+    rpm_dep,
+    gmodule_dep,
+  ],
+  install: true,
+  install_dir: get_option('libexecdir'),
+  c_args: [
+    c_args
+  ]
 )

--- a/backends/dnf/pk-backend-dnf-common.c
+++ b/backends/dnf/pk-backend-dnf-common.c
@@ -1,0 +1,110 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2013-2014 Richard Hughes <richard@hughsie.com>
+ *
+ * Licensed under the GNU General Public License Version 2
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <config.h>
+
+#include <gmodule.h>
+#include <glib.h>
+#include <appstream-glib.h>
+#include <libdnf/libdnf.h>
+
+#include "pk-shared.h"
+#include "pk-backend-dnf-common.h"
+
+gboolean
+pk_backend_setup_dnf_context (DnfContext *context, GKeyFile *conf, const gchar *release_ver, GError **error)
+{
+	const gchar * const *repo_dirs;
+	const gchar * const *var_dirs;
+	gboolean keep_cache;
+	g_autofree gchar *cache_dir = NULL;
+	g_autofree gchar *destdir = NULL;
+	g_autofree gchar *lock_dir = NULL;
+	g_autofree gchar *solv_dir = NULL;
+
+	destdir = g_key_file_get_string (conf, "Daemon", "DestDir", NULL);
+	if (destdir == NULL)
+		destdir = g_strdup ("/");
+	dnf_context_set_install_root (context, destdir);
+	cache_dir = g_build_filename (destdir, "/var/cache/PackageKit", release_ver, "metadata", NULL);
+	dnf_context_set_cache_dir (context, cache_dir);
+	solv_dir = g_build_filename (destdir, "/var/cache/PackageKit", release_ver, "hawkey", NULL);
+	dnf_context_set_solv_dir (context, solv_dir);
+	lock_dir = g_build_filename (destdir, "/var/run", NULL);
+	dnf_context_set_lock_dir (context, lock_dir);
+	dnf_context_set_rpm_verbosity (context, "info");
+
+	/* Add prefix to repo directories */
+	repo_dirs = dnf_context_get_repos_dir (context);
+	if (repo_dirs != NULL && repo_dirs[0] != NULL) {
+		g_auto(GStrv) full_repo_dirs = NULL;
+		guint len = g_strv_length ((gchar **)repo_dirs);
+		full_repo_dirs = g_new0 (gchar*, len + 1);
+		for (guint i = 0; i < len; i++)
+			full_repo_dirs[i] = g_build_filename (destdir, repo_dirs[i], NULL);
+		dnf_context_set_repos_dir (context, (const gchar * const*)full_repo_dirs);
+	}
+
+	/* Add prefix to var directories */
+	var_dirs = dnf_context_get_vars_dir (context);
+	if (var_dirs != NULL && var_dirs[0] != NULL) {
+		g_auto(GStrv) full_var_dirs = NULL;
+		guint len = g_strv_length ((gchar **)var_dirs);
+		full_var_dirs = g_new0 (gchar*, len + 1);
+		for (guint i = 0; i < len; i++)
+			full_var_dirs[i] = g_build_filename (destdir, var_dirs[i], NULL);
+		dnf_context_set_vars_dir (context, (const gchar * const*)full_var_dirs);
+	}
+
+	/* use this initial data if repos are not present */
+	dnf_context_set_vendor_cache_dir (context, "/usr/share/PackageKit/metadata");
+	dnf_context_set_vendor_solv_dir (context, "/usr/share/PackageKit/hawkey");
+
+	/* do we keep downloaded packages */
+	keep_cache = g_key_file_get_boolean (conf, "Daemon", "KeepCache", NULL);
+	dnf_context_set_keep_cache (context, keep_cache);
+
+	/* set up context */
+	return dnf_context_setup (context, NULL, error);
+}
+
+gboolean
+dnf_utils_refresh_repo_appstream (DnfRepo *repo, GError **error)
+{
+	const gchar *as_basenames[] = { "appstream", "appstream-icons", NULL };
+	for (guint i = 0; as_basenames[i] != NULL; i++) {
+		const gchar *tmp = dnf_repo_get_filename_md (repo, as_basenames[i]);
+		if (tmp != NULL) {
+#if AS_CHECK_VERSION(0,3,4)
+			if (!as_utils_install_filename (AS_UTILS_LOCATION_CACHE,
+							tmp,
+							dnf_repo_get_id (repo),
+							NULL,
+							error)) {
+				return FALSE;
+			}
+#else
+			g_warning ("need to install AppStream metadata %s", tmp);
+#endif
+		}
+	}
+	return TRUE;
+}

--- a/backends/dnf/pk-backend-dnf-common.h
+++ b/backends/dnf/pk-backend-dnf-common.h
@@ -1,0 +1,37 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2014 Richard Hughes <richard@hughsie.com>
+ *
+ * Licensed under the GNU Lesser General Public License Version 2.1
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#ifndef __PK_BACKEND_DNF_COMMON_H
+#define __PK_BACKEND_DNF_COMMON_H
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+gboolean	pk_backend_setup_dnf_context (DnfContext *context,
+					      GKeyFile *conf,
+					      const gchar *release_ver,
+					      GError **error);
+gboolean	dnf_utils_refresh_repo_appstream (DnfRepo *repo, GError **error);
+
+G_END_DECLS
+
+#endif /* __PK_BACKEND_DNF_COMMON_H */

--- a/backends/dnf/pk-backend-dnf-refresh.c
+++ b/backends/dnf/pk-backend-dnf-refresh.c
@@ -1,0 +1,170 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2013-2014 Richard Hughes <richard@hughsie.com>
+ *
+ * Licensed under the GNU General Public License Version 2
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <config.h>
+
+#include <gmodule.h>
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <glib/gi18n.h>
+#include <string.h>
+#include <appstream-glib.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+#include <pk-backend.h>
+#include <packagekit-glib2/pk-common-private.h>
+#include <packagekit-glib2/pk-debug.h>
+
+#include <libdnf/libdnf.h>
+#include <libdnf/dnf-advisory.h>
+#include <libdnf/dnf-advisoryref.h>
+#include <libdnf/dnf-db.h>
+#include <libdnf/hy-packageset.h>
+#include <libdnf/hy-query.h>
+#include <libdnf/dnf-version.h>
+#include <libdnf/dnf-sack.h>
+#include <libdnf/hy-util.h>
+#include <librepo/librepo.h>
+#include <rpm/rpmlib.h>
+
+#include "dnf-backend-vendor.h"
+#include "dnf-backend.h"
+#include "pk-backend-dnf-common.h"
+
+static gboolean
+pk_backend_refresh_repo (guint max_cache_age,
+                         DnfRepo *repo,
+                         DnfState *state,
+                         GError **error)
+{
+	gboolean ret;
+	gboolean repo_okay;
+	DnfState *state_local;
+	GError *error_local = NULL;
+
+	/* set state */
+	ret = dnf_state_set_steps (state, error,
+				   2, /* check */
+				   98, /* download */
+				   -1);
+	if (!ret)
+		return FALSE;
+
+	/* is the repo up to date? */
+	state_local = dnf_state_get_child (state);
+	repo_okay = dnf_repo_check (repo,
+	                            max_cache_age,
+	                            state_local,
+	                            &error_local);
+	if (!repo_okay) {
+		g_debug ("repo %s not okay [%s], refreshing",
+			 dnf_repo_get_id (repo), error_local->message);
+		g_clear_error (&error_local);
+		if (!dnf_state_finished (state_local, error))
+			return FALSE;
+	}
+
+	/* done */
+	if (!dnf_state_done (state, error))
+		return FALSE;
+
+	/* update repo, TODO: if we have network access */
+	if (!repo_okay) {
+		state_local = dnf_state_get_child (state);
+		ret = dnf_repo_update (repo,
+		                       DNF_REPO_UPDATE_FLAG_IMPORT_PUBKEY,
+		                       state_local,
+		                       &error_local);
+		if (!ret) {
+			if (g_error_matches (error_local,
+					     DNF_ERROR,
+					     DNF_ERROR_CANNOT_FETCH_SOURCE)) {
+				g_warning ("Skipping refresh of %s: %s",
+					   dnf_repo_get_id (repo),
+					   error_local->message);
+				g_clear_error (&error_local);
+				if (!dnf_state_finished (state_local, error))
+					return FALSE;
+			} else {
+				g_propagate_error (error, error_local);
+				return FALSE;
+			}
+		}
+	}
+
+	/* copy the appstream files somewhere that the GUI will pick them up */
+	if (!dnf_utils_refresh_repo_appstream (repo, error))
+		return FALSE;
+
+	/* done */
+	return dnf_state_done (state, error);
+}
+
+int
+main (int argc, char *argv[])
+{
+	guint max_cache_age, i, ret;
+	g_autofree gchar *conf_filename = NULL;
+	g_autoptr(GKeyFile) conf = NULL;
+	g_autoptr(DnfState) state = NULL;
+	g_autoptr(DnfContext) context = NULL;
+	g_autoptr(GPtrArray) repos = NULL;
+	g_autoptr(GError) error = NULL;
+
+	if (argc != 4) {
+		printf("Use: packagekit-dnf-refresh-repo <age> <repo-id> <release-ver>\n");
+		return 1;
+	}
+
+	conf = g_key_file_new ();
+	conf_filename = pk_util_get_config_filename ();
+	if (conf_filename == NULL) {
+		g_printerr ("%s\n", _("Config file was not found."));
+		return 1;
+	}
+	ret = g_key_file_load_from_file (conf, conf_filename,
+					 G_KEY_FILE_NONE, &error);
+	if (!ret) {
+		/* TRANSLATORS: The placeholder is an error message */
+		g_autofree gchar *message = g_strdup_printf (_("Failed to load config file: %s"), error->message);
+		g_printerr ("%s\n", message);
+		return 1;
+	}
+
+	max_cache_age = atoi(argv[1]);
+	context = dnf_context_new ();
+	if (!pk_backend_setup_dnf_context (context, conf, argv[3], &error))
+		return 1;
+	repos = dnf_repo_loader_get_repos (dnf_context_get_repo_loader (context), &error);
+	if (repos == NULL)
+		return 1;
+	for (i = 0; i < repos->len; i++) {
+                DnfRepo *repo = g_ptr_array_index (repos, i);
+		if (strcmp(dnf_repo_get_id (repo), argv[2]) == 0) {
+			state = dnf_state_new ();
+			pk_backend_refresh_repo (max_cache_age,
+						 repo,
+						 state,
+						 &error);
+		}
+        }
+}

--- a/contrib/PackageKit.spec.in
+++ b/contrib/PackageKit.spec.in
@@ -200,6 +200,7 @@ popd > /dev/null
 %{_datadir}/PackageKit/helpers/test_spawn/search-name.sh
 %{_libexecdir}/packagekitd
 %{_libexecdir}/packagekit-direct
+%{_libexecdir}/packagekit-dnf-refresh-repo
 %pycached %{python3_sitelib}/dnf-plugins/notify_packagekit.py
 %{_bindir}/pkmon
 %{_bindir}/pkcon


### PR DESCRIPTION
Run pk_backend_refresh_repo in a new process to avoid keeping libdnf memory leaks.

This is not a real PR, I do not expect this to be merged.  I understand that running complex code in a process forked from a threaded process is not safe.

This PR is instead intended as a suggestion / request to move pk_backend_refresh_repo into a new helper application, and to fork&&exec that helper from pk_backend_refresh_cache_thread.

While reviewing packagekitd memory use on Fedora, I saw constant growth of memory use every time repo metadata was refreshed (easily demonstrated by running `pkcon refresh force` repeatedly.  Running packagekitd under valgrind appeared to locate numerous memory leaks, most of which were under libdnf's dnf_repo_update().  The number of unique leaks detected makes fixing them in the short term probably infeasible.  However, running the update in a new process means that at least leaks get collected when the process exits.  That does mean that error information from pk_backend_refresh_repo will be lost, but that seems like a sensible trade for now.

Whereas before this change, memory use grew each time the repo was refreshed, after this change memory use settled at ~ 200MB.  (Which is still kind of large, but significantly smaller than without it.)

Would you consider creating a new helper binary to perform repo refresh, and run that helper in a new process, rather than running pk_backend_refresh_repo in the packagekitd process?