### PR TITLE
PkTask: Fix invalid cast from 'GsPackagekitTask' to 'GTask'

### DIFF
--- a/lib/packagekit-glib2/pk-task.c
+++ b/lib/packagekit-glib2/pk-task.c
@@ -993,7 +993,7 @@ pk_task_ready_cb (GObject *source_object, GAsyncResult *res, gpointer user_data)
 	if (state->exit_enum == PK_EXIT_ENUM_CANCELLED_PRIORITY) {
 		state->retry_id = g_timeout_add (PK_TASK_TRANSACTION_CANCELLED_RETRY_TIMEOUT,
 						 pk_task_retry_cancelled_transaction_cb,
-						 g_steal_pointer (&task));
+						 g_steal_pointer (&gtask));
 		return;
 	}
 


### PR DESCRIPTION
Fix the following regression from 9dfaf0dd6

```
11:30:26:977 PK  internal error: failed, but no error code: cancelled-priority
11:30:37:456 PK  internal error: failed, but no error code: cancelled-priority
11:30:42:759 PK  internal error: failed, but no error code: cancelled-priority
11:30:47:878 PK  internal error: failed, but no error code: cancelled-priority
11:30:55:800 GLib-GObject invalid cast from 'GsPackagekitTask' to 'GTask'
11:30:55:800 GLib-GIO g_task_get_task_data: assertion 'G_IS_TASK (task)' failed
11:30:55:801 GLib-GIO g_task_get_source_object: assertion 'G_IS_TASK (task)' failed
11:30:55:801 GLib-GIO g_task_get_task_data: assertion 'G_IS_TASK (task)' failed
11:30:55:801 GLib-GIO g_task_get_cancellable: assertion 'G_IS_TASK (task)' failed
```

```
(gdb) bt
#0  0x00007f75e63df814 in pk_task_do_async_action (gtask=0x7f758c1c0450 [GsPackagekitTask]) at ../lib/packagekit-glib2/pk-task.c:162
#1  0x00007f75e63e1b13 in pk_task_retry_cancelled_transaction_cb (user_data=0x7f758c1c0450, user_data@entry=<error reading variable: value has been optimized out>) at ../lib/packagekit-glib2/pk-task.c:835
#2  0x00007f75e70fe02e in g_timeout_dispatch (source=0x7f758c018400, callback=<optimized out>, user_data=<optimized out>) at ../../../glib/gmain.c:5121
#3  0x00007f75e70fa0d9 in g_main_dispatch (context=context@entry=0x560ce35bf500) at ../../../glib/gmain.c:3476
#4  0x00007f75e70fd317 in g_main_context_dispatch_unlocked (context=0x560ce35bf500) at ../../../glib/gmain.c:4284
#5  g_main_context_iterate_unlocked (context=context@entry=0x560ce35bf500, block=block@entry=1, dispatch=dispatch@entry=1, self=<optimized out>) at ../../../glib/gmain.c:4349
#6  0x00007f75e70fd930 in g_main_context_iteration (context=context@entry=0x560ce35bf500, may_block=may_block@entry=1) at ../../../glib/gmain.c:4414
#7  0x00007f75e732fb7d in g_application_run (application=0x560ce356b990 [GsApplication], argc=1, argv=<optimized out>) at ../../../gio/gapplication.c:2577
#8  0x0000560ce2895404 in main (argc=1, argv=0x7ffd3dfd6438) at ../src/gs-main.c:49
(gdb) 
```