### PR TITLE
PkClient: Successfully return when calling pk_client_adopt_async

### DIFF
--- a/lib/packagekit-glib2/pk-client.c
+++ b/lib/packagekit-glib2/pk-client.c
@@ -4240,6 +4240,9 @@ pk_client_adopt_get_proxy_cb (GObject *object,
 
 	/* connect */
 	pk_client_proxy_connect (state);
+
+	state->ret = TRUE;
+	pk_client_state_finish (state, NULL);
 }
 
 /**


### PR DESCRIPTION
We had no way to return a PkResults in the correct path.

Closes #709