### PR TITLE
entropy/portage: Fix missing 'comma' in meson.install_data ()

### DIFF
--- a/backends/entropy/meson.build
+++ b/backends/entropy/meson.build
@@ -15,6 +15,6 @@ shared_module(
 
 install_data(
   'entropyBackend.py',
-  install_dir: join_paths(get_option('datadir'), 'PackageKit', 'helpers', 'entropy')
+  install_dir: join_paths(get_option('datadir'), 'PackageKit', 'helpers', 'entropy'),
   install_mode: 'rwxr--r--'
 )

--- a/backends/portage/meson.build
+++ b/backends/portage/meson.build
@@ -15,6 +15,6 @@ shared_module(
 
 install_data(
   'portageBackend.py',
-  install_dir: join_paths(get_option('datadir'), 'PackageKit', 'helpers', 'portage')
+  install_dir: join_paths(get_option('datadir'), 'PackageKit', 'helpers', 'portage'),
   install_mode: 'rwxr--r--'
 )


### PR DESCRIPTION
Fixes https://github.com/PackageKit/PackageKit/issues/694