### PR TITLE
Add G_PARAM_STATIC_STRINGS to all properties

### DIFF
--- a/lib/packagekit-glib2/pk-category.c
+++ b/lib/packagekit-glib2/pk-category.c
@@ -318,7 +318,7 @@ pk_category_class_init (PkCategoryClass *klass)
 	 */
 	pspec = g_param_spec_string ("parent-id", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_PARENT_ID, pspec);
 
 	/**
@@ -328,7 +328,7 @@ pk_category_class_init (PkCategoryClass *klass)
 	 */
 	pspec = g_param_spec_string ("cat-id", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_CAT_ID, pspec);
 
 	/**
@@ -338,7 +338,7 @@ pk_category_class_init (PkCategoryClass *klass)
 	 */
 	pspec = g_param_spec_string ("name", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_NAME, pspec);
 
 	/**
@@ -348,7 +348,7 @@ pk_category_class_init (PkCategoryClass *klass)
 	 */
 	pspec = g_param_spec_string ("summary", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_SUMMARY, pspec);
 
 	/**
@@ -358,7 +358,7 @@ pk_category_class_init (PkCategoryClass *klass)
 	 */
 	pspec = g_param_spec_string ("icon", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_ICON, pspec);
 
 	g_type_class_add_private (klass, sizeof (PkCategoryPrivate));

--- a/lib/packagekit-glib2/pk-client.c
+++ b/lib/packagekit-glib2/pk-client.c
@@ -4699,7 +4699,7 @@ pk_client_class_init (PkClientClass *klass)
 	 */
 	pspec = g_param_spec_string ("locale", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_LOCALE, pspec);
 
 	/**
@@ -4709,7 +4709,7 @@ pk_client_class_init (PkClientClass *klass)
 	 */
 	pspec = g_param_spec_boolean ("background", NULL, NULL,
 				      FALSE,
-				      G_PARAM_READWRITE);
+				      G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_BACKGROUND, pspec);
 
 	/**
@@ -4719,7 +4719,7 @@ pk_client_class_init (PkClientClass *klass)
 	 */
 	pspec = g_param_spec_boolean ("interactive", NULL, NULL,
 				      TRUE,
-				      G_PARAM_READWRITE);
+				      G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_INTERACTIVE, pspec);
 
 	/**
@@ -4729,7 +4729,7 @@ pk_client_class_init (PkClientClass *klass)
 	 */
 	pspec = g_param_spec_boolean ("idle", NULL, "if there are no transactions in progress on this client",
 				      TRUE,
-				      G_PARAM_READABLE);
+				      G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_IDLE, pspec);
 
 	g_type_class_add_private (klass, sizeof (PkClientPrivate));
@@ -4741,7 +4741,7 @@ pk_client_class_init (PkClientClass *klass)
 	 */
 	pspec = g_param_spec_uint ("cache-age", NULL, NULL,
 				   0, G_MAXUINT, G_MAXUINT,
-				   G_PARAM_READWRITE);
+				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_CACHE_AGE, pspec);
 
 	/**
@@ -4751,7 +4751,7 @@ pk_client_class_init (PkClientClass *klass)
 	 */
 	pspec = g_param_spec_boolean ("details-with-deps-size", NULL, NULL,
 				      FALSE,
-				      G_PARAM_READWRITE);
+				      G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_DETAILS_WITH_DEPS_SIZE, pspec);
 }
 

