### PR TITLE
data/meson.build: Install dbus policy in /usr/share, not /etc

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -9,7 +9,7 @@ dbus_config_data.set('libexecdir', join_paths(get_option('prefix'), get_option('
 
 dbus_sys_dir = get_option('dbus_sys')
 if dbus_sys_dir == ''
-  dbus_sys_dir = join_paths(get_option('sysconfdir'), 'dbus-1', 'system.d')
+  dbus_sys_dir = join_paths(get_option('datadir'), 'dbus-1', 'system.d')
 endif
 
 configure_file(


### PR DESCRIPTION
From https://bugs.debian.org/1006631:

> dbus supports policy files in both `/usr/share/dbus-1/system.d` and
> `/etc/dbus-1/systemd`. [The] recently released dbus 1.14.0, officially
> deprecates installing packages' default policies into `/etc/dbus-1/systemd`,
> instead reserving it for the sysadmin. This is the same idea as the
> difference between `/usr/lib/udev/rules.d` and `/etc/udev/rules.d`.