### PR TITLE
Replace www.packagekit.org domain with Freedesktop URL

### DIFF
--- a/PackageKit.doap
+++ b/PackageKit.doap
@@ -22,6 +22,5 @@
 
   <license rdf:resource="http://www.gnu.org/licenses/gpl-2.0.txt" />
   <bug-database rdf:resource="http://bugzilla.freedesktop.org/" />
-  <screenshots rdf:resource="http://www.packagekit.org/pk-screenshots.html#gnome" />
 
 </Project>

--- a/PackageKit.doap
+++ b/PackageKit.doap
@@ -10,7 +10,7 @@
     manage packages in a secure way using a cross-distro, cross-architecture API.
   </description>
 
-  <homepage rdf:resource="http://www.packagekit.org/" />
+  <homepage rdf:resource="https://www.freedesktop.org/software/PackageKit/" />
   <mailing-list rdf:resource="http://lists.freedesktop.org/mailman/listinfo/packagekit/" />
 
   <maintainer>

--- a/client/pkcon.xml
+++ b/client/pkcon.xml
@@ -358,7 +358,7 @@ manpage.1: manpage.xml
     <title>SEE ALSO</title>
     <para>pkmon (1).</para>
     <para>
-      The programs are documented fully on http://www.packagekit.org.
+      The programs are documented fully on https://www.freedesktop.org/software/PackageKit.
     </para>
   </refsect1>
   <refsect1>

--- a/client/pkmon.xml
+++ b/client/pkmon.xml
@@ -90,7 +90,7 @@ manpage.1: manpage.xml
     <title>SEE ALSO</title>
     <para>pkcon (1).</para>
     <para>
-      The programs are documented fully on http://www.packagekit.org.
+      The programs are documented fully on https://www.freedesktop.org/software/PackageKit.
     </para>
   </refsect1>
   <refsect1>

--- a/docs/html/pk-faq.html
+++ b/docs/html/pk-faq.html
@@ -169,9 +169,9 @@ Most user just don't have got the technical understanding to handle this well.</
 PackageKit runs a process <code>packagekitd</code> that is a daemon that runs per-system.
 The daemon lets you schedule transactions using either the raw
 <a href="http://gitweb.freedesktop.org/?p=packagekit.git;a=blob;f=src/org.freedesktop.PackageKit.Transaction.xml">
-DBUS methods</a>, or using <a href="http://www.packagekit.org/gtk-doc/PkClient.html">libpackagekit</a>.
+DBUS methods</a>, or using <a href="https://www.freedesktop.org/software/PackageKit/gtk-doc/PkClient.html">libpackagekit</a>.
 The transactions are very fine grained, so an application would have to manage
-<a href="http://www.packagekit.org/gtk-doc/introduction-ideas-transactions.html">
+<a href="https://www.freedesktop.org/software/PackageKit/gtk-doc/introduction-ideas-transactions.html">
 the transaction process</a> itself.
 This would mean handling the EULA and GPG callbacks in each application. This is less than ideal.
 </p>
@@ -186,10 +186,10 @@ managing callbacks to update custom GUIs.
 <p>
 The session helper is implemented in <code>gpk-update-icon</code> on GNOME,
 and is also availble when <code>apper</code> is installed on KDE.
-If you want full integration using <a href="http://www.packagekit.org/img/gpk-added-deps.png">
-custom dialogs</a> without running the extra session process, then use libpackagekit.
+If you want full integration using custom dialogs without running the extra
+session process, then use libpackagekit.
 If you don't care, and just want things to <i>work</i> then
-<a href="http://www.packagekit.org/pk-faq.html#session-methods">use the session interface</a>.
+<a href="https://www.freedesktop.org/software/PackageKit/pk-faq.html#session-methods">use the session interface</a>.
 If you want a demo, you can download <a href="files/session.c">session.c</a> for a
 session example and <a href="files/system.c">system.c</a> as a system example.
 </p>
@@ -207,7 +207,7 @@ gcc -o system -Wall system.c `pkg-config --cflags --libs packagekit-glib`
 Using the shared session interface you can use the following DBUS methods
 to make PackageKit just do the right thing.
 All the additional
-<a href="http://www.packagekit.org/gtk-doc/introduction-ideas-transactions.html">
+<a href="https://www.freedesktop.org/software/PackageKit/gtk-doc/introduction-ideas-transactions.html">
 confirmation, package downloads, GPG and EULA prompting is done automatically.</a>
 </p>
 <p>

--- a/docs/html/pk-reference.html
+++ b/docs/html/pk-reference.html
@@ -20,7 +20,7 @@
 <h1>Reference Documentation</h1>
 
 <p>
-You need to see the new mini-site <a href="http://www.packagekit.org/gtk-doc/">
+You need to see the new mini-site <a href="https://www.freedesktop.org/software/PackageKit/gtk-doc/">
 here</a>. Please update your links!
 </p>
 

--- a/etc/Vendor.conf
+++ b/etc/Vendor.conf
@@ -11,8 +11,8 @@
 #
 # If the value is set to 'none' then no link is shown.
 #
-# default=http://www.packagekit.org/pk-package-not-found.html
-DefaultUrl=http://www.packagekit.org/pk-package-not-found.html
+# default=https://www.freedesktop.org/software/PackageKit/pk-package-not-found.html
+DefaultUrl=https://www.freedesktop.org/software/PackageKit/pk-package-not-found.html
 
 # The URL which is shown to the user when a codec could not be found.
 # It should explain why certain codecs cannot be used, and perhaps show

--- a/lib/packagekit-glib2/pk-client.c
+++ b/lib/packagekit-glib2/pk-client.c
@@ -26,7 +26,7 @@
  * A GObject to use for accessing PackageKit asynchronously. If you're
  * using #PkClient to install, remove, or update packages, be prepared that
  * the eula, gpg and trusted callbacks need to be rescheduled manually, as in
- * http://www.packagekit.org/gtk-doc/introduction-ideas-transactions.html
+ * https://www.freedesktop.org/software/PackageKit/gtk-doc/introduction-ideas-transactions.html
  */
 
 #include "config.h"

--- a/policy/org.freedesktop.packagekit.policy.in
+++ b/policy/org.freedesktop.packagekit.policy.in
@@ -10,7 +10,7 @@
   -->
 
   <vendor>The PackageKit Project</vendor>
-  <vendor_url>http://www.packagekit.org/</vendor_url>
+  <vendor_url>https://www.freedesktop.org/software/PackageKit/</vendor_url>
   <icon_name>package-x-generic</icon_name>
 
   <action id="org.freedesktop.packagekit.cancel-foreign">


### PR DESCRIPTION
Fixes #618

Split into three commits to make separation of concerns easier.

- metadata: Remove reference to defunct screenshots URL
- metadata: replace defunct www.packagekit.org URL with freedesktop URL
- docs: replace defunct www.packagekit.org URL with freedesktop URL
