### PR TITLE
apt: Adjust for libapt-pkg7.0 API

### DIFF
--- a/backends/apt/apt-job.cpp
+++ b/backends/apt/apt-job.cpp
@@ -747,7 +747,7 @@ bool AptJob::getArchive(pkgAcquire *Owner,
         StoreFilename = QuoteString(Version.ParentPkg().Name(),"_:") + '_' +
                 QuoteString(Version.VerStr(),"_:") + '_' +
                 QuoteString(Version.Arch(),"_:.") +
-                "." + flExtension(Parse.FileName());
+                "." + std::string{flExtension(Parse.FileName())};
     }
 
     for (; Vf.end() == false; Vf++) {
@@ -776,7 +776,7 @@ bool AptJob::getArchive(pkgAcquire *Owner,
                                  Version.ParentPkg().Name());
         }
 
-        string DestFile = directory + "/" + flNotDir(StoreFilename);
+        string DestFile = directory + "/" + std::string{flNotDir(StoreFilename)};
 
         // Create the item
         new pkgAcqFile(Owner,

--- a/backends/apt/pk-backend-apt.cpp
+++ b/backends/apt/pk-backend-apt.cpp
@@ -528,7 +528,7 @@ static void pk_backend_download_packages_thread(PkBackendJob *job, GVariant *par
                 }
 
                 gchar **files = (gchar **) g_malloc(2 * sizeof(gchar *));
-                files[0] = g_strdup_printf("%s/%s", directory.c_str(), flNotDir(storeFileName).c_str());
+                files[0] = g_strdup_printf("%s/%s", directory.c_str(), std::string{flNotDir(storeFileName)}.c_str());
                 files[1] = NULL;
                 pk_backend_job_files(job, pi, files);
                 g_strfreev(files);


### PR DESCRIPTION
These functions return std::string_view now; adjust the callers to wrap them in std::string{}. An alternative would be to use append() instead of a temporary string object but this is not performance critical anyway.

I'm cherry-picking this in the package, I already committed the patch in salsa, and will upload once APT transition starts and it has been built everywhere.