### PR TITLE
Use '|' as package-id separator when writing offline updates trigger file

### DIFF
--- a/docs/offline-updates.txt
+++ b/docs/offline-updates.txt
@@ -47,7 +47,7 @@ For success, the file will contain the following:
 [PackageKit Offline Update Results]
 Success=true
 Role=update-packages
-Packages=gimp;2.10.34-1.fc38;x86_64;updates,bash;5.2.15-3.fc38;x86_64;updates
+Packages=gimp;2.10.34-1.fc38;x86_64;updates|bash;5.2.15-3.fc38;x86_64;updates
 """
 
 ________________________________________________________________________

--- a/lib/packagekit-glib2/pk-offline-private.c
+++ b/lib/packagekit-glib2/pk-offline-private.c
@@ -310,7 +310,7 @@ pk_offline_auth_set_prepared_ids (gchar **package_ids, GError **error)
 
 	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
 
-	data = g_strjoinv (",", package_ids);
+	data = g_strjoinv ("|", package_ids);
 	keyfile = g_key_file_new ();
 	g_key_file_set_string (keyfile, "update", "prepared_ids", data);
 	return g_key_file_save_to_file (keyfile, PK_OFFLINE_PREPARED_FILENAME, error);
@@ -475,7 +475,7 @@ pk_offline_auth_set_results (PkResults *results, GError **error)
 
 				/* deduplicate entries in case the backend has emitted them multiple times */
 				if (g_hash_table_add (known_pkgids, (gpointer) pkgid))
-					g_string_append_printf (string, "%s,", pkgid);
+					g_string_append_printf (string, "%s|", pkgid);
 				break;
 			default:
 				break;

--- a/lib/packagekit-glib2/pk-offline.c
+++ b/lib/packagekit-glib2/pk-offline.c
@@ -483,7 +483,7 @@ pk_offline_get_prepared_ids (GError **error)
 		return NULL;
 
 	/* return raw package ids */
-	return g_strsplit (prepared_ids, ",", -1);
+	return g_strsplit (prepared_ids, "|", -1);
 }
 
 /**
@@ -725,7 +725,7 @@ pk_offline_get_results (GError **error)
 	data = g_key_file_get_string (file, PK_OFFLINE_RESULTS_GROUP,
 				      "Packages", NULL);
 	if (data != NULL) {
-		package_ids = g_strsplit (data, ",", -1);
+		package_ids = g_strsplit (data, "|", -1);
 		for (i = 0; package_ids[i] != NULL; i++) {
 			g_autoptr(PkPackage) pkg = NULL;
 			pkg = pk_package_new ();

--- a/lib/packagekit-glib2/pk-test-private.c
+++ b/lib/packagekit-glib2/pk-test-private.c
@@ -623,7 +623,7 @@ pk_test_offline_func (void)
 	const gchar *results_success =
 			"[PackageKit Offline Update Results]\n"
 			"Success=true\n"
-			"Packages=upower;0.9.16-1.fc17;x86_64;updates,"
+			"Packages=upower;0.9.16-1.fc17;x86_64;updates|"
 				 "zif;0.3.0-1.fc17;x86_64;updates\n";
 
 	/* cleanup */


### PR DESCRIPTION
The ',' separator is unsuitable because FreeBSD packages may contain it in version strings.