### PR TITLE
Pass -DPK_COMPILATION to the C++ compiler too.

### DIFF
--- a/backends/apt/meson.build
+++ b/backends/apt/meson.build
@@ -62,7 +62,6 @@ shared_module(
   ],
   c_args: c_args,
   cpp_args: [
-    '-DPK_COMPILATION',
     c_args,
     ddtp_flag,
   ],

--- a/backends/nix/meson.build
+++ b/backends/nix/meson.build
@@ -19,7 +19,6 @@ shared_module(
     gmodule_dep,
   ],
   cpp_args: [
-    '-DPK_COMPILATION=1',
     '-DG_LOG_DOMAIN="PackageKit-Nix"',
   ],
   install: true,

--- a/backends/slack/meson.build
+++ b/backends/slack/meson.build
@@ -21,7 +21,6 @@ packagekit_backend_slack_module = shared_module(
   ],
   cpp_args: [
     '-DG_LOG_DOMAIN="PackageKit-Slackware"',
-    '-DPK_COMPILATION=1',
     '-DLOCALSTATEDIR="@0@"'.format(join_paths(get_option('prefix'), get_option('localstatedir'))),
     '-DLIBDIR="@0@"'.format(join_paths(get_option('prefix'), get_option('libdir'))),
     '-DSYSCONFDIR="@0@"'.format(get_option('sysconfdir')),

--- a/backends/slack/tests/meson.build
+++ b/backends/slack/tests/meson.build
@@ -10,7 +10,6 @@ pk_slack_test_dependencies = [
 
 pk_slack_test_cpp_args = [
   '-DG_LOG_DOMAIN="PackageKit-Slackware"',
-  '-DPK_COMPILATION=1',
   '-DLOCALSTATEDIR="@0@"'.format(join_paths(get_option('prefix'), get_option('localstatedir'))),
   '-DLIBDIR="@0@"'.format(join_paths(get_option('prefix'), get_option('libdir'))),
   '-DSYSCONFDIR="@0@"'.format(get_option('sysconfdir')),

--- a/backends/zypp/meson.build
+++ b/backends/zypp/meson.build
@@ -18,7 +18,6 @@ shared_module(
     gmodule_dep,
   ],
   cpp_args: [
-    '-DPK_COMPILATION=1',
     '-DG_LOG_DOMAIN="PackageKit-Zypp"',
     '-Wall',
     '-Woverloaded-virtual',

--- a/meson.build
+++ b/meson.build
@@ -68,7 +68,7 @@ add_project_arguments ('-D_DEFAULT_SOURCE', language: 'c')
 add_project_arguments ('-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_44', language: 'c')
 
 # allow the daemon to include library files directly
-add_project_arguments ('-DPK_COMPILATION', language: 'c')
+add_project_arguments ('-DPK_COMPILATION', language: ['c', 'cpp'])
 
 conf = configuration_data()
 conf.set_quoted('DATADIR', join_paths(get_option('prefix'), get_option('datadir')))


### PR DESCRIPTION
This removes ad-hoc flag passing from backends that are written in C++.