### PR TITLE
Fix the "update" command usage message in pkcon.

### DIFF
--- a/client/pk-console.c
+++ b/client/pk-console.c
@@ -1450,7 +1450,7 @@ pk_console_get_summary (PkConsoleCtx *ctx)
 	if (pk_bitfield_contain (ctx->roles, PK_ROLE_ENUM_REMOVE_PACKAGES))
 		g_string_append_printf (string, "  %s\n", "remove [package]");
 	if (pk_bitfield_contain (ctx->roles, PK_ROLE_ENUM_UPDATE_PACKAGES))
-		g_string_append_printf (string, "  %s\n", "update <package>");
+		g_string_append_printf (string, "  %s\n", "update [package]");
 	if (pk_bitfield_contain (ctx->roles, PK_ROLE_ENUM_REFRESH_CACHE))
 		g_string_append_printf (string, "  %s\n", "refresh [force]");
 	if (pk_bitfield_contain (ctx->roles, PK_ROLE_ENUM_RESOLVE))


### PR DESCRIPTION
It actually accepts zero or more values, just like "install", "remove", etc.