### PR TITLE
apt: Use 'pk_backend_job_details_full()' so download size is reported properly

### DIFF
--- a/backends/apt/apt-job.cpp
+++ b/backends/apt/apt-job.cpp
@@ -825,14 +825,15 @@ void AptJob::emitPackageDetail(const pkgCache::VerIterator &ver)
     }
 
     g_autofree gchar *package_id = m_cache->buildPackageId(ver);
-    pk_backend_job_details(m_job,
-                           package_id,
-                           m_cache->getShortDescription(ver).c_str(),
-                           "unknown",
-                           get_enum_group(section),
-                           m_cache->getLongDescriptionParsed(ver).c_str(),
-                           rec.Homepage().c_str(),
-                           size);
+    pk_backend_job_details_full (m_job,
+                                 package_id,
+                                 m_cache->getShortDescription(ver).c_str(),
+                                 "unknown",
+                                 get_enum_group(section),
+                                 m_cache->getLongDescriptionParsed(ver).c_str(),
+                                 rec.Homepage().c_str(),
+                                 ver->InstalledSize,
+                                 ver->Size);
 }
 
 void AptJob::emitDetails(PkgList &pkgs)


### PR DESCRIPTION
This is needed for download size reporting to work in PK clients which use the `download-size` property (introduced in 3741c6842b) in `get-details` response. `download-size` property is available only when the PK backend uses `pk_backend_job_details_full()`, not otherwise.

Fixes: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1026076

I'll submit changes for other backends in separate pull requests.