### PR TITLE
ci: Reduce verbose logs in freebsd build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,7 +13,7 @@ task:
         -Dsystemd=false -Doffline_update=false  -Dbash_completion=false -Dbash_command_not_found=false
         -Dgstreamer_plugin=false -Dpackaging_backend=freebsd _build
     - cd _build
-    - ninja -v all
+    - ninja all
   test_script:
    - cd _build
    - service dbus onestart


### PR DESCRIPTION
Removes the `-v` ninja build flag, as there is just too much build output. 

https://github.com/PackageKit/PackageKit/pull/842 fixes all build issues related to `FreeBSD` (which uses `Clang`).

@arrowd: Thoughts?