### PR TITLE
alpm: add compatibility with libalpm 14

### DIFF
--- a/backends/alpm/meson.build
+++ b/backends/alpm/meson.build
@@ -1,4 +1,4 @@
-alpm_dep = dependency('libalpm', version: '>=13.0.0')
+alpm_dep = dependency('libalpm', version: '>=14.0.0')
 
 shared_module(
   'pk_backend_alpm',

--- a/backends/alpm/pk-alpm-config.c
+++ b/backends/alpm/pk-alpm-config.c
@@ -615,6 +615,11 @@ pk_alpm_config_parse (PkAlpmConfig *config, const gchar *filename,
 			continue;
 		}
 
+		if (g_strcmp0 (key, "CacheServer") == 0 && str != NULL) {
+			/* Ignore "CacheServer" key instead of crashing */
+			continue;
+		}
+
 		/* report errors from above */
 		g_set_error (&e, PK_ALPM_ERROR, PK_ALPM_ERR_CONFIG_INVALID,
 			     "unrecognised directive '%s'", key);

--- a/backends/alpm/pk-alpm-transaction.c
+++ b/backends/alpm/pk-alpm-transaction.c
@@ -865,16 +865,19 @@ pk_alpm_conflict_build_list (const alpm_list_t *i)
 		alpm_conflict_t *conflict = (alpm_conflict_t *) i->data;
 		alpm_depend_t *depend = conflict->reason;
 
-		if (g_strcmp0 (conflict->package1, depend->name) == 0 ||
-		    g_strcmp0 (conflict->package2, depend->name) == 0) {
+		const char *package_name1 = alpm_pkg_get_name (conflict->package1);
+		const char *package_name2 = alpm_pkg_get_name (conflict->package2);
+
+		if (g_strcmp0 (package_name1, depend->name) == 0 ||
+		    g_strcmp0 (package_name2, depend->name) == 0) {
 			g_string_append_printf (list, "%s <-> %s, ",
-						conflict->package1,
-						conflict->package2);
+						package_name1,
+						package_name2);
 		} else {
 			char *reason = alpm_dep_compute_string (depend);
 			g_string_append_printf (list, "%s <-> %s (%s), ",
-						conflict->package1,
-						conflict->package2, reason);
+						package_name1,
+						package_name2, reason);
 			free (reason);
 		}
 	}


### PR DESCRIPTION
In libalpm alpm_conflict_t package struct members are now of type alpm_pkg_t instead of char*.

libalpm sadly does not expose the version in `libalpm.h` in theory this can be made backwards compatible, but not sure how to hack that in with `pkgconf --modversion libalpm` and most distro's shipping pacman are rolling release so should have pacman 6.1