### PR TITLE
pk-client: Handle few error cases to avoid crash

### DIFF
--- a/client/pk-console.c
+++ b/client/pk-console.c
@@ -40,6 +40,7 @@
 #define PK_EXIT_CODE_NOTHING_USEFUL	5
 #define PK_EXIT_CODE_CANNOT_SETUP	6
 #define PK_EXIT_CODE_TRANSACTION_FAILED	7
+#define PK_EXIT_CODE_INTERNAL_ERROR	8
 
 #define PK_CONSOLE_ERROR	1
 
@@ -664,15 +665,20 @@ pk_console_finished_cb (GObject *object, GAsyncResult *res, gpointer data)
 	if (results == NULL) {
 		/* TRANSLATORS: we failed to get any results, which is pretty
 		 * fatal in my book */
-		g_print ("%s: %s\n", _("Fatal error"), error->message);
-		switch (error->code - 0xff) {
-		case PK_ERROR_ENUM_ALL_PACKAGES_ALREADY_INSTALLED:
-		case PK_ERROR_ENUM_REPO_NOT_AVAILABLE:
-			ctx->retval = PK_EXIT_CODE_NOTHING_USEFUL;
-			break;
-		default:
-			ctx->retval = PK_EXIT_CODE_TRANSACTION_FAILED;
-			break;
+		if (error != NULL) {
+			g_print ("%s: %s\n", _("Fatal error"), error->message);
+			switch (error->code - 0xff) {
+			case PK_ERROR_ENUM_ALL_PACKAGES_ALREADY_INSTALLED:
+			case PK_ERROR_ENUM_REPO_NOT_AVAILABLE:
+				ctx->retval = PK_EXIT_CODE_NOTHING_USEFUL;
+				break;
+			default:
+				ctx->retval = PK_EXIT_CODE_TRANSACTION_FAILED;
+				break;
+			}
+		} else {
+			g_print ("%s: %s\n", _("Fatal error"), _("Internal error"));
+			ctx->retval = PK_EXIT_CODE_INTERNAL_ERROR;
 		}
 		goto out;
 	}


### PR DESCRIPTION
### Without https://github.com/PackageKit/PackageKit/pull/674:

```
$ pkcon -p get-details /etc/passwd
Transaction:	Getting details
Status: 	Waiting in queue
The daemon crashed mid-transaction!
```
### With https://github.com/PackageKit/PackageKit/pull/674:

```
$ pkcon -p get-details /etc/passwd
Transaction:	Getting details
Status: 	Waiting in queue
Status: 	Finished

(pkcon:426791): GLib-GIO-CRITICAL **: 21:26:00.688: g_simple_async_result_set_from_error: assertion 'error != NULL' failed
Trace/breakpoint trap (core dumped)
```

### With https://github.com/PackageKit/PackageKit/pull/674 and this MR:

```
$ pkcon -p get-details /etc/passwd
Transaction:	Getting details
Status: 	Waiting in queue
Status: 	Finished
Results:
Fatal error: File /etc/passwd is not found or unsupported
```