### PR TITLE
Revert "Enable testing on FreeBSD CI"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 task:
-  name: "build and test (freebsd)"
+  name: "build (freebsd)"
   freebsd_instance:
     matrix:
       - image_family: freebsd-13-2-snap
@@ -7,14 +7,9 @@ task:
     - env ASSUME_ALWAYS_YES=yes pkg update -f
     - env ASSUME_ALWAYS_YES=yes pkg install -y docbook-xsl vala libxslt fontconfig polkit consolekit2
         desktop-file-utils gettext meson ninja python3 glib gtk3 pkgconf sqlite3 gobject-introspection
-        dbus
   build_script:
-    - meson --auto-features=enabled -Db_colorout=never --buildtype debug -Dlocal_checkout=true -Dlocalstatedir=/var
+    - meson --auto-features=enabled -Db_colorout=never --buildtype debug --strip -Dlocalstatedir=/var
         -Dsystemd=false -Doffline_update=false  -Dbash_completion=false -Dbash_command_not_found=false
         -Dgstreamer_plugin=false _build
     - cd _build
     - ninja -v all
-  test_script:
-    - cd _build
-    - service dbus onestart
-    - ninja test


### PR DESCRIPTION
The tests are currently failing and there's been no progress yet on a fix. Drop testing on this for now while we wait for this to be resolved.

This reverts commit 45dc514fb5fb4e5b4118334a710d6e23cea8af07.

cc: @arrowd 