### PR TITLE
pk-transaction: Add support for getting the RemainingTime property

### DIFF
--- a/src/pk-transaction.c
+++ b/src/pk-transaction.c
@@ -5212,6 +5212,9 @@ pk_transaction_get_property (GDBusConnection *connection_, const gchar *sender,
 		return g_variant_new_uint64 (priv->download_size_remaining);
 	if (g_strcmp0 (property_name, "TransactionFlags") == 0)
 		return g_variant_new_uint64 (priv->cached_transaction_flags);
+	if (g_strcmp0 (property_name, "RemainingTime") == 0)
+		return g_variant_new_uint32 (priv->remaining_time);
+
 	return NULL;
 }
 

--- a/src/pk-transaction.c
+++ b/src/pk-transaction.c
@@ -5215,6 +5215,8 @@ pk_transaction_get_property (GDBusConnection *connection_, const gchar *sender,
 	if (g_strcmp0 (property_name, "RemainingTime") == 0)
 		return g_variant_new_uint32 (priv->remaining_time);
 
+	g_set_error (error, G_DBUS_ERROR, G_DBUS_ERROR_UNKNOWN_PROPERTY,
+		     "Unknown transaction property ‘%s’", property_name);
 	return NULL;
 }
 


### PR DESCRIPTION
This seems to have been forgotten when the property was added.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>