--- a/lib/packagekit-glib2/pk-control.c
+++ b/lib/packagekit-glib2/pk-control.c
@@ -2140,7 +2140,7 @@ pk_control_class_init (PkControlClass *klass)
 	 */
 	pspec = g_param_spec_uint ("version-major", NULL, NULL,
 				   0, G_MAXUINT, 0,
-				   G_PARAM_READABLE);
+				   G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_VERSION_MAJOR, pspec);
 
 	/**
@@ -2150,7 +2150,7 @@ pk_control_class_init (PkControlClass *klass)
 	 */
 	pspec = g_param_spec_uint ("version-minor", NULL, NULL,
 				   0, G_MAXUINT, 0,
-				   G_PARAM_READABLE);
+				   G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_VERSION_MINOR, pspec);
 
 	/**
@@ -2160,7 +2160,7 @@ pk_control_class_init (PkControlClass *klass)
 	 */
 	pspec = g_param_spec_uint ("version-micro", NULL, NULL,
 				   0, G_MAXUINT, 0,
-				   G_PARAM_READABLE);
+				   G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_VERSION_MICRO, pspec);
 
 	/**
@@ -2170,7 +2170,7 @@ pk_control_class_init (PkControlClass *klass)
 	 */
 	pspec = g_param_spec_string ("backend-name", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_BACKEND_NAME, pspec);
 
 	/**
@@ -2180,7 +2180,7 @@ pk_control_class_init (PkControlClass *klass)
 	 */
 	pspec = g_param_spec_string ("backend-description", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_BACKEND_DESCRIPTION, pspec);
 
 	/**
@@ -2190,7 +2190,7 @@ pk_control_class_init (PkControlClass *klass)
 	 */
 	pspec = g_param_spec_string ("backend-author", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_BACKEND_AUTHOR, pspec);
 
 	/**
@@ -2200,7 +2200,7 @@ pk_control_class_init (PkControlClass *klass)
 	 */
 	pspec = g_param_spec_uint64 ("roles", NULL, NULL,
 				     0, G_MAXUINT64, 0,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_ROLES, pspec);
 
 	/**
@@ -2210,7 +2210,7 @@ pk_control_class_init (PkControlClass *klass)
 	 */
 	pspec = g_param_spec_uint64 ("groups", NULL, NULL,
 				     0, G_MAXUINT64, 0,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_GROUPS, pspec);
 
 	/**
@@ -2220,7 +2220,7 @@ pk_control_class_init (PkControlClass *klass)
 	 */
 	pspec = g_param_spec_uint64 ("filters", NULL, NULL,
 				     0, G_MAXUINT64, 0,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_FILTERS, pspec);
 
 	/**
@@ -2230,7 +2230,7 @@ pk_control_class_init (PkControlClass *klass)
 	 */
 	pspec = g_param_spec_uint64 ("provides", NULL, NULL,
 				     0, G_MAXUINT64, 0,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_PROVIDES, pspec);
 
 	/**
@@ -2240,7 +2240,7 @@ pk_control_class_init (PkControlClass *klass)
 	 */
 	pspec = g_param_spec_boxed ("mime-types", NULL, NULL,
 				    G_TYPE_STRV,
-				    G_PARAM_READWRITE);
+				    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_MIME_TYPES, pspec);
 
 	/**
@@ -2250,7 +2250,7 @@ pk_control_class_init (PkControlClass *klass)
 	 */
 	pspec = g_param_spec_boolean ("locked", NULL, NULL,
 				      FALSE,
-				      G_PARAM_READWRITE);
+				      G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_LOCKED, pspec);
 
 	/**
@@ -2260,7 +2260,7 @@ pk_control_class_init (PkControlClass *klass)
 	 */
 	pspec = g_param_spec_enum ("network-state", NULL, NULL,
 				   PK_TYPE_NETWORK_ENUM, PK_NETWORK_ENUM_LAST,
-				   G_PARAM_READWRITE);
+				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_NETWORK_STATE, pspec);
 
 	/**
@@ -2270,7 +2270,7 @@ pk_control_class_init (PkControlClass *klass)
 	 */
 	pspec = g_param_spec_string ("distro-id", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_DISTRO_ID, pspec);
 
 	/**
@@ -2280,7 +2280,7 @@ pk_control_class_init (PkControlClass *klass)
 	 */
 	pspec = g_param_spec_boolean ("connected", NULL, NULL,
 				      FALSE,
-				      G_PARAM_READWRITE);
+				      G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_CONNECTED, pspec);
 
 	/**

--- a/lib/packagekit-glib2/pk-details.c
+++ b/lib/packagekit-glib2/pk-details.c
@@ -312,7 +312,7 @@ pk_details_class_init (PkDetailsClass *klass)
 	 */
 	pspec = g_param_spec_string ("package-id", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_PACKAGE_ID, pspec);
 
 	/**
@@ -322,7 +322,7 @@ pk_details_class_init (PkDetailsClass *klass)
 	 */
 	pspec = g_param_spec_string ("license", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_LICENSE, pspec);
 
 	/**
@@ -332,7 +332,7 @@ pk_details_class_init (PkDetailsClass *klass)
 	 */
 	pspec = g_param_spec_enum ("group", NULL, NULL,
 				   PK_TYPE_GROUP_ENUM, PK_GROUP_ENUM_UNKNOWN,
-				   G_PARAM_READWRITE);
+				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_GROUP, pspec);
 
 	/**
@@ -342,7 +342,7 @@ pk_details_class_init (PkDetailsClass *klass)
 	 */
 	pspec = g_param_spec_string ("description", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_DESCRIPTION, pspec);
 
 	/**
@@ -352,7 +352,7 @@ pk_details_class_init (PkDetailsClass *klass)
 	 */
 	pspec = g_param_spec_string ("url", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_URL, pspec);
 
 	/**
@@ -362,7 +362,7 @@ pk_details_class_init (PkDetailsClass *klass)
 	 */
 	pspec = g_param_spec_uint64 ("size", NULL, NULL,
 				     0, G_MAXUINT64, 0,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_SIZE, pspec);
 
 	/**
@@ -372,7 +372,7 @@ pk_details_class_init (PkDetailsClass *klass)
 	 */
 	pspec = g_param_spec_string ("summary", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_SUMMARY, pspec);
 
 	/**
@@ -382,7 +382,7 @@ pk_details_class_init (PkDetailsClass *klass)
 	 */
 	pspec = g_param_spec_uint64 ("download-size", NULL, NULL,
 				     0, G_MAXUINT64, G_MAXUINT64,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_DOWNLOAD_SIZE, pspec);
 
 	g_type_class_add_private (klass, sizeof (PkDetailsPrivate));

--- a/lib/packagekit-glib2/pk-distro-upgrade.c
+++ b/lib/packagekit-glib2/pk-distro-upgrade.c
@@ -186,7 +186,7 @@ pk_distro_upgrade_class_init (PkDistroUpgradeClass *klass)
 	 */
 	pspec = g_param_spec_enum ("state", NULL, NULL,
 				   PK_TYPE_DISTRO_UPGRADE_ENUM, PK_DISTRO_UPGRADE_ENUM_UNKNOWN,
-				   G_PARAM_READWRITE);
+				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_STATE, pspec);
 
 	/**
@@ -196,7 +196,7 @@ pk_distro_upgrade_class_init (PkDistroUpgradeClass *klass)
 	 */
 	pspec = g_param_spec_string ("name", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_NAME, pspec);
 
 	/**
@@ -206,7 +206,7 @@ pk_distro_upgrade_class_init (PkDistroUpgradeClass *klass)
 	 */
 	pspec = g_param_spec_string ("summary", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_SUMMARY, pspec);
 
 	g_type_class_add_private (klass, sizeof (PkDistroUpgradePrivate));

