### PR TITLE
packagekit-glib2: Use the correct enum for DDE

### DIFF
--- a/lib/packagekit-glib2/pk-enum.c
+++ b/lib/packagekit-glib2/pk-enum.c
@@ -263,7 +263,7 @@ static const PkEnumMatch enum_group[] = {
 	{PK_GROUP_ENUM_DESKTOP_GNOME,		"desktop-gnome"},
 	{PK_GROUP_ENUM_DESKTOP_KDE,		"desktop-kde"},
 	{PK_GROUP_ENUM_DESKTOP_XFCE,		"desktop-xfce"},
-	{PK_GROUP_ENUM_DESKTOP_DEEPIN,		"desktop-dde"},
+	{PK_GROUP_ENUM_DESKTOP_DDE,		"desktop-dde"},
 	{PK_GROUP_ENUM_DESKTOP_OTHER,		"desktop-other"},
 	{PK_GROUP_ENUM_PUBLISHING,		"publishing"},
 	{PK_GROUP_ENUM_SERVERS,			"servers"},


### PR DESCRIPTION
Fixes: aa07e0b77bd297cf9fd617ae9b8dd7e0cf218c50 ("Use the term DDE instead of deepin")