### PR TITLE
Add an option to count download size with dependencies

### DIFF
--- a/lib/packagekit-glib2/pk-client.h
+++ b/lib/packagekit-glib2/pk-client.h
@@ -431,6 +431,9 @@ gboolean	 pk_client_get_idle			(PkClient		*client);
 void		 pk_client_set_cache_age		(PkClient		*client,
 							 guint			 cache_age);
 guint		 pk_client_get_cache_age		(PkClient		*client);
+void		 pk_client_set_details_with_deps_size	(PkClient		*client,
+							 gboolean		 details_with_deps_size);
+gboolean	 pk_client_get_details_with_deps_size	(PkClient		*client);
 
 G_END_DECLS
 

--- a/src/pk-backend-job.c
+++ b/src/pk-backend-job.c
@@ -100,6 +100,7 @@ struct PkBackendJobPrivate
 	gboolean		 allow_cancel;
 	gboolean		 background;
 	gboolean		 interactive;
+	gboolean		 details_with_deps_size;
 	gboolean		 locked;
 	GHashTable		*emitted;
 	PkErrorEnum		 last_error_code;
@@ -480,6 +481,20 @@ pk_backend_job_set_interactive (PkBackendJob *job, gboolean interactive)
 {
 	g_return_if_fail (PK_IS_BACKEND_JOB (job));
 	job->priv->interactive = interactive;
+}
+
+gboolean
+pk_backend_job_get_details_with_deps_size (PkBackendJob *job)
+{
+	g_return_val_if_fail (PK_IS_BACKEND_JOB (job), FALSE);
+	return job->priv->details_with_deps_size;
+}
+
+void
+pk_backend_job_set_details_with_deps_size (PkBackendJob *job, gboolean details_with_deps_size)
+{
+	g_return_if_fail (PK_IS_BACKEND_JOB (job));
+	job->priv->details_with_deps_size = details_with_deps_size;
 }
 
 PkRoleEnum

--- a/src/pk-backend-job.h
+++ b/src/pk-backend-job.h
@@ -146,6 +146,11 @@ const gchar	*pk_backend_job_get_pac			(PkBackendJob	*job);
 const gchar	*pk_backend_job_get_locale		(PkBackendJob	*job);
 const gchar	*pk_backend_job_get_frontend_socket	(PkBackendJob	*job);
 guint		 pk_backend_job_get_cache_age		(PkBackendJob	*job);
+gboolean	 pk_backend_job_get_details_with_deps_size
+							(PkBackendJob	*job);
+void		 pk_backend_job_set_details_with_deps_size
+							(PkBackendJob	*job,
+							 gboolean	 details_with_deps_size);
 
 /* transaction vfuncs */
 typedef void	 (*PkBackendJobVFunc)			(PkBackendJob	*job,

--- a/src/pk-transaction.c
+++ b/src/pk-transaction.c
@@ -4878,6 +4878,22 @@ pk_transaction_set_hint (PkTransaction *transaction,
 		return TRUE;
 	}
 
+	/* details-with-deps-size=true */
+	if (g_strcmp0 (key, "details-with-deps-size") == 0) {
+		if (g_strcmp0 (value, "true") == 0) {
+			pk_backend_job_set_details_with_deps_size (priv->job, TRUE);
+		} else if (g_strcmp0 (value, "false") == 0) {
+			pk_backend_job_set_details_with_deps_size (priv->job, FALSE);
+		} else {
+			g_set_error (error,
+				     PK_TRANSACTION_ERROR,
+				     PK_TRANSACTION_ERROR_NOT_SUPPORTED,
+				      "details-with-deps-size hint expects true or false, not %s", value);
+			return FALSE;
+		}
+		return TRUE;
+	}
+
 	/* Is the plural Packages signal supported? The key’s value is ignored,
 	 * as clients will only send it if it’s true. */
 	if (g_strcmp0 (key, "supports-plural-signals") == 0) {


### PR DESCRIPTION
Allow returning package details with download size including the dependencies, which provides more accurate information, especially for packages, which are split to a binary package and to a data package, like the games.
Use this option in the DNF backend.