--- a/lib/packagekit-glib2/pk-error.c
+++ b/lib/packagekit-glib2/pk-error.c
@@ -158,7 +158,7 @@ pk_error_class_init (PkErrorClass *klass)
 	 */
 	pspec = g_param_spec_enum ("code", NULL, NULL,
 				   PK_TYPE_ERROR_ENUM, PK_ERROR_ENUM_UNKNOWN,
-				   G_PARAM_READWRITE);
+				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_CODE, pspec);
 
 	/**
@@ -168,7 +168,7 @@ pk_error_class_init (PkErrorClass *klass)
 	 */
 	pspec = g_param_spec_string ("details", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_DETAILS, pspec);
 
 	g_type_class_add_private (klass, sizeof (PkErrorPrivate));

--- a/lib/packagekit-glib2/pk-eula-required.c
+++ b/lib/packagekit-glib2/pk-eula-required.c
@@ -211,7 +211,7 @@ pk_eula_required_class_init (PkEulaRequiredClass *klass)
 	 */
 	pspec = g_param_spec_string ("eula-id", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_EULA_ID, pspec);
 
 	/**
@@ -223,7 +223,7 @@ pk_eula_required_class_init (PkEulaRequiredClass *klass)
 	 */
 	pspec = g_param_spec_string ("package-id", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_PACKAGE_ID, pspec);
 
 	/**
@@ -235,7 +235,7 @@ pk_eula_required_class_init (PkEulaRequiredClass *klass)
 	 */
 	pspec = g_param_spec_string ("vendor-name", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_VENDOR_NAME, pspec);
 
 	/**
@@ -247,7 +247,7 @@ pk_eula_required_class_init (PkEulaRequiredClass *klass)
 	 */
 	pspec = g_param_spec_string ("license-agreement", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_LICENSE_AGREEMENT, pspec);
 
 	g_type_class_add_private (klass, sizeof (PkEulaRequiredPrivate));

--- a/lib/packagekit-glib2/pk-files.c
+++ b/lib/packagekit-glib2/pk-files.c
@@ -157,7 +157,7 @@ pk_files_class_init (PkFilesClass *klass)
 	 */
 	pspec = g_param_spec_string ("package-id", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_PACKAGE_ID, pspec);
 
 	/**
@@ -167,7 +167,7 @@ pk_files_class_init (PkFilesClass *klass)
 	 */
 	pspec = g_param_spec_boxed ("files", NULL, NULL,
 				    G_TYPE_STRV,
-				    G_PARAM_READWRITE);
+				    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_FILES, pspec);
 
 	g_type_class_add_private (klass, sizeof (PkFilesPrivate));

--- a/lib/packagekit-glib2/pk-item-progress.c
+++ b/lib/packagekit-glib2/pk-item-progress.c
@@ -173,7 +173,7 @@ pk_item_progress_class_init (PkItemProgressClass *klass)
 	 */
 	pspec = g_param_spec_string ("package-id", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_PACKAGE_ID, pspec);
 
 	/**
@@ -183,7 +183,7 @@ pk_item_progress_class_init (PkItemProgressClass *klass)
 	 */
 	pspec = g_param_spec_uint ("status", NULL, NULL,
 				   0, G_MAXUINT, 0,
-				   G_PARAM_READWRITE);
+				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_STATUS, pspec);
 
 	/**
@@ -193,7 +193,7 @@ pk_item_progress_class_init (PkItemProgressClass *klass)
 	 */
 	pspec = g_param_spec_uint ("percentage", NULL, NULL,
 				   0, G_MAXUINT, 0,
-				   G_PARAM_READWRITE);
+				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_PERCENTAGE, pspec);
 
 	g_type_class_add_private (klass, sizeof (PkItemProgressPrivate));

--- a/lib/packagekit-glib2/pk-media-change-required.c
+++ b/lib/packagekit-glib2/pk-media-change-required.c
@@ -133,7 +133,7 @@ pk_media_change_required_class_init (PkMediaChangeRequiredClass *klass)
 	 */
 	pspec = g_param_spec_enum ("media-type", NULL, NULL,
 				   PK_TYPE_MEDIA_TYPE_ENUM, PK_MEDIA_TYPE_ENUM_UNKNOWN,
-				   G_PARAM_READWRITE);
+				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_MEDIA_TYPE, pspec);
 
 	/**
@@ -143,7 +143,7 @@ pk_media_change_required_class_init (PkMediaChangeRequiredClass *klass)
 	 */
 	pspec = g_param_spec_string ("media-id", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_MEDIA_ID, pspec);
 
 	/**
@@ -153,7 +153,7 @@ pk_media_change_required_class_init (PkMediaChangeRequiredClass *klass)
 	 */
 	pspec = g_param_spec_string ("media-text", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_MEDIA_TEXT, pspec);
 
 	g_type_class_add_private (klass, sizeof (PkMediaChangeRequiredPrivate));

