### PR TITLE
alpm: Use 'alpm_errno()' rather than incorrect 'errno' for libalpm errors

### DIFF
--- a/backends/alpm/pk-alpm-update.c
+++ b/backends/alpm/pk-alpm-update.c
@@ -267,7 +267,7 @@ pk_alpm_refresh_databases (PkBackendJob *job, gint force, alpm_list_t *dbs, GErr
 	result = alpm_db_update (priv->alpm, dbs, force);
 	if (result < 0) {
 		g_set_error (error, PK_ALPM_ERROR, alpm_errno (priv->alpm), "failed to update database: %s",
-				alpm_strerror (errno));
+			     alpm_strerror (alpm_errno (priv->alpm)));
 		return FALSE;
 	}
 


### PR DESCRIPTION
Refer https://github.com/PackageKit/PackageKit/issues/661