### PR TITLE
OpenMandriva: small repo changes

### DIFF
--- a/backends/dnf/dnf-backend-vendor-openmandriva.c
+++ b/backends/dnf/dnf-backend-vendor-openmandriva.c
@@ -29,7 +29,7 @@ dnf_validate_supported_repo (const gchar *id)
 	guint i, j, k, l, m;
 
 	const gchar *valid_sourcesect[] = { "",
-					  "-unsupported",
+					  "-extra",
 					  "-restricted",
 					  "-non-free",
 					  NULL };
@@ -44,6 +44,7 @@ dnf_validate_supported_repo (const gchar *id)
 				      "i686",
 				      "aarch64",
 				      "armv7hnl",
+				      "riscv64",
 				      NULL };
 
 	const gchar *valid_stage[] = {  "",


### PR DESCRIPTION
- rename "unsupported" repository to "extra"
- add riscv64 architecture