--- a/lib/packagekit-glib2/pk-package.c
+++ b/lib/packagekit-glib2/pk-package.c
@@ -595,7 +595,7 @@ pk_package_class_init (PkPackageClass *klass)
 	pspec = g_param_spec_enum ("info", NULL,
 				   "The PkInfoEnum package type, e.g. PK_INFO_ENUM_NORMAL",
 				   PK_TYPE_INFO_ENUM, PK_INFO_ENUM_UNKNOWN,
-				   G_PARAM_READWRITE);
+				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_INFO, pspec);
 
 	/**
@@ -606,7 +606,7 @@ pk_package_class_init (PkPackageClass *klass)
 	pspec = g_param_spec_string ("package-id", NULL,
 				     "The full package_id, e.g. 'gnome-power-manager;0.1.2;i386;fedora'",
 				     NULL,
-				     G_PARAM_READABLE);
+				     G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_PACKAGE_ID, pspec);
 
 	/**
@@ -617,7 +617,7 @@ pk_package_class_init (PkPackageClass *klass)
 	pspec = g_param_spec_string ("summary", NULL,
 				     "The package summary",
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_SUMMARY, pspec);
 
 	/**
@@ -628,7 +628,7 @@ pk_package_class_init (PkPackageClass *klass)
 	pspec = g_param_spec_string ("license", NULL,
 				     "The package license",
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_LICENSE, pspec);
 
 	/**
@@ -639,7 +639,7 @@ pk_package_class_init (PkPackageClass *klass)
 	pspec = g_param_spec_enum ("group", NULL,
 				   "The package group",
 				   PK_TYPE_GROUP_ENUM, PK_GROUP_ENUM_UNKNOWN,
-				   G_PARAM_READWRITE);
+				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_GROUP, pspec);
 
 	/**
@@ -650,7 +650,7 @@ pk_package_class_init (PkPackageClass *klass)
 	pspec = g_param_spec_string ("description", NULL,
 				     "The package description",
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_DESCRIPTION, pspec);
 
 	/**
@@ -661,7 +661,7 @@ pk_package_class_init (PkPackageClass *klass)
 	pspec = g_param_spec_string ("url", NULL,
 				     "The package homepage URL",
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_URL, pspec);
 
 	/**
@@ -672,7 +672,7 @@ pk_package_class_init (PkPackageClass *klass)
 	pspec = g_param_spec_uint64 ("size", NULL,
 				     "The package size",
 				     0, G_MAXUINT64, 0,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_SIZE, pspec);
 
 	/**
@@ -683,7 +683,7 @@ pk_package_class_init (PkPackageClass *klass)
 	pspec = g_param_spec_string ("update-updates", NULL,
 				     "The update packages",
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_UPDATE_UPDATES, pspec);
 
 	/**
@@ -694,7 +694,7 @@ pk_package_class_init (PkPackageClass *klass)
 	pspec = g_param_spec_string ("update-obsoletes", NULL,
 				     "The update packages that are obsoleted",
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_UPDATE_OBSOLETES, pspec);
 
 	/**
@@ -705,7 +705,7 @@ pk_package_class_init (PkPackageClass *klass)
 	pspec = g_param_spec_boxed ("update-vendor-urls", NULL,
 				    "The update vendor URLs",
 				    G_TYPE_STRV,
-				    G_PARAM_READWRITE);
+				    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_UPDATE_VENDOR_URLS, pspec);
 
 	/**
@@ -716,7 +716,7 @@ pk_package_class_init (PkPackageClass *klass)
 	pspec = g_param_spec_boxed ("update-bugzilla-urls", NULL,
 				    "The update bugzilla URLs",
 				    G_TYPE_STRV,
-				    G_PARAM_READWRITE);
+				    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_UPDATE_BUGZILLA_URLS, pspec);
 
 	/**
@@ -727,7 +727,7 @@ pk_package_class_init (PkPackageClass *klass)
 	pspec = g_param_spec_boxed ("update-cve-urls", NULL,
 				    "The update CVE URLs",
 				    G_TYPE_STRV,
-				    G_PARAM_READWRITE);
+				    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_UPDATE_CVE_URLS, pspec);
 
 	/**
@@ -738,7 +738,7 @@ pk_package_class_init (PkPackageClass *klass)
 	pspec = g_param_spec_enum ("update-restart", NULL,
 				   "The update restart type",
 				   PK_TYPE_RESTART_ENUM, PK_RESTART_ENUM_UNKNOWN,
-				   G_PARAM_READWRITE);
+				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_UPDATE_RESTART, pspec);
 
 	/**
@@ -749,7 +749,7 @@ pk_package_class_init (PkPackageClass *klass)
 	pspec = g_param_spec_string ("update-text", NULL,
 				     "The update description",
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_UPDATE_UPDATE_TEXT, pspec);
 
 	/**
@@ -760,7 +760,7 @@ pk_package_class_init (PkPackageClass *klass)
 	pspec = g_param_spec_string ("update-changelog", NULL,
 				     "The update ChangeLog",
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_UPDATE_CHANGELOG, pspec);
 
 	/**
@@ -771,7 +771,7 @@ pk_package_class_init (PkPackageClass *klass)
 	pspec = g_param_spec_enum ("update-state", NULL,
 				   "The update state",
 				   PK_TYPE_UPDATE_STATE_ENUM, PK_UPDATE_STATE_ENUM_UNKNOWN,
-				   G_PARAM_READWRITE);
+				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_UPDATE_STATE, pspec);
 
 	/**
@@ -782,7 +782,7 @@ pk_package_class_init (PkPackageClass *klass)
 	pspec = g_param_spec_string ("update-issued", NULL,
 				     "When the update was issued",
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_UPDATE_ISSUED, pspec);
 
 	/**
@@ -793,7 +793,7 @@ pk_package_class_init (PkPackageClass *klass)
 	pspec = g_param_spec_string ("update-updated", NULL,
 				     "When the update was last updated",
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_UPDATE_UPDATED, pspec);
 
 	/**
@@ -807,7 +807,7 @@ pk_package_class_init (PkPackageClass *klass)
 	pspec = g_param_spec_enum ("update-severity", NULL,
 				   "Package update severity",
 				    PK_TYPE_INFO_ENUM, PK_INFO_ENUM_UNKNOWN,
-				    G_PARAM_READWRITE);
+				    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_UPDATE_SEVERITY, pspec);
 
 	/**

--- a/lib/packagekit-glib2/pk-progress.c
+++ b/lib/packagekit-glib2/pk-progress.c
@@ -946,7 +946,7 @@ pk_progress_class_init (PkProgressClass *klass)
 	pspec = g_param_spec_string ("package-id", NULL,
 				     "The full package_id, e.g. 'gnome-power-manager;0.1.2;i386;fedora'",
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_PACKAGE_ID, pspec);
 
 	/**
@@ -959,7 +959,7 @@ pk_progress_class_init (PkProgressClass *klass)
 	pspec = g_param_spec_string ("transaction-id", NULL,
 				     "The transaction_id, e.g. '/892_deabbbdb_data'",
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_TRANSACTION_ID, pspec);
 
 	/**
@@ -971,7 +971,7 @@ pk_progress_class_init (PkProgressClass *klass)
 	 */
 	pspec = g_param_spec_int ("percentage", NULL, NULL,
 				  -1, G_MAXINT, -1,
-				  G_PARAM_READWRITE);
+				  G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_PERCENTAGE, pspec);
 
 	/**
@@ -983,7 +983,7 @@ pk_progress_class_init (PkProgressClass *klass)
 	 */
 	pspec = g_param_spec_boolean ("allow-cancel", NULL, NULL,
 				      FALSE,
-				      G_PARAM_READWRITE);
+				      G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_ALLOW_CANCEL, pspec);
 
 	/**
@@ -995,7 +995,7 @@ pk_progress_class_init (PkProgressClass *klass)
 	 */
 	pspec = g_param_spec_uint ("status", NULL, NULL,
 				   0, PK_STATUS_ENUM_LAST, PK_STATUS_ENUM_UNKNOWN,
-				   G_PARAM_READWRITE);
+				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_STATUS, pspec);
 
 	/**
@@ -1007,7 +1007,7 @@ pk_progress_class_init (PkProgressClass *klass)
 	 */
 	pspec = g_param_spec_uint ("role", NULL, NULL,
 				   0, PK_ROLE_ENUM_LAST, PK_ROLE_ENUM_UNKNOWN,
-				   G_PARAM_READWRITE);
+				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_ROLE, pspec);
 
 	/**
@@ -1019,7 +1019,7 @@ pk_progress_class_init (PkProgressClass *klass)
 	 */
 	pspec = g_param_spec_boolean ("caller-active", NULL, NULL,
 				      FALSE,
-				      G_PARAM_READWRITE);
+				      G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_CALLER_ACTIVE, pspec);
 
 	/**
@@ -1031,7 +1031,7 @@ pk_progress_class_init (PkProgressClass *klass)
 	 */
 	pspec = g_param_spec_uint ("elapsed-time", NULL, NULL,
 				   0, G_MAXUINT, 0,
-				   G_PARAM_READWRITE);
+				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_ELAPSED_TIME, pspec);
 
 	/**
@@ -1043,7 +1043,7 @@ pk_progress_class_init (PkProgressClass *klass)
 	 */
 	pspec = g_param_spec_uint ("remaining-time", NULL, NULL,
 				   0, G_MAXUINT, 0,
-				   G_PARAM_READWRITE);
+				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_REMAINING_TIME, pspec);
 
 	/**
@@ -1055,7 +1055,7 @@ pk_progress_class_init (PkProgressClass *klass)
 	 */
 	pspec = g_param_spec_uint ("speed", NULL, NULL,
 				   0, G_MAXUINT, 0,
-				   G_PARAM_READWRITE);
+				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_SPEED, pspec);
 
 	/**
@@ -1067,7 +1067,7 @@ pk_progress_class_init (PkProgressClass *klass)
 	 */
 	pspec = g_param_spec_uint64 ("download-size-remaining", NULL, NULL,
 				     0, G_MAXUINT64, 0,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_DOWNLOAD_SIZE_REMAINING, pspec);
 
 	/**
@@ -1079,7 +1079,7 @@ pk_progress_class_init (PkProgressClass *klass)
 	 */
 	pspec = g_param_spec_uint64 ("transaction-flags", NULL, NULL,
 				     0, G_MAXUINT64, 0,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_TRANSACTION_FLAGS, pspec);
 
 	/**
@@ -1091,7 +1091,7 @@ pk_progress_class_init (PkProgressClass *klass)
 	 */
 	pspec = g_param_spec_uint ("uid", NULL, NULL,
 				   0, G_MAXUINT, 0,
-				   G_PARAM_READWRITE);
+				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_UID, pspec);
 
 	/**
@@ -1103,7 +1103,7 @@ pk_progress_class_init (PkProgressClass *klass)
 	 */
 	pspec = g_param_spec_string ("sender", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_SENDER, pspec);
 
 	/**
@@ -1115,7 +1115,7 @@ pk_progress_class_init (PkProgressClass *klass)
 	 */
 	pspec = g_param_spec_object ("package", NULL, NULL,
 				     PK_TYPE_PACKAGE,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_PACKAGE, pspec);
 
 	/**
@@ -1127,7 +1127,7 @@ pk_progress_class_init (PkProgressClass *klass)
 	 */
 	pspec = g_param_spec_object ("item-progress", NULL, NULL,
 				     PK_TYPE_ITEM_PROGRESS,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_ITEM_PROGRESS, pspec);
 
 	g_type_class_add_private (klass, sizeof (PkProgressPrivate));

