### PR TITLE
pk-offline-update: Fix crash due to invalid g_auto declaration in switch / case

### DIFF
--- a/client/pk-offline-update.c
+++ b/client/pk-offline-update.c
@@ -113,6 +113,7 @@ pk_offline_update_progress_cb (PkProgress *progress,
 	PkStatusEnum status;
 	gint percentage;
 	g_autofree gchar *msg = NULL;
+	g_autofree gchar *tmp_perc = NULL;
 	g_autoptr(PkPackage) pkg = NULL;
 
 	switch (type) {
@@ -145,8 +146,6 @@ pk_offline_update_progress_cb (PkProgress *progress,
 				  pk_package_get_data (pkg));
 		break;
 	case PK_PROGRESS_TYPE_PERCENTAGE:
-		g_autofree gchar *tmp_perc = NULL;
-
 		g_object_get (progress, "percentage", &percentage, NULL);
 		if (percentage < 0)
 			return;


### PR DESCRIPTION
`case PK_PROGRESS_TYPE_PERCENTAGE` is just a label and doesn't offer any scope as such. So, `tmp_perc` auto variable will be allocated in the stack, but will not be initialized to `NULL` for `case:` statements other than `PK_PROGRESS_TYPE_PERCENTAGE`, causing GLib to consider the `tmp_perc` garbage value as a valid memory address allocated via `g_malloc()`, triggering an invalid `free()` causing the crash.

Rather than adding a scope `{}` within `case`, and causing a huge noise in git diff, we just move the declaration to an upper scope.