### PR TITLE
alpm: Fix 'pk_alpm_logcb' printf format warning

### DIFF
--- a/backends/alpm/pk-backend-alpm.c
+++ b/backends/alpm/pk-backend-alpm.c
@@ -57,7 +57,9 @@ pk_alpm_logcb (void *ctx, alpm_loglevel_t level, const gchar *format, va_list ar
 
 	if (format == NULL || format[0] == '\0')
 		return;
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=format"
 	output = g_strdup_vprintf (format, args);
+#pragma GCC diagnostic pop
 
 	/* report important output to PackageKit */
 	switch (level) {


### PR DESCRIPTION
Fixes the following warning: (from https://github.com/PackageKit/PackageKit/actions/runs/14432889256/job/40469819487?pr=787)

```
../backends/alpm/pk-backend-alpm.c: In function 'pk_alpm_logcb': ../backends/alpm/pk-backend-alpm.c:60:9: warning: function 'pk_alpm_logcb' might be a candidate for 'gnu_printf' format attribute [-Wsuggest-attribute=format]
   60 |         output = g_strdup_vprintf (format, args);
      |
```

### Explanation:

`pk_alpm_logcb` function signature is from `libalpm/alpm.h` (public API), so nothing much we can do except ignore the warning.

`typedef void (*alpm_cb_log)(alpm_loglevel_t, const char *, va_list);`