--- a/lib/packagekit-glib2/pk-repo-detail.c
+++ b/lib/packagekit-glib2/pk-repo-detail.c
@@ -182,7 +182,7 @@ pk_repo_detail_class_init (PkRepoDetailClass *klass)
 	 */
 	pspec = g_param_spec_string ("repo-id", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_REPO_ID, pspec);
 
 	/**
@@ -192,7 +192,7 @@ pk_repo_detail_class_init (PkRepoDetailClass *klass)
 	 */
 	pspec = g_param_spec_string ("description", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_DESCRIPTION, pspec);
 
 	/**
@@ -202,7 +202,7 @@ pk_repo_detail_class_init (PkRepoDetailClass *klass)
 	 */
 	pspec = g_param_spec_boolean ("enabled", NULL, NULL,
 				      FALSE,
-				      G_PARAM_READWRITE);
+				      G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_ENABLED, pspec);
 
 	g_type_class_add_private (klass, sizeof (PkRepoDetailPrivate));

--- a/lib/packagekit-glib2/pk-repo-signature-required.c
+++ b/lib/packagekit-glib2/pk-repo-signature-required.c
@@ -178,7 +178,7 @@ pk_repo_signature_required_class_init (PkRepoSignatureRequiredClass *klass)
 	 */
 	pspec = g_param_spec_string ("package-id", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_PACKAGE_ID, pspec);
 
 	/**
@@ -188,7 +188,7 @@ pk_repo_signature_required_class_init (PkRepoSignatureRequiredClass *klass)
 	 */
 	pspec = g_param_spec_string ("repository-name", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_REPOSITORY_NAME, pspec);
 
 	/**
@@ -198,7 +198,7 @@ pk_repo_signature_required_class_init (PkRepoSignatureRequiredClass *klass)
 	 */
 	pspec = g_param_spec_string ("key-url", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_KEY_URL, pspec);
 
 	/**
@@ -208,7 +208,7 @@ pk_repo_signature_required_class_init (PkRepoSignatureRequiredClass *klass)
 	 */
 	pspec = g_param_spec_string ("key-userid", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_KEY_USERID, pspec);
 
 	/**
@@ -218,7 +218,7 @@ pk_repo_signature_required_class_init (PkRepoSignatureRequiredClass *klass)
 	 */
 	pspec = g_param_spec_string ("key-id", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_KEY_ID, pspec);
 
 	/**
@@ -228,7 +228,7 @@ pk_repo_signature_required_class_init (PkRepoSignatureRequiredClass *klass)
 	 */
 	pspec = g_param_spec_string ("key-fingerprint", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_KEY_FINGERPRINT, pspec);
 
 	/**
@@ -238,7 +238,7 @@ pk_repo_signature_required_class_init (PkRepoSignatureRequiredClass *klass)
 	 */
 	pspec = g_param_spec_string ("key-timestamp", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_KEY_TIMESTAMP, pspec);
 
 	/**
@@ -248,7 +248,7 @@ pk_repo_signature_required_class_init (PkRepoSignatureRequiredClass *klass)
 	 */
 	pspec = g_param_spec_enum ("type", NULL, NULL,
 				   PK_TYPE_SIG_TYPE_ENUM, PK_SIGTYPE_ENUM_UNKNOWN,
-				   G_PARAM_READWRITE);
+				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_TYPE, pspec);
 
 	g_type_class_add_private (klass, sizeof (PkRepoSignatureRequiredPrivate));

