### PR TITLE
Apply i18n for percentage values

### DIFF
--- a/client/pk-offline-update.c
+++ b/client/pk-offline-update.c
@@ -150,15 +150,19 @@ pk_offline_update_progress_cb (PkProgress *progress,
 			return;
 		sd_journal_print (LOG_INFO, "percentage %i%%", percentage);
 
+		g_autofree gchar *tmp_perc = NULL;
+		/* TRANSLATORS: this is a percentage value we use in messages, e.g. "90%" */
+		tmp_perc = g_strdup_printf (_("%i%%"), percentage);
+
 		role = pk_progress_get_role (progress);
 		if (role == PK_ROLE_ENUM_UPGRADE_SYSTEM) {
 			/* TRANSLATORS: this is the message we send plymouth to
 			 * advise of the new percentage completion when installing system upgrades */
-			msg = g_strdup_printf ("%s - %i%%", _("Installing System Upgrade"), percentage);
+			msg = g_strdup_printf ("%s - %s", _("Installing System Upgrade"), tmp_perc);
 		} else {
 			/* TRANSLATORS: this is the message we send plymouth to
 			 * advise of the new percentage completion when installing updates */
-			msg = g_strdup_printf ("%s - %i%%", _("Installing Updates"), percentage);
+			msg = g_strdup_printf ("%s - %s", _("Installing Updates"), tmp_perc);
 		}
 		if (percentage > 10)
 			pk_offline_update_set_plymouth_msg (msg);

--- a/client/pk-offline-update.c
+++ b/client/pk-offline-update.c
@@ -158,11 +158,11 @@ pk_offline_update_progress_cb (PkProgress *progress,
 		if (role == PK_ROLE_ENUM_UPGRADE_SYSTEM) {
 			/* TRANSLATORS: this is the message we send plymouth to
 			 * advise of the new percentage completion when installing system upgrades */
-			msg = g_strdup_printf ("%s - %s", _("Installing System Upgrade"), tmp_perc);
+			msg = g_strdup_printf ("%s – %s", _("Installing System Upgrade"), tmp_perc);
 		} else {
 			/* TRANSLATORS: this is the message we send plymouth to
 			 * advise of the new percentage completion when installing updates */
-			msg = g_strdup_printf ("%s - %s", _("Installing Updates"), tmp_perc);
+			msg = g_strdup_printf ("%s – %s", _("Installing Updates"), tmp_perc);
 		}
 		if (percentage > 10)
 			pk_offline_update_set_plymouth_msg (msg);

--- a/lib/packagekit-glib2/pk-progress-bar.c
+++ b/lib/packagekit-glib2/pk-progress-bar.c
@@ -22,6 +22,8 @@
 #include "config.h"
 
 #include <glib.h>
+#include <glib/gi18n.h>
+#include <locale.h>
 #include <string.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -131,10 +133,13 @@ pk_progress_bar_draw (PkProgressBar *self, gint percentage)
 	for (i = 0; i < self->priv->size - section; i++)
 		g_string_append (str, " ");
 	g_string_append (str, "] ");
-	if (percentage >= 0 && percentage < 100)
-		g_string_append_printf (str, "(%i%%)  ", percentage);
-	else
+	if (percentage >= 0 && percentage < 100) {
+		/* TRANSLATORS: this is a percentage value we use in messages, e.g. "90%. */
+		g_string_append_printf (str, _("(%i%%)"), percentage);
+		g_string_append_printf (str, "  ");
+	} else {
 		g_string_append (str, "        ");
+	}
 	pk_progress_bar_console (self, str->str);
 	g_string_free (str, TRUE);
 	return TRUE;
@@ -172,10 +177,13 @@ pk_progress_bar_pulse_bar (PkProgressBar *self)
 	for (i = 0; i < (gint) (self->priv->size - self->priv->pulse_state.position - 1); i++)
 		g_string_append (str, " ");
 	g_string_append (str, "] ");
-	if (self->priv->percentage >= 0 && self->priv->percentage != PK_PROGRESS_BAR_PERCENTAGE_INVALID)
-		g_string_append_printf (str, "(%i%%)  ", self->priv->percentage);
-	else
+	if (self->priv->percentage >= 0 && self->priv->percentage != PK_PROGRESS_BAR_PERCENTAGE_INVALID) {
+		/* TRANSLATORS: this is a percentage value we use in messages, e.g. "90%. */
+		g_string_append_printf (str, _("(%i%%)"), self->priv->percentage);
+		g_string_append_printf (str, "  ");
+	} else {
 		g_string_append (str, "        ");
+	}
 	pk_progress_bar_console (self, str->str);
 	g_string_free (str, TRUE);
 


### PR DESCRIPTION
Some languages like Turkish and French (and more) uses another percentage format other than 100% (%100 and 100 % respectively). Lack of i18n on UI strings causes an incohesive look, and wrong grammar-wise.

Fixes #633.