### PR TITLE
packagekitd: Use export_dynamic explicitly

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -76,6 +76,7 @@ packagekitd_exec = executable(
   ],
   install: true,
   install_dir: get_option('libexecdir'),
+  export_dynamic: true,
   c_args: [
     '-DPK_BUILD_DAEMON=1',
     '-DG_LOG_DOMAIN="PackageKit"',


### PR DESCRIPTION
We used to get that implicitly through GModule .pc file defining -Wl,--export-dynamic so that modules could reference symbols in the main executable.

With newer GLib including glib@11bdd6fc the gmodule .pc file will no longer define this compiler flag in a way that works for us, resulting in errors like:
packagekitd[2394]: Failed to load the backend: opening module zypp failed : /usr/lib64/packagekit-backend/libpk_backend_zypp.so: undefined symbol: pk_backend_job_require_restart