--- a/lib/packagekit-glib2/pk-require-restart.c
+++ b/lib/packagekit-glib2/pk-require-restart.c
@@ -124,7 +124,7 @@ pk_require_restart_class_init (PkRequireRestartClass *klass)
 	 */
 	pspec = g_param_spec_enum ("restart", NULL, NULL,
 				   PK_TYPE_RESTART_ENUM, PK_RESTART_ENUM_UNKNOWN,
-				   G_PARAM_READWRITE);
+				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_RESTART, pspec);
 
 	/**
@@ -134,7 +134,7 @@ pk_require_restart_class_init (PkRequireRestartClass *klass)
 	 */
 	pspec = g_param_spec_string ("package-id", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_PACKAGE_ID, pspec);
 
 	g_type_class_add_private (klass, sizeof (PkRequireRestartPrivate));

--- a/lib/packagekit-glib2/pk-results.c
+++ b/lib/packagekit-glib2/pk-results.c
@@ -846,7 +846,7 @@ pk_results_class_init (PkResultsClass *klass)
 	 */
 	pspec = g_param_spec_enum ("role", NULL, NULL,
 				   PK_TYPE_ROLE_ENUM, PK_ROLE_ENUM_UNKNOWN,
-				   G_PARAM_READWRITE);
+				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_ROLE, pspec);
 
 	/**
@@ -858,7 +858,7 @@ pk_results_class_init (PkResultsClass *klass)
 	 */
 	pspec = g_param_spec_uint64 ("transaction-flags", NULL, NULL,
 				     0, G_MAXUINT64, 0,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_TRANSACTION_FLAGS, pspec);
 
 	/**
@@ -868,7 +868,7 @@ pk_results_class_init (PkResultsClass *klass)
 	 */
 	pspec = g_param_spec_uint ("inputs", NULL, NULL,
 				   0, G_MAXUINT, 0,
-				   G_PARAM_READWRITE);
+				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_INPUTS, pspec);
 
 	g_type_class_add_private (klass, sizeof (PkResultsPrivate));
