### PR TITLE
Add GetResult{,Packages,Error} methods to the Offline interface

### DIFF
--- a/src/org.freedesktop.PackageKit.xml
+++ b/src/org.freedesktop.PackageKit.xml
@@ -592,6 +592,75 @@
     </property>
 
     <!--*********************************************************************-->
+    <method name="GetResult">
+      <doc:doc>
+        <doc:description>
+          <doc:para>
+            Returns if the last offline action was completed successfully.
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+      <arg type="b" name="success" direction="out">
+        <doc:doc>
+          <doc:summary>
+            <doc:para>
+              A boolean value representing success.
+            </doc:para>
+          </doc:summary>
+        </doc:doc>
+      </arg>
+    </method>
+
+    <!--*********************************************************************-->
+    <method name="GetResultPackages">
+      <doc:doc>
+        <doc:description>
+          <doc:para>
+            Returns the list of packages that were updated during the last offline action.
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+      <arg type="as" name="package_ids" direction="out">
+        <doc:doc>
+          <doc:summary>
+            <doc:para>
+              An array of package IDs.
+            </doc:para>
+          </doc:summary>
+        </doc:doc>
+      </arg>
+    </method>
+
+    <!--*********************************************************************-->
+    <method name="GetResultError">
+      <doc:doc>
+        <doc:description>
+          <doc:para>
+            Returns the error if the last offline action has failed.
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+      <arg type="s" name="error_code" direction="out">
+        <doc:doc>
+          <doc:summary>
+            <doc:para>
+              An stringified PackageKit error code.
+            </doc:para>
+          </doc:summary>
+        </doc:doc>
+      </arg>
+      <arg type="s" name="error_description" direction="out">
+        <doc:doc>
+          <doc:summary>
+            <doc:para>
+              A detailed error description.
+            </doc:para>
+          </doc:summary>
+        </doc:doc>
+      </arg>
+    </method>
+
+    <!--*********************************************************************-->
     <method name="ClearResults">
       <doc:doc>
         <doc:description>

--- a/src/pk-engine.c
+++ b/src/pk-engine.c
@@ -1755,6 +1755,63 @@ pk_engine_offline_method_call (GDBusConnection *connection_, const gchar *sender
 		g_dbus_method_invocation_return_value (invocation, value);
 		return;
 	}
+	if (g_strcmp0 (method_name, "GetResult") == 0) {
+		g_autoptr(PkResults) results = NULL;
+
+		results = pk_offline_get_results (&error);
+		if (results == NULL) {
+			g_dbus_method_invocation_return_error (invocation,
+							       PK_ENGINE_ERROR,
+							       PK_ENGINE_ERROR_INVALID_STATE,
+							       "%s", error->message);
+			return;
+		}
+
+		g_dbus_method_invocation_return_value (invocation, g_variant_new ("(b)", pk_results_get_exit_code (results) == PK_EXIT_ENUM_SUCCESS));
+		return;
+	}
+	if (g_strcmp0 (method_name, "GetResultPackages") == 0) {
+		g_autoptr(PkResults) results = NULL;
+		GVariant *value = NULL;
+
+		results = pk_offline_get_results (&error);
+		if (results == NULL) {
+			g_dbus_method_invocation_return_error (invocation,
+							       PK_ENGINE_ERROR,
+							       PK_ENGINE_ERROR_INVALID_STATE,
+							       "%s", error->message);
+			return;
+		}
+
+		value = g_variant_new ("(^as)", pk_package_sack_get_ids (pk_results_get_package_sack (results)));
+
+		g_dbus_method_invocation_return_value (invocation, value);
+		return;
+	}
+	if (g_strcmp0 (method_name, "GetResultError") == 0) {
+		g_autoptr(PkResults) results = NULL;
+		g_autoptr(PkError) pk_error = NULL;
+		GVariant *value = NULL;
+
+		results = pk_offline_get_results (&error);
+		if (results == NULL) {
+			g_dbus_method_invocation_return_error (invocation,
+							       PK_ENGINE_ERROR,
+							       PK_ENGINE_ERROR_INVALID_STATE,
+							       "%s", error->message);
+			return;
+		}
+
+		pk_error = pk_results_get_error_code (results);
+
+		if (pk_error != NULL) {
+			value = g_variant_new ("(ss)", pk_error_enum_to_string (pk_error_get_code (pk_error)), pk_error_get_details (pk_error));
+		} else {
+			value = g_variant_new ("(ss)", "", "");
+		}
+		g_dbus_method_invocation_return_value (invocation, value);
+		return;
+	}
 }
 
 static void


### PR DESCRIPTION
Continuing from #795 , this change adds methods for accessing the `PK_OFFLINE_RESULTS_FILENAME` data.

The `GetResultPackages` method returns a plain strings array because
1. The `PK_OFFLINE_RESULTS_FILENAME` contents is still a private implementation detail of the `packagekit-glib` library.
2. The `GetPrepared` method already returns a string array, which might be as large as the resulting array.