### PR TITLE
pk-client: Fix runtime warning when backend does not support role

### DIFF
--- a/lib/packagekit-glib2/pk-client.c
+++ b/lib/packagekit-glib2/pk-client.c
@@ -1616,11 +1616,11 @@ pk_client_signal_cb (GDBusProxy *proxy,
 	if (g_strcmp0 (signal_name, "Destroy") == 0) {
 		g_autoptr(GError) local_error = NULL;
 
-		if (state->waiting_for_finished)
+		if (state->waiting_for_finished) {
 			local_error = g_error_new_literal (PK_CLIENT_ERROR, PK_CLIENT_ERROR_FAILED,
 							   "PackageKit transaction disappeared");
-
-		pk_client_state_finish (state, g_steal_pointer (&local_error));
+			pk_client_state_finish (state, g_steal_pointer (&local_error));
+		}
 		return;
 	}
 }


### PR DESCRIPTION
The daemon returns "op not supported by the backend" as part of the method call response, but this response can be received after the "Destroy" signal, which causes infinite wait for the transaction end and runtime warnings about NULL error being passed to the g_task_return_error() on the client side.

This is a regression from commit https://github.com/PackageKit/PackageKit/commit/44215db95d9cfda23045d9a9b97175519f473eb2