@@ -881,7 +881,7 @@ pk_results_class_init (PkResultsClass *klass)
 	pspec = g_param_spec_object ("progress", NULL,
 				     "The progress instance",
 				     PK_TYPE_PROGRESS,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_PROGRESS, pspec);
 }
 

--- a/lib/packagekit-glib2/pk-source.c
+++ b/lib/packagekit-glib2/pk-source.c
@@ -123,7 +123,7 @@ pk_source_class_init (PkSourceClass *klass)
 	 */
 	pspec = g_param_spec_enum ("role", NULL, NULL,
 				   PK_TYPE_ROLE_ENUM, PK_ROLE_ENUM_UNKNOWN,
-				   G_PARAM_READWRITE);
+				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_ROLE, pspec);
 
 	/**
@@ -133,7 +133,7 @@ pk_source_class_init (PkSourceClass *klass)
 	 */
 	pspec = g_param_spec_string ("transaction-id", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_TRANSACTION_ID, pspec);
 
 	g_type_class_add_private (klass, sizeof (PkSourcePrivate));

--- a/lib/packagekit-glib2/pk-task.c
+++ b/lib/packagekit-glib2/pk-task.c
@@ -2581,7 +2581,7 @@ pk_task_class_init (PkTaskClass *klass)
 	 */
 	pspec = g_param_spec_boolean ("simulate", NULL, NULL,
 				      TRUE,
-				      G_PARAM_READWRITE);
+				      G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_SIMULATE, pspec);
 
 	/**
@@ -2593,7 +2593,7 @@ pk_task_class_init (PkTaskClass *klass)
 	 */
 	pspec = g_param_spec_boolean ("only-download", NULL, NULL,
 				      FALSE,
-				      G_PARAM_READWRITE);
+				      G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_ONLY_PREPARE, pspec);
 
 	/**
@@ -2605,7 +2605,7 @@ pk_task_class_init (PkTaskClass *klass)
 	 */
 	pspec = g_param_spec_boolean ("only-trusted", NULL, NULL,
 				      TRUE,
-				      G_PARAM_READWRITE);
+				      G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_ONLY_TRUSTED, pspec);
 
 	/**
@@ -2617,7 +2617,7 @@ pk_task_class_init (PkTaskClass *klass)
 	 */
 	pspec = g_param_spec_boolean ("allow-reinstall", NULL, NULL,
 				      FALSE,
-				      G_PARAM_READWRITE);
+				      G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_ALLOW_REINSTALL, pspec);
 
 	/**
@@ -2629,7 +2629,7 @@ pk_task_class_init (PkTaskClass *klass)
 	 */
 	pspec = g_param_spec_boolean ("allow-downgrade", NULL, NULL,
 				      FALSE,
-				      G_PARAM_READWRITE);
+				      G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_ALLOW_DOWNGRADE, pspec);
 
 	g_type_class_add_private (klass, sizeof (PkTaskPrivate));

--- a/lib/packagekit-glib2/pk-transaction-past.c
+++ b/lib/packagekit-glib2/pk-transaction-past.c
@@ -357,7 +357,7 @@ pk_transaction_past_class_init (PkTransactionPastClass *klass)
 	 */
 	pspec = g_param_spec_string ("tid", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_TID, pspec);
 
 	/**
@@ -367,7 +367,7 @@ pk_transaction_past_class_init (PkTransactionPastClass *klass)
 	 */
 	pspec = g_param_spec_string ("timespec", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_TIMESPEC, pspec);
 
 	/**
@@ -377,7 +377,7 @@ pk_transaction_past_class_init (PkTransactionPastClass *klass)
 	 */
 	pspec = g_param_spec_boolean ("succeeded", NULL, NULL,
 				      FALSE,
-				      G_PARAM_READWRITE);
+				      G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_SUCCEEDED, pspec);
 
 	/**
@@ -387,7 +387,7 @@ pk_transaction_past_class_init (PkTransactionPastClass *klass)
 	 */
 	pspec = g_param_spec_enum ("role", NULL, NULL,
 				   PK_TYPE_ROLE_ENUM, PK_ROLE_ENUM_UNKNOWN,
-				   G_PARAM_READWRITE);
+				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_ROLE, pspec);
 
 	/**
@@ -397,7 +397,7 @@ pk_transaction_past_class_init (PkTransactionPastClass *klass)
 	 */
 	pspec = g_param_spec_uint ("duration", NULL, NULL,
 				   0, G_MAXUINT, 0,
-				   G_PARAM_READWRITE);
+				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_DURATION, pspec);
 
 	/**
@@ -407,7 +407,7 @@ pk_transaction_past_class_init (PkTransactionPastClass *klass)
 	 */
 	pspec = g_param_spec_string ("data", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_DATA, pspec);
 
 	/**
@@ -417,7 +417,7 @@ pk_transaction_past_class_init (PkTransactionPastClass *klass)
 	 */
 	pspec = g_param_spec_uint ("uid", NULL, NULL,
 				   0, G_MAXUINT, G_MAXUINT,
-				   G_PARAM_READWRITE);
+				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_UID, pspec);
 
 	/**
@@ -427,7 +427,7 @@ pk_transaction_past_class_init (PkTransactionPastClass *klass)
 	 */
 	pspec = g_param_spec_string ("cmdline", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_CMDLINE, pspec);
 
 	g_type_class_add_private (klass, sizeof (PkTransactionPastPrivate));

