### PR TITLE
docs: Update real-time chat room to point to the new Matrix room

### DIFF
--- a/docs/html/pk-help.html
+++ b/docs/html/pk-help.html
@@ -21,7 +21,8 @@
 
 <p>
 Anyone interested in PackageKit development is invited to join the
-channel <code>#PackageKit</code> on <code>freenode</code>.
+Matrix room <a href="https://matrix.to/#/#PackageKit:matrix.org">
+<code>#PackageKit:matrix.org</code></a>.
 We are a friendly bunch, and can answer questions on backends, GUI's or
 anything else PackageKit related.
 </p>


### PR DESCRIPTION
The IRC channel on Freenode was abandoned long ago, and the one on Libera Chat is dead. As both major stakeholders (GNOME and KDE) use Matrix primarily now, let's move there so that they can talk to us.