### PR TITLE
Use portable shebang in shell scripts.

### DIFF
--- a/backends/test/helpers/search-name.sh
+++ b/backends/test/helpers/search-name.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2007 Richard Hughes <richard@hughsie.com>
 #

--- a/tests/data/pk-spawn-test.sh
+++ b/tests/data/pk-spawn-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2007 Richard Hughes <richard@hughsie.com>
 # Licensed under the GNU General Public License Version 2
 # This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
This unbreaks most of tests on FreeBSD.

Unfortunately, one test is plagued by the same problem as described in https://github.com/ximion/appstream/pull/520 so I didn't enable testing yet.