### PR TITLE
dnf/zypp: Add support for language(ll_CC) to what-provides queries

### DIFF
--- a/backends/dnf/pk-backend-dnf.c
+++ b/backends/dnf/pk-backend-dnf.c
@@ -873,6 +873,7 @@ pk_backend_what_provides_decompose (gchar **values, GError **error)
 		g_ptr_array_add (array, g_strdup_printf ("postscriptdriver(%s)", values[i]));
 		g_ptr_array_add (array, g_strdup_printf ("plasma4(%s)", values[i]));
 		g_ptr_array_add (array, g_strdup_printf ("plasma5(%s)", values[i]));
+		g_ptr_array_add (array, g_strdup_printf ("language(%s)", values[i]));
 	}
 	g_ptr_array_add (array, NULL);
 	return (gchar **) g_ptr_array_free (array, FALSE);

--- a/backends/zypp/pk-backend-zypp.cpp
+++ b/backends/zypp/pk-backend-zypp.cpp
@@ -3766,6 +3766,7 @@ pk_backend_what_provides_decompose (PkBackendJob *job, gchar **values)
 		g_ptr_array_add (array, g_strdup_printf ("postscriptdriver(%s)", values[i]));
 		g_ptr_array_add (array, g_strdup_printf ("plasma4(%s)", values[i]));
 		g_ptr_array_add (array, g_strdup_printf ("plasma5(%s)", values[i]));
+		g_ptr_array_add (array, g_strdup_printf ("language(%s)", values[i]));
 	}
 	search = pk_ptr_array_to_strv (array);
 	for (i = 0; search[i] != NULL; i++)


### PR DESCRIPTION
This was already documented in the [‘package component provides naming’ spec](./docs/provides-component-naming.txt), so should be uncontroversial.

This is part of a plan to drop the fedora-langpacks plugin from gnome-software, and replace it with the equivalent of a call to `pkcon what-provides 'language(zh_CN)'` (for example).

See https://gitlab.gnome.org/GNOME/gnome-software/-/merge_requests/2055#note_2134286