### PR TITLE
transaction: Add transaction data to syslog when available

### DIFF
--- a/src/pk-transaction.c
+++ b/src/pk-transaction.c
@@ -1153,9 +1153,12 @@ pk_transaction_finished_cb (PkBackendJob *job, PkExitEnum exit_enum, PkTransacti
 {
 	guint time_ms;
 	guint i;
+	guint n_args;
 	PkPackage *item;
 	PkInfoEnum info;
 	PkBitfield transaction_flags;
+	gchar **cached_data = NULL;
+	g_autofree gchar *transaction_args = NULL;
 
 	g_return_if_fail (PK_IS_TRANSACTION (transaction));
 	g_return_if_fail (transaction->priv->tid != NULL);
@@ -1259,20 +1262,38 @@ pk_transaction_finished_cb (PkBackendJob *job, PkExitEnum exit_enum, PkTransacti
 	/* remove any inhibit */
 	//TODO: on main interface
 
+	/* add cached transaction data to syslog if available */
+	if (transaction->priv->cached_values != NULL)
+		cached_data = transaction->priv->cached_values;
+	else if (transaction->priv->cached_package_ids != NULL)
+		cached_data = transaction->priv->cached_package_ids;
+	else if (transaction->priv->cached_full_paths != NULL)
+		cached_data = transaction->priv->cached_full_paths;
+
+	if (cached_data) {
+		n_args = g_strv_length (cached_data);
+		if (n_args == 1)
+			transaction_args = g_strdup_printf (" (%s)", cached_data[0]);
+		else if (n_args > 1)
+			transaction_args = g_strdup_printf (" (n=%u)", n_args);
+	}
+
 	/* report to syslog */
 	if (transaction->priv->client_uid != PK_TRANSACTION_UID_INVALID) {
 		syslog (LOG_DAEMON | LOG_DEBUG,
-			"%s transaction %s from uid %i finished with %s after %ims",
+			"%s transaction %s%s from uid %i finished with %s after %ims",
 			pk_role_enum_to_string (transaction->priv->role),
 			transaction->priv->tid,
+			transaction_args ? transaction_args : "",
 			transaction->priv->client_uid,
 			pk_exit_enum_to_string (exit_enum),
 			time_ms);
 	} else {
 		syslog (LOG_DAEMON | LOG_DEBUG,
-			"%s transaction %s finished with %s after %ims",
+			"%s transaction %s%s finished with %s after %ims",
 			pk_role_enum_to_string (transaction->priv->role),
 			transaction->priv->tid,
+			transaction_args ? transaction_args : "",
 			pk_exit_enum_to_string (exit_enum),
 			time_ms);
 	}


### PR DESCRIPTION
I've been using it for a while and it helps greatly in debugging PK clients.

### Sample `journalctl` log during GNOME Software start:

```
Apr 23 17:23:10 linux PackageKit[39494]: resolve transaction /1_aedeeece (n=15) from uid 1010 finished with success after 880ms
Apr 23 17:23:11 linux PackageKit[39494]: resolve transaction /2_aeabcabd (n=128) from uid 1010 finished with success after 872ms
Apr 23 17:23:12 linux PackageKit[39494]: resolve transaction /3_dbbbdeae (n=45) from uid 1010 finished with success after 856ms
Apr 23 17:23:13 linux PackageKit[39494]: resolve transaction /4_aacdbebe (n=20) from uid 1010 finished with success after 814ms
Apr 23 17:23:14 linux PackageKit[39494]: resolve transaction /5_baaadcee (n=11) from uid 1010 finished with success after 837ms
Apr 23 17:23:14 linux PackageKit[39494]: resolve transaction /6_beccaded (geary) from uid 1010 finished with success after 797ms
Apr 23 17:23:15 linux PackageKit[39494]: resolve transaction /7_eecccabc (n=36) from uid 1010 finished with success after 922ms
Apr 23 17:23:16 linux PackageKit[39494]: resolve transaction /8_ddaeeabe (n=311) from uid 1010 finished with success after 870ms
Apr 23 17:23:17 linux PackageKit[39494]: resolve transaction /9_bdeaeeee (n=189) from uid 1010 finished with success after 890ms
Apr 23 17:23:18 linux PackageKit[39494]: resolve transaction /10_bdcbdeba (n=453) from uid 1010 finished with success after 906ms
Apr 23 17:23:19 linux PackageKit[39494]: resolve transaction /11_dcaacead (n=497) from uid 1010 finished with success after 998ms
Apr 23 17:23:20 linux PackageKit[39494]: resolve transaction /12_ceadecda (n=17) from uid 1010 finished with success after 840ms
Apr 23 17:23:21 linux PackageKit[39494]: resolve transaction /13_caceabda (n=431) from uid 1010 finished with success after 893ms
Apr 23 17:23:22 linux PackageKit[39494]: resolve transaction /14_aacbabcd (gnome-software) from uid 1010 finished with success after 964ms
Apr 23 17:23:23 linux PackageKit[39494]: get-updates transaction /15_eccdadec from uid 1010 finished with success after 1690ms
Apr 23 17:23:25 linux PackageKit[39494]: get-updates transaction /16_ccbabebc from uid 1010 finished with success after 1782ms
Apr 23 17:23:26 linux PackageKit[39494]: resolve transaction /17_bbddabee (n=135) from uid 1010 finished with success after 899ms
Apr 23 17:23:35 linux PackageKit[39494]: search-file transaction /18_edeacabe (/usr/share/metainfo/org.freedesktop.appstream.compose.metainfo.xml) from uid 1010 finished with success after 8712ms
Apr 23 17:23:36 linux PackageKit[39494]: search-file transaction /19_edadcbaa (/usr/share/applications/firefox-esr.desktop) from uid 1010 finished with success after 1204ms
Apr 23 17:23:37 linux PackageKit[39494]: search-file transaction /20_bacedccc (/usr/share/applications/google-chrome.desktop) from uid 1010 finished with success after 1147ms
Apr 23 17:23:39 linux PackageKit[39494]: search-file transaction /21_addccaed (/usr/share/applications/empathy.desktop) from uid 1010 finished with success after 1262ms
Apr 23 17:23:39 linux PackageKit[39494]: resolve transaction /22_ededbbaa (n=4) from uid 1010 finished with success after 831ms
Apr 23 17:23:40 linux PackageKit[39494]: resolve transaction /23_daebcbce (n=20) from uid 1010 finished with success after 860ms
Apr 23 17:23:41 linux PackageKit[39494]: get-details transaction /24_deabdcea (n=20) from uid 1010 finished with success after 768ms
Apr 23 17:23:43 linux PackageKit[39494]: get-updates transaction /25_adedabdb from uid 1010 finished with success after 1515ms
Apr 23 17:23:43 linux PackageKit[39494]: get-details transaction /26_aaddabee (gnome-software;46.0-4;amd64;manual:debian-unstable-main) from uid 1010 finished with success after 767ms
Apr 23 17:23:44 linux PackageKit[39494]: get-details transaction /27_deaecbba (n=3) from uid 1010 finished with success after 775ms
Apr 23 17:23:45 linux PackageKit[39494]: get-details transaction /28_cdeabacd (n=2) from uid 1010 finished with success after 769ms
Apr 23 17:23:59 linux PackageKit[39494]: get-details transaction /29_caadeacc (bijiben;40.1-6+b1;amd64;manual:debian-unstable-main) from uid 1010 finished with success after 819ms
Apr 23 17:24:00 linux PackageKit[39494]: get-details transaction /30_acacbebc (bijiben;40.1-6+b1;amd64;manual:debian-unstable-main) from uid 1010 finished with success after 789ms
Apr 23 17:24:01 linux PackageKit[39494]: get-details transaction /31_edbcdaab (bijiben;40.1-6+b1;amd64;manual:debian-unstable-main) from uid 1010 finished with success after 867ms
Apr 23 17:24:31 linux PackageKit[39494]: resolve transaction /32_ebeedbbd (n=7) from uid 1010 finished with success after 779ms
Apr 23 17:24:32 linux PackageKit[39494]: get-details transaction /33_ecbcddee (n=11) from uid 1010 finished with success after 782ms
Apr 23 17:29:34 linux PackageKit[39494]: daemon quit
```