### PR TITLE
pk-progress: Fix a leak of package ID

### DIFF
--- a/lib/packagekit-glib2/pk-progress.c
+++ b/lib/packagekit-glib2/pk-progress.c
@@ -1238,7 +1238,7 @@ pk_progress_finalize (GObject *object)
 	PkProgress *progress = PK_PROGRESS (object);
 	PkProgressPrivate *priv = pk_progress_get_instance_private (progress);
 
-	g_clear_pointer (&priv->item_progress, g_free);
+	g_clear_pointer (&priv->package_id, g_free);
 	g_clear_pointer (&priv->transaction_id, g_free);
 	g_clear_pointer (&priv->sender, g_free);
 


### PR DESCRIPTION
And remove an invalid free of the item progress object at the same time. This was never a problem in practice, because it had already been cleared (correctly, using `g_object_unref()`) in `dispose`.