--- a/lib/packagekit-glib2/pk-update-detail.c
+++ b/lib/packagekit-glib2/pk-update-detail.c
@@ -415,7 +415,7 @@ pk_update_detail_class_init (PkUpdateDetailClass *klass)
 	 */
 	pspec = g_param_spec_string ("package-id", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_PACKAGE_ID, pspec);
 
 	/**
@@ -425,7 +425,7 @@ pk_update_detail_class_init (PkUpdateDetailClass *klass)
 	 */
 	pspec = g_param_spec_boxed ("updates", NULL, NULL,
 				    G_TYPE_STRV,
-				    G_PARAM_READWRITE);
+				    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_UPDATES, pspec);
 
 	/**
@@ -435,7 +435,7 @@ pk_update_detail_class_init (PkUpdateDetailClass *klass)
 	 */
 	pspec = g_param_spec_boxed ("obsoletes", NULL, NULL,
 				    G_TYPE_STRV,
-				    G_PARAM_READWRITE);
+				    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_OBSOLETES, pspec);
 
 	/**
@@ -445,7 +445,7 @@ pk_update_detail_class_init (PkUpdateDetailClass *klass)
 	 */
 	pspec = g_param_spec_boxed ("vendor-urls", NULL, NULL,
 				    G_TYPE_STRV,
-				    G_PARAM_READWRITE);
+				    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_VENDOR_URLS, pspec);
 
 	/**
@@ -455,7 +455,7 @@ pk_update_detail_class_init (PkUpdateDetailClass *klass)
 	 */
 	pspec = g_param_spec_boxed ("bugzilla-urls", NULL, NULL,
 				    G_TYPE_STRV,
-				    G_PARAM_READWRITE);
+				    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_BUGZILLA_URLS, pspec);
 
 	/**
@@ -465,7 +465,7 @@ pk_update_detail_class_init (PkUpdateDetailClass *klass)
 	 */
 	pspec = g_param_spec_boxed ("cve-urls", NULL, NULL,
 				    G_TYPE_STRV,
-				    G_PARAM_READWRITE);
+				    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_CVE_URLS, pspec);
 
 	/**
@@ -475,7 +475,7 @@ pk_update_detail_class_init (PkUpdateDetailClass *klass)
 	 */
 	pspec = g_param_spec_enum ("restart", NULL, NULL,
 				   PK_TYPE_RESTART_ENUM, PK_RESTART_ENUM_UNKNOWN,
-				   G_PARAM_READWRITE);
+				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_RESTART, pspec);
 
 	/**
@@ -485,7 +485,7 @@ pk_update_detail_class_init (PkUpdateDetailClass *klass)
 	 */
 	pspec = g_param_spec_string ("update-text", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_UPDATE_TEXT, pspec);
 
 	/**
@@ -495,7 +495,7 @@ pk_update_detail_class_init (PkUpdateDetailClass *klass)
 	 */
 	pspec = g_param_spec_string ("changelog", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_CHANGELOG, pspec);
 
 	/**
@@ -505,7 +505,7 @@ pk_update_detail_class_init (PkUpdateDetailClass *klass)
 	 */
 	pspec = g_param_spec_enum ("state", NULL, NULL,
 				   PK_TYPE_UPDATE_STATE_ENUM, PK_UPDATE_STATE_ENUM_UNKNOWN,
-				   G_PARAM_READWRITE);
+				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_STATE, pspec);
 
 	/**
@@ -515,7 +515,7 @@ pk_update_detail_class_init (PkUpdateDetailClass *klass)
 	 */
 	pspec = g_param_spec_string ("issued", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_ISSUED, pspec);
 
 	/**
@@ -525,7 +525,7 @@ pk_update_detail_class_init (PkUpdateDetailClass *klass)
 	 */
 	pspec = g_param_spec_string ("updated", NULL, NULL,
 				     NULL,
-				     G_PARAM_READWRITE);
+				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_UPDATED, pspec);
 
 	g_type_class_add_private (klass, sizeof (PkUpdateDetailPrivate));

--- a/src/pk-spawn.c
+++ b/src/pk-spawn.c
@@ -690,7 +690,7 @@ pk_spawn_class_init (PkSpawnClass *klass)
 	 */
 	pspec = g_param_spec_boolean ("background", NULL, NULL,
 				      FALSE,
-				      G_PARAM_READWRITE);
+				      G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_BACKGROUND, pspec);
 
 	/**
@@ -701,7 +701,7 @@ pk_spawn_class_init (PkSpawnClass *klass)
 	 */
 	pspec = g_param_spec_boolean ("allow-sigkill", NULL, NULL,
 				      FALSE,
-				      G_PARAM_READWRITE);
+				      G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_ALLOW_SIGKILL, pspec);
 
 	signals [SIGNAL_EXIT] =


### PR DESCRIPTION
We are never doing dynamic construction of name, nickname or blurb. The GObject manual claims that it allows internal performance improvements.