### PR TITLE
apt: Fix 'search-file' regexp as per BRE pattern (which is the default)

### DIFF
--- a/backends/apt/apt-job.cpp
+++ b/backends/apt/apt-job.cpp
@@ -1278,7 +1278,7 @@ PkgList AptJob::searchPackageFiles(gchar **values)
         }
 
         if (!search.empty()) {
-            search.append("|");
+            search.append("\\|");
         }
 
         if (value[0] == '/') {


### PR DESCRIPTION
We should either set the `'REG_EXTENDED'` flag (Extended Regular Expressions) to `regcomp()` and use the `"|"` regex pattern, or use the `"\\|"` regex pattern, as per the BRE (Basic Regular Expressions), which is the default when 'REG_EXTENDED' flag is not set.

From `'man grep'`:

Basic vs Extended Regular Expressions:

In basic regular expressions the meta‐characters ?, +, {, |, (, and ) lose their special meaning; instead use the backslashed versions \?, \+, \{, \|, \(, and \).