### PR TITLE
Lock dnf_context_new, which is not thread-safe.

### DIFF
--- a/backends/dnf/pk-backend-dnf.c
+++ b/backends/dnf/pk-backend-dnf.c
@@ -248,6 +248,7 @@ remove_old_cache_directories (PkBackend *backend, const gchar *release_ver)
 static gboolean
 pk_backend_ensure_default_dnf_context (PkBackend *backend, GError **error)
 {
+	static GMutex dnf_context_new_mutex;
 	PkBackendDnfPrivate *priv = pk_backend_get_user_data (backend);
 	g_autoptr(DnfContext) context = NULL;
 
@@ -259,7 +260,9 @@ pk_backend_ensure_default_dnf_context (PkBackend *backend, GError **error)
 	g_assert (priv->release_ver != NULL);
 
 	/* set defaults */
+	g_mutex_lock (&dnf_context_new_mutex);
 	context = dnf_context_new ();
+	g_mutex_unlock (&dnf_context_new_mutex);
 	if (!pk_backend_setup_dnf_context (context, priv->conf, priv->release_ver, error))
 		return FALSE;
 


### PR DESCRIPTION
Valgrind sometimes reports a large number of probable leaks in code descending from dnf_context_new.  It looks like this *might* be a race condition in [rpmluaGetGlobalState](https://github.com/rpm-software-management/rpm/blob/master/rpmio/rpmlua.c#L93).

I'm not sure this change fix fully resolves the problem, but it looks to me like rpmReadConfigFiles is not thread safe, and should be executed only in a locked context.

```
==244687== 4,096 bytes in 1 blocks are possibly lost in loss record 4,511 of 4,635
==244687==    at 0x48486AF: realloc (vg_replace_malloc.c:1451)
==244687==    by 0x14F61253: luaM_realloc_ (lmem.c:166)
==244687==    by 0x14F62717: luaS_resize (lstring.c:91)
==244687==    by 0x14F6290F: UnknownInlinedFun (lstring.c:181)
==244687==    by 0x14F6290F: internshrstr.lto_priv.0 (lstring.c:205)
==244687==    by 0x14F68703: luaS_new (lstring.c:253)
==244687==    by 0x14F4ADB7: auxsetstr (lapi.c:834)
==244687==    by 0x14F52D94: luaL_setfuncs (lauxlib.c:938)
==244687==    by 0x1480F8D1: luaopen_rpm (rpmlua.c:1261)
==244687==    by 0x14F5B671: UnknownInlinedFun (ldo.c:507)
==244687==    by 0x14F5B671: luaD_precall (ldo.c:573)
==244687==    by 0x14F532D7: UnknownInlinedFun (ldo.c:608)
==244687==    by 0x14F532D7: UnknownInlinedFun (ldo.c:628)
==244687==    by 0x14F532D7: lua_callk (lapi.c:1022)
==244687==    by 0x14F5380B: luaL_requiref (lauxlib.c:976)
==244687==    by 0x1481619C: rpmluaNew (rpmlua.c:134)
==244687==    by 0x14816340: UnknownInlinedFun (rpmlua.c:96)
==244687==    by 0x14816340: rpmluaGetGlobalState (rpmlua.c:93)
==244687==    by 0x14B84E4C: rpmReadConfigFiles (rpmrc.c:1662)
==244687==    by 0x146EB193: dnf_context_globals_init (dnf-context.cpp:411)
==244687==    by 0x1475C205: libdnf::initLibRpm() (os-release.cpp:85)
==244687==    by 0x1475C71A: UnknownInlinedFun (os-release.cpp:101)
==244687==    by 0x1475C71A: libdnf::getUserAgent(std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&) (os-release.cpp:127)
==244687==    by 0x1475CD49: libdnf::getUserAgent[abi:cxx11]() (os-release.cpp:153)
==244687==    by 0x146ED09F: dnf_context_init(_DnfContext*) (dnf-context.cpp:374)
==244687==    by 0x4A5B0E7: g_type_create_instance (gtype.c:1931)
==244687==    by 0x4A40C1F: g_object_new_internal (gobject.c:2228)
==244687==    by 0x4A42247: g_object_new_with_properties (gobject.c:2391)
==244687==    by 0x4A42FF0: g_object_new (gobject.c:2037)
==244687==    by 0x146F3395: dnf_context_new (dnf-context.cpp:2883)
==244687==    by 0x48616A4: pk_backend_ensure_default_dnf_context (pk-backend-dnf.c:223)
```