### PR TITLE
apt: Use shared_module instead of shared_library as this is a loaded module

### DIFF
--- a/backends/apt/meson.build
+++ b/backends/apt/meson.build
@@ -29,7 +29,7 @@ c_args = ['-DG_LOG_DOMAIN="PackageKit-APT"',
           '-DDATADIR="@0@"'.format(join_paths(get_option('prefix'), get_option('datadir'))),
 ]
 
-packagekit_backend_apt_module = shared_library(
+packagekit_backend_apt_module = shared_module(
   'pk_backend_apt',
   'pk-backend-apt.cpp',
   'acqpkitstatus.cpp',


### PR DESCRIPTION
We are not exactly creating a library here.