### PR TITLE
Check string length correctly to prevent memory over-consumption (RHEL-19527)

### DIFF
--- a/src/pk-engine.c
+++ b/src/pk-engine.c
@@ -686,7 +686,7 @@ pk_engine_set_proxy (PkEngine *engine,
 
 	/* check length of http */
 	len = pk_strlen (proxy_http, 1024);
-	if (len == 1024) {
+	if (len >= 1024) {
 		error = g_error_new_literal (PK_ENGINE_ERROR,
 					     PK_ENGINE_ERROR_CANNOT_SET_PROXY,
 					     "http proxy was too long");
@@ -696,7 +696,7 @@ pk_engine_set_proxy (PkEngine *engine,
 
 	/* check length of ftp */
 	len = pk_strlen (proxy_ftp, 1024);
-	if (len == 1024) {
+	if (len >= 1024) {
 		error = g_error_new_literal (PK_ENGINE_ERROR,
 					     PK_ENGINE_ERROR_CANNOT_SET_PROXY,
 					     "ftp proxy was too long");

--- a/src/pk-transaction.c
+++ b/src/pk-transaction.c
@@ -2484,7 +2484,7 @@ pk_transaction_strvalidate (const gchar *text, GError **error)
 				     "Invalid input passed to daemon: zero length string");
 		return FALSE;
 	}
-	if (length > 1024) {
+	if (length >= 1024) {
 		g_set_error (error, PK_TRANSACTION_ERROR, PK_TRANSACTION_ERROR_INPUT_INVALID,
 			     "Invalid input passed to daemon: input too long: %u", length);
 		return FALSE;
@@ -2536,7 +2536,7 @@ pk_transaction_search_check_item (const gchar *values, GError **error)
 				     "Invalid search containing '?'");
 		return FALSE;
 	}
-	if (size == 1024) {
+	if (size >= 1024) {
 		g_set_error_literal (error,
 				     PK_TRANSACTION_ERROR,
 				     PK_TRANSACTION_ERROR_SEARCH_INVALID,


### PR DESCRIPTION
pk_strlen() cannot return larger values than the sentinel value (1024) in this case. This invalid check could allow an unprivileged user to consume all of the system's memory (tested for versions <= 1.2.6).