### PR TITLE
pk-client-helper: Do not crash on edge-case GIO error

### DIFF
--- a/lib/packagekit-glib2/pk-client-helper.c
+++ b/lib/packagekit-glib2/pk-client-helper.c
@@ -207,7 +207,7 @@ pk_client_helper_copy_stdout_cb (GIOChannel *source, GIOCondition condition, PkC
 	g_debug ("child has input to push to the socket: %s", data);
 	status = g_io_channel_write_chars (child->socket_channel, data, len, &written, &error);
 	if (status != G_IO_STATUS_NORMAL) {
-		g_warning ("failed to write to socket: %s", error->message);
+		g_warning ("failed to write to socket: %s", error ?  error->message : "Unknown error");
 		return G_SOURCE_REMOVE;
 	}
 	if (written != len) {
@@ -278,7 +278,7 @@ pk_client_helper_copy_conn_cb (GIOChannel *source, GIOCondition condition, PkCli
 	g_debug ("socket has data to push to child: '%s'", data);
 	status = g_io_channel_write_chars (child->stdin_channel, data, len, &written, &error);
 	if (status != G_IO_STATUS_NORMAL) {
-		g_warning ("failed to write to stdin: %s", error->message);
+		g_warning ("failed to write to stdin: %s", error ? error->message : "Unknown error");
 		return G_SOURCE_REMOVE;
 	}
 	if (written != len) {


### PR DESCRIPTION
The GIOChannel API provides both a `status` and an `error` output. The status can be NORMAL, AGAIN, EOF, ERROR.

It is not the case, as the code previously assumed, that `(status != NORMAL) => (error != NULL)`.
It is unfortunately not even true that `(status == ERROR)  => (error != NULL)`.

We could try handling AGAIN and EOF better, but for now let's avoid crashing with a NULL pointer dereference.