### PR TITLE
ci: Update the name of the FreeBSD CI pipeline

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,4 +1,5 @@
 task:
+  name: "build (freebsd)"
   freebsd_instance:
     matrix:
       - image_family: freebsd-13-2-snap


### PR DESCRIPTION
That makes it easier to identify when looking at the pipelines at a glance.