### PR TITLE
Pass HOME environment variable through to the client

### DIFF
--- a/lib/packagekit-glib2/pk-client.c
+++ b/lib/packagekit-glib2/pk-client.c
@@ -2120,6 +2120,7 @@ pk_client_create_helper_argv_envp (gchar ***argv,
 	const gchar *dialog = NULL;
 	const gchar *display;
 	const gchar *term;
+	const gchar *home;
 	gboolean ret;
 	guint envpi = 0;
 	gchar **envp;
@@ -2156,6 +2157,12 @@ pk_client_create_helper_argv_envp (gchar ***argv,
 			dialog = "kde";
 		else
 			dialog = "gnome";
+	}
+
+	/* pass through the home directory */
+	home = g_getenv ("HOME");
+	if (home != NULL) {
+		envp[envpi++] = g_strdup_printf ("HOME=%s", home);
 	}
 
 	/* indicate a prefered frontend */


### PR DESCRIPTION
To fix debconf-kde-helper error dialog:
https://bugs.launchpad.net/ubuntu/+source/kde-runtime/+bug/1851573

I reproduced the bug on Ubuntu 22.04. I tested the patch by applying it to the OS package (1.2.5-2ubuntu2), rebuilding and installing. I confirmed that it fixed the bug.