### PR TITLE
pk-client: Fix GTask warning caused by PkClientState refcount issue

### DIFF
--- a/lib/packagekit-glib2/pk-client.c
+++ b/lib/packagekit-glib2/pk-client.c
@@ -194,6 +194,8 @@ pk_client_state_unset_proxy (PkClientState *state)
 						      state);
 		g_clear_object (&state->proxy);
 	}
+
+	g_object_unref (state);
 }
 
 static void
@@ -1656,6 +1658,8 @@ pk_client_proxy_connect (PkClientState *state)
 {
 	guint i;
 	g_auto(GStrv) props = NULL;
+
+	g_object_ref (state);
 
 	/* coldplug properties */
 	props = g_dbus_proxy_get_cached_property_names (state->proxy);


### PR DESCRIPTION
Fixes the following warning message while running `pkmon` and gives the proper output.

`GTask finalized without ever returning (using g_task_return_*())`

This was caused because `PkClientState` was finalized incorrectly, causing the state's `GTask` object to be finalized before expected, causing the warning.

Fixes: #709