### PR TITLE
apt: Define an apt backend static library

### DIFF
--- a/backends/apt/meson.build
+++ b/backends/apt/meson.build
@@ -29,9 +29,9 @@ c_args = ['-DG_LOG_DOMAIN="PackageKit-APT"',
           '-DDATADIR="@0@"'.format(join_paths(get_option('prefix'), get_option('datadir'))),
 ]
 
-packagekit_backend_apt_module = shared_library(
-  'pk_backend_apt',
-  'pk-backend-apt.cpp',
+# Required to be used by the test suite
+packagekit_backend_apt_lib = static_library(
+  'pk_backend_apt_lib',
   'acqpkitstatus.cpp',
   'acqpkitstatus.h',
   'apt-cache-file.cpp',
@@ -53,7 +53,6 @@ packagekit_backend_apt_module = shared_library(
   include_directories: packagekit_src_include,
   dependencies: [
     packagekit_glib2_dep,
-    gmodule_dep,
     apt_pkg_dep,
     appstream_dep,
     gstreamer_dep,
@@ -67,6 +66,37 @@ packagekit_backend_apt_module = shared_library(
   ],
   link_args: [
     '-lutil',
+  ],
+  override_options: [
+    'b_lundef=false',
+    'c_std=c11',
+    'cpp_std=c++17'
+  ],
+)
+
+packagekit_backend_apt_dep = declare_dependency(
+    link_whole: packagekit_backend_apt_lib,
+    include_directories: [
+        packagekit_src_include,
+        include_directories('.'),
+    ],
+    dependencies: [
+        packagekit_glib2_dep,
+    ],
+)
+
+packagekit_backend_apt_module = shared_module(
+  'pk_backend_apt',
+  'pk-backend-apt.cpp',
+  include_directories: packagekit_src_include,
+  dependencies: [
+    packagekit_glib2_dep,
+    packagekit_backend_apt_dep,
+  ],
+  c_args: c_args,
+  cpp_args: [
+    c_args,
+    ddtp_flag,
   ],
   override_options: [
     'b_lundef=false',

--- a/backends/apt/tests/meson.build
+++ b/backends/apt/tests/meson.build
@@ -2,15 +2,12 @@ apt_tests = executable(
   'apt-tests',
   'apt-tests.cpp',
   'definitions.cpp',
-  link_with: [
-    packagekit_backend_apt_module,
-  ],
   include_directories: [
-    include_directories('..'),
     packagekit_src_include,
   ],
   dependencies: [
     packagekit_glib2_dep,
+    packagekit_backend_apt_dep,
     gstreamer_dep,
   ],
   build_by_default: true,


### PR DESCRIPTION
Include it in the module and in the test executable. No behavioral changes.