### PR TITLE
Fix check in pk_engine_proxy_logind_cb

### DIFF
--- a/src/pk-engine.c
+++ b/src/pk-engine.c
@@ -1751,7 +1751,7 @@ pk_engine_proxy_logind_cb (GObject *source_object,
 	PkEngine *engine = PK_ENGINE (user_data);
 
 	engine->priv->logind_proxy = g_dbus_proxy_new_finish (res, &error);
-	if (engine->priv->logind_proxy == NULL)
+	if (g_dbus_proxy_get_name_owner (engine->priv->logind_proxy) == NULL) // https://gitlab.gnome.org/GNOME/glib/-/issues/879
 		g_warning ("failed to connect to logind: %s", error->message);
 }
 #endif


### PR DESCRIPTION
The original code does not produce a warning on a system without the org.freedesktop.login1 service. The proxy object gets created neverthless and this glib issue [1] hints that it is the owner name that should be checked for NULL.

The correct fix belongs to glib but for now workaround it on the PackageKit side.

[1] https://gitlab.gnome.org/GNOME/glib/-/issues/879