### PR TITLE
transaction: We only need to emit finished when we were committed

### DIFF
--- a/src/pk-transaction.c
+++ b/src/pk-transaction.c
@@ -5526,6 +5526,7 @@ pk_transaction_dispose (GObject *object)
 	if (transaction->priv->registration_id > 0) {
 		/* We should have emitted ::Finished if the object was ever registered and committed */
 		if (transaction->priv->state != PK_TRANSACTION_STATE_UNKNOWN &&
+		    transaction->priv->state != PK_TRANSACTION_STATE_ERROR &&
 		    transaction->priv->state != PK_TRANSACTION_STATE_NEW)
 			g_assert (transaction->priv->emitted_finished);
 


### PR DESCRIPTION
Follow up to commit 96a05994d.

Resolves: #656

### Steps to reproduce:

```
$ /usr/bin/pkcon -p get-details /etc/passwd
Transaction:	Getting details
Status: 	Waiting in queue
The daemon crashed mid-transaction!
```

```
Sep 25 20:20:19 linux packagekitd[425371]: PackageKit:ERROR:../src/pk-transaction.c:5530:pk_transaction_dispose: assertion failed: (transaction->priv->emitted_finished)
Sep 25 20:20:19 linux packagekitd[425371]: Bail out! PackageKit:ERROR:../src/pk-transaction.c:5530:pk_transaction_dispose: assertion failed: (transaction->priv->emitted_finished)
```