### PR TITLE
zypp: Raise exception on empty search string

### DIFF
--- a/backends/zypp/pk-backend-zypp.cpp
+++ b/backends/zypp/pk-backend-zypp.cpp
@@ -3112,7 +3112,7 @@ backend_find_packages_thread (PkBackendJob *job, GVariant *params, gpointer user
 		&_filters,
 		&values);
 
-	if (values == NULL && values[0] == NULL) {
+	if (values == NULL || values[0] == NULL) {
 		pk_backend_job_error_code (job, PK_ERROR_ENUM_PACKAGE_ID_INVALID,
 					   "Empty search string is not supported.");
 		return;


### PR DESCRIPTION
This fixes a bug where, with zypper backend, PackageKit crashes on empty search strings.

After you make a call with empty search string , you'll get a journal message that looks something like this:

```
Feb 25 11:06:41 tw packagekitd[1513]: terminate called after throwing an instance of 'std::logic_error'
Feb 25 11:06:41 tw packagekitd[1513]:   what():  basic_string: construction from null is not valid
Feb 25 11:06:41 tw systemd-coredump[1540]: Process 1513 (Zypp-main) of user 0 terminated abnormally with signal 6/ABRT, processing...
Feb 25 11:06:41 tw systemd[1]: Started Process Core Dump (PID 1540/UID 0).
Feb 25 11:06:41 tw systemd-coredump[1541]: [🡕] Process 1513 (Zypp-main) of user 0 dumped core.

   Stack trace of thread 1519:
   #0  0x00007f976069a13c __pthread_kill_implementation (libc.so.6 + 0x9a13c)
   #1  0x00007f9760641436 raise (libc.so.6 + 0x41436)
   #2  0x00007f97606289a4 abort (libc.so.6 + 0x289a4)
   #3  0x00007f975d6adc4d n/a (libstdc++.so.6 + 0xadc4d)
   #4  0x00007f975d6bf28c n/a (libstdc++.so.6 + 0xbf28c)
   #5  0x00007f975d6ad7f5 _ZSt9terminatev (libstdc++.so.6 + 0xad7f5)
   #6  0x00007f975d6bf518 __cxa_throw (libstdc++.so.6 + 0xbf518)
   #7  0x00007f975d6b035c _ZSt19__throw_logic_errorPKc (libstdc++.so.6 + 0xb035c)
   #8  0x00007f975e127692 n/a (libpk_backend_zypp.so + 0x17692)
   #9  0x00007f975e139b38 n/a (libpk_backend_zypp.so + 0x29b38)
   #10 0x000056304d0f3b7a n/a (n/a + 0x0)
   ELF object binary architecture: AMD x86-64
```

With this change, the exception of an empty search string is properly reported