### PR TITLE
trivial: Specify metadata 'cache-age' usage more clearly

### DIFF
--- a/client/pk-console.c
+++ b/client/pk-console.c
@@ -1671,7 +1671,7 @@ main (int argc, char *argv[])
 			_("Print to screen a machine readable output, rather than using animated widgets"), NULL},
 		{ "cache-age", 'c', 0, G_OPTION_ARG_INT, &cache_age,
 			/* TRANSLATORS: command line argument, just output without fancy formatting */
-			_("The maximum metadata cache age. Use -1 for 'never'."), NULL},
+			_("The maximum metadata cache age (in seconds). Use -1 to use only cache, 1 to reload cache."), NULL},
 		{ "allow-untrusted", '\0', 0, G_OPTION_ARG_NONE, &allow_untrusted,
 			/* command line argument, do we ask questions */
 			_("Allow untrusted packages to be installed."), NULL },

--- a/lib/packagekit-glib2/pk-client.c
+++ b/lib/packagekit-glib2/pk-client.c
@@ -4605,7 +4605,8 @@ pk_client_get_idle (PkClient *client)
 /**
  * pk_client_set_cache_age:
  * @client: a valid #PkClient instance
- * @cache_age: the cache age to set, where %G_MAXUINT means "never"
+ * @cache_age: the cache age to set in seconds, where %G_MAXUINT
+ * means cache "never expires"
  *
  * Sets the maximum cache age value for the client.
  *
@@ -4736,6 +4737,9 @@ pk_client_class_init (PkClientClass *klass)
 
 	/**
 	 * PkClient:cache-age:
+	 *
+	 * The cache age in seconds, where %G_MAXUINT means cache
+	 * "never expires"
 	 *
 	 * Since: 0.6.10
 	 */

--- a/src/pk-backend-job.c
+++ b/src/pk-backend-job.c
@@ -444,7 +444,7 @@ pk_backend_job_set_cache_age (PkBackendJob *job, guint cache_age)
 	if (cache_age != G_MAXUINT && cache_age > cache_age_offset)
 		cache_age -= cache_age_offset;
 
-	g_debug ("cache-age changed to %u", cache_age);
+	g_debug ("cache-age changed to %u seconds", cache_age);
 	job->priv->cache_age = cache_age;
 }
 


### PR DESCRIPTION
Refer: #679