### PR TITLE
ci: Disable deprecation errors in zypp backend temporarily

### DIFF
--- a/backends/zypp/meson.build
+++ b/backends/zypp/meson.build
@@ -22,10 +22,10 @@ shared_module(
     '-Wall',
     '-Woverloaded-virtual',
     '-Wnon-virtual-dtor',
+    '-Wno-error=deprecated-declarations',
     '-std=c++1z'
   ],
   c_args: [
-    '-Wno-deprecated',
     '-D_FILE_OFFSET_BITS=64',
   ],
   install: true,


### PR DESCRIPTION
This is just an interim fix until the deprecation warnings are fixed.

Refer: https://github.com/PackageKit/PackageKit/issues/839