### PR TITLE
Expand PkInfoEnum to contain package target states for updates

### DIFF
--- a/backends/apt/pk-backend-apt.cpp
+++ b/backends/apt/pk-backend-apt.cpp
@@ -388,10 +388,10 @@ static void backend_get_updates_thread(PkBackendJob *job, GVariant *params, gpoi
     updates = apt->getUpdates(blocked, downgrades, installs, removals, obsoleted);
 
     apt->emitUpdates(updates, filters);
-    apt->emitPackages(installs, filters, PK_INFO_ENUM_INSTALLING);
-    apt->emitPackages(removals, filters, PK_INFO_ENUM_REMOVING);
-    apt->emitPackages(obsoleted, filters, PK_INFO_ENUM_OBSOLETING);
-    apt->emitPackages(downgrades, filters, PK_INFO_ENUM_DOWNGRADING);
+    apt->emitPackages(installs, filters, PK_INFO_ENUM_INSTALL);
+    apt->emitPackages(removals, filters, PK_INFO_ENUM_REMOVE);
+    apt->emitPackages(obsoleted, filters, PK_INFO_ENUM_OBSOLETE);
+    apt->emitPackages(downgrades, filters, PK_INFO_ENUM_DOWNGRADE);
     apt->emitPackages(blocked, filters, PK_INFO_ENUM_BLOCKED);
 }
 

--- a/lib/packagekit-glib2/pk-enum.c
+++ b/lib/packagekit-glib2/pk-enum.c
@@ -320,9 +320,13 @@ static const PkEnumMatch enum_info[] = {
 	{PK_INFO_ENUM_DOWNGRADING,		"downgrading"},
 	{PK_INFO_ENUM_PREPARING,		"preparing"},
 	{PK_INFO_ENUM_DECOMPRESSING,		"decompressing"},
-	{PK_INFO_ENUM_UNTRUSTED,			"untrusted"},
-	{PK_INFO_ENUM_TRUSTED,				"trusted"},
+	{PK_INFO_ENUM_UNTRUSTED,		"untrusted"},
+	{PK_INFO_ENUM_TRUSTED,			"trusted"},
 	{PK_INFO_ENUM_CRITICAL,			"critical"},
+	{PK_INFO_ENUM_INSTALL,			"install"},
+	{PK_INFO_ENUM_REMOVE,			"remove"},
+	{PK_INFO_ENUM_OBSOLETE,			"obsolete"},
+	{PK_INFO_ENUM_DOWNGRADE,		"downgrade"},
 	{0, NULL}
 };
 
@@ -1007,6 +1011,22 @@ pk_info_enum_to_localised_text (PkInfoEnum info)
 	case PK_INFO_ENUM_UNAVAILABLE:
 		/* TRANSLATORS: The state of a package, i.e. not installed */
 		text = dgettext("PackageKit", "Unavailable");
+		break;
+	case PK_INFO_ENUM_INSTALL:
+		/* TRANSLATORS: The state of a package: to be installed with the next action */
+		text = dgettext("PackageKit", "Install");
+		break;
+	case PK_INFO_ENUM_REMOVE:
+		/* TRANSLATORS: The state of a package: to be removed with the next action */
+		text = dgettext("PackageKit", "Remove");
+		break;
+	case PK_INFO_ENUM_OBSOLETE:
+		/* TRANSLATORS: The state of a package: package is obsolete */
+		text = dgettext("PackageKit", "Obsolete");
+		break;
+	case PK_INFO_ENUM_DOWNGRADE:
+		/* TRANSLATORS: The state of a package: package is to be downgraded */
+		text = dgettext("PackageKit", "Downgrade");
 		break;
 	default:
 		g_warning ("info unrecognised: %s", pk_info_enum_to_string (info));

--- a/lib/packagekit-glib2/pk-enum.h
+++ b/lib/packagekit-glib2/pk-enum.h
@@ -644,7 +644,11 @@ typedef enum {
  * @PK_INFO_ENUM_UNTRUSTED:
  * @PK_INFO_ENUM_TRUSTED:
  * @PK_INFO_ENUM_UNAVAILABLE:	Package is unavailable
- * @PK_INFO_ENUM_CRITICAL: 	Package update severity is critical; Since: 1.2.4
+ * @PK_INFO_ENUM_CRITICAL: 	Package update severity is critical. Since: 1.2.4
+ * @PK_INFO_ENUM_INSTALL:	Package is intended for installation. Since 1.3.0
+ * @PK_INFO_ENUM_REMOVE:	Package is intended for removal. Since 1.3.0
+ * @PK_INFO_ENUM_OBSOLETE:	Package is obsoleted. Since 1.3.0
+ * @PK_INFO_ENUM_DOWNGRADE:	Package is intended for downgrade. Since 1.3.0
  * @PK_INFO_ENUM_LAST:
  *
  * The enumerated types used in Package() - these have to refer to a specific
@@ -677,7 +681,11 @@ typedef enum {
 	PK_INFO_ENUM_UNTRUSTED,
 	PK_INFO_ENUM_TRUSTED,
 	PK_INFO_ENUM_UNAVAILABLE,
-	PK_INFO_ENUM_CRITICAL,	/* Since: 1.2.4 */
+	PK_INFO_ENUM_CRITICAL,
+	PK_INFO_ENUM_INSTALL,
+	PK_INFO_ENUM_REMOVE,
+	PK_INFO_ENUM_OBSOLETE,
+	PK_INFO_ENUM_DOWNGRADE,
 	PK_INFO_ENUM_LAST
 } PkInfoEnum;
 


### PR DESCRIPTION
Hi!

I was investigating https://gitlab.gnome.org/GNOME/gnome-software/-/issues/2462 - the gist of that issue is that GNOME Software emits a `Refresh` action. The APT backend in this case has a bunch of packages that the update will install or remove. So it emits them as `PK_INFO_ENUM_INSTALLING`/`REMOVING` etc. Same for a call to `GetUpdates`. GNOME Software reads this as "there is currently a package being installed so the cache may be out of date!" and immediately fires another `Refresh`, resulting in an endless loop between PK and GS (and a lot of drained batteries on Debian laptops).

According to our own documentation, emitting INSTALLING etc. is actually not valid and PackageKit/the APT backend is wrong here. But we also do not seem to have any state conveying the information that the package is supposed to be install/removed/obsoleted/downgraded with the *next* action / when  the update is executed.
So the APT backend can't currently do anything here. From looking at the code (and without testing it), DNF just seems to ignore this problem, other backends do similarly wrong things.

This patch expands PK itself to provide the necessary states. But I am fairly puzzled that this feature hasn't been there since forever. And while this is not a breaking change, it will add some extra work for frontends. So I wonder, am I missing anything here and has this been possible in a different way? I honestly can't recall any, and we just used `INSTALLING` without issues so far until GS ran into it.

But maybe @hughsie knows? If this is really missing, I will polish this PR up a bit and merge it.