### PR TITLE
pkcon: Widen progressbar text area

### DIFF
--- a/client/pk-console.c
+++ b/client/pk-console.c
@@ -1639,7 +1639,7 @@ main (int argc, char *argv[])
 	g_autofree gchar *filter = NULL;
 	g_autofree gchar *options_help = NULL;
 	g_autofree gchar *summary = NULL;
-	guint bar_padding = 30;
+	guint bar_padding = 40;
 	guint bar_size = 25;
 	struct winsize w;
 


### PR DESCRIPTION
The `pk_progress_bar` `padding` value was set to 30, making that the minimum width for status text displayed next to a progress bar. But one of the status texts displayed in English during `refresh` is "Downloading repository information", which is 34 characters. As a result, the output ends up looking like this:

```console
$ pkcon refresh force
Refreshing cache              [=========================]         
Loading cache                 [=========================]         
Downloading repository information[=========================]         
Loading cache                 [=========================]         
Downloading repository information[=========================]         
Loading cache                 [=========================]         
Downloading repository information[=========================]         
Loading cache                 [=========================]         
Downloading repository information[=========================]         
Loading cache                 [=========================]         
```

But there's plenty of room to the right of the output, beore hitting the 80-column limit. So, this PR raises the padding to `40`, resulting in:

```console
$ _build/client/pkcon refresh force
Refreshing cache                        [=========================]         
Loading cache                           [=========================]         
Downloading repository information      [=========================]         
Loading cache                           [=========================]         
Downloading repository information      [=========================]         
Loading cache                           [=========================]         
Downloading repository information      [=========================]         
Loading cache                           [=========================]         
Downloading repository information      [=========================]         
Loading cache                           [=========================]         
Downloading repository information      [=========================]         
Loading cache                           [=========================]         
Downloading repository information      [=========================]         
Loading cache                           [=========================]         
```

Still comfortably fitting within an 80-column width, even (just barely) when `(100%)` is shown to the right of the bar.