### PR TITLE
meson: Add "dbdir" option allowing to specify where to install transactions.db

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -81,5 +81,5 @@ endif
 
 install_data(
   'transactions.db',
-  install_dir: join_paths(get_option('localstatedir'), 'lib', 'PackageKit'),
+  install_dir: pk_db_dir,
 )

--- a/meson.build
+++ b/meson.build
@@ -97,8 +97,8 @@ config_dep = declare_dependency(
   include_directories: include_directories('.')
 )
 
-pk_db_dir = join_paths(get_option('localstatedir'), 'lib', 'PackageKit')
 local_state_dir = get_option('localstatedir')
+pk_db_dir = join_paths(local_state_dir, get_option('dbdir'))
 test_data_dir = join_paths(meson.source_root(), 'tests', 'data')
 package_data_dir = get_option('datadir')
 package_locale_dir = join_paths(get_option('prefix'), get_option('datadir'), 'locale')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -20,3 +20,4 @@ option('dbus_services', type : 'string', value : '', description : 'D-BUS system
 option('python_backend', type : 'boolean', value : true, description : 'Provide a python backend')
 option('pythonpackagedir', type : 'string', value : '', description : 'Location for python modules')
 option('daemon_tests', type : 'boolean', value : true, description : 'Test the daemon using the dummy backend')
+option('dbdir', type : 'string', value : 'lib/PackageKit', description : 'Path to the directory containing transactions DB relative to localstatedir')


### PR DESCRIPTION
The main rationale for this change is that FreeBSD prefers /var/db for keeping
programs state and does not have /var/lib