### PR TITLE
apt: Implement support for Deb822 sources.list

### DIFF
--- a/backends/apt/apt-job.cpp
+++ b/backends/apt/apt-job.cpp
@@ -1098,8 +1098,8 @@ PkgList AptJob::getPackagesFromRepo(SourcesList::SourceRecord *&rec)
             continue;
         }
 
-        // Check if the site the package comes from is include in the Repo uri
-        if (vf.File().Site() == NULL || rec->URI.find(vf.File().Site()) == std::string::npos) {
+        // Check if the site the package comes from is included in the Repo uri
+        if (vf.File().Site() == NULL || rec->PrimaryURI.find(vf.File().Site()) == std::string::npos) {
             continue;
         }
 

--- a/backends/apt/apt-sourceslist.cpp
+++ b/backends/apt/apt-sourceslist.cpp
@@ -1,4 +1,4 @@
-/* apt-sourceslist.cpp - access the sources.list file
+/* apt-sourceslist.cpp - read & write APT repository sources
  *
  * Copyright (c) 1999 Patrick Cole <z@amused.net>
  *           (c) 2002 Synaptic development team
@@ -36,8 +36,6 @@
 #include <apt-pkg/strutl.h>
 #include <apt-pkg/error.h>
 #include <apt-pkg/tagfile.h>
-#include <apt-pkg/indexfile.h>
-#include <apt-pkg/metaindex.h>
 #include <algorithm>
 #include <fstream>
 #include <fcntl.h>
@@ -244,7 +242,7 @@ bool SourcesList::ReadSourceDeb822(string listpath)
     return true;
 }
 
-bool SourcesList::ReadSourceOneLine(string listpath)
+bool SourcesList::ReadSourceLegacy(string listpath)
 {
     char buf[512];
     const char *p;
@@ -362,7 +360,7 @@ bool SourcesList::ReadSourcePart(string listpath)
     if (g_str_has_suffix (listpath.c_str(), ".sources")) {
         return ReadSourceDeb822(listpath);
     } else {
-        return ReadSourceOneLine(listpath);
+        return ReadSourceLegacy(listpath);
     }
 }
 

--- a/backends/apt/apt-sourceslist.cpp
+++ b/backends/apt/apt-sourceslist.cpp
@@ -3,6 +3,7 @@
  * Copyright (c) 1999 Patrick Cole <z@amused.net>
  *           (c) 2002 Synaptic development team
  *           (c) 2016 Daniel Nicoletti <dantti12@gmail.com>
+ *           (c) 2018-2025 Matthias Klumpp <matthias@tenstral.net>
  *
  * Author: Patrick Cole <z@amused.net>
  *         Michael Vogt <mvo@debian.org>
@@ -312,7 +313,7 @@ bool SourcesList::ReadSourceOneLine(string listpath)
                 //return _error->Error("Syntax error in line %s", buf);
             }
         }
-#ifndef HAVE_RPM
+
         // check for absolute dist
         if (rec.Dist.empty() == false && rec.Dist[rec.Dist.size() - 1] == '/') {
             // make sure there's no section
@@ -325,7 +326,6 @@ bool SourcesList::ReadSourceOneLine(string listpath)
             AddSourceNode(rec);
             continue;
         }
-#endif
 
         const char *tmp = p;
         rec.NumSections = 0;
@@ -393,7 +393,7 @@ bool SourcesList::ReadSourceDir(string Dir)
             continue;
         }
 
-        // Only look at files ending in .list to skip .rpmnew etc files
+        // Only look at files ending in .list and .sources, skip .dpkg-new/.bak/.save etc.
         if (!g_str_has_suffix (Ent->d_name, ".list") &&
             !g_str_has_suffix (Ent->d_name, ".sources")) {
             continue;
@@ -444,11 +444,7 @@ bool SourcesList::ReadSources()
 SourcesList::SourceRecord *SourcesList::AddEmptySource()
 {
     SourceRecord rec;
-#ifdef HAVE_RPM
-    rec.Type = Rpm;
-#else
     rec.Type = Deb;
-#endif
     rec.VendorID = "";
     rec.SourceFile = _config->FindFile("Dir::Etc::sourcelist");
     rec.Dist = "";
@@ -557,23 +553,10 @@ bool SourcesList::SourceRecord::SetType(string S)
         Type |= Deb;
     } else if (S == "deb-src") {
         Type |= DebSrc;
-    } else if (S == "rpm") {
-        Type |= Rpm;
-    } else if (S == "rpm-src") {
-        Type |= RpmSrc;
-    } else if (S == "rpm-dir") {
-        Type |= RpmDir;
-    } else if (S == "rpm-src-dir") {
-        Type |= RpmSrcDir;
-    } else if (S == "repomd") {
-        Type |= Repomd;
-    } else if (S == "repomd-src") {
-        Type |= RepomdSrc;
     } else {
         return false;
     }
 
-    //cout << S << " settype " << (Type | Repomd) << endl;
     return true;
 }
 
@@ -583,21 +566,8 @@ string SourcesList::SourceRecord::GetType()
         return "deb";
     } else if ((Type & DebSrc) != 0) {
         return "deb-src";
-    } else if ((Type & Rpm) != 0) {
-        return "rpm";
-    } else if ((Type & RpmSrc) != 0) {
-        return "rpm-src";
-    } else if ((Type & RpmDir) != 0) {
-        return "rpm-dir";
-    } else if ((Type & RpmSrcDir) != 0) {
-        return "rpm-src-dir";
-    } else if ((Type & Repomd) != 0) {
-        return "repomd";
-    } else if ((Type & RepomdSrc) != 0) {
-        return "repomd-src";
     }
 
-    //cout << "type " << (Type & Repomd) << endl;
     return "unknown";
 }
 
@@ -834,24 +804,6 @@ ostream &operator<<(ostream &os, const SourcesList::SourceRecord &rec)
     }
     if ((rec.Type & SourcesList::DebSrc) != 0) {
         os << "DebSrc";
-    }
-    if ((rec.Type & SourcesList::Rpm) != 0) {
-        os << "Rpm";
-    }
-    if ((rec.Type & SourcesList::RpmSrc) != 0) {
-        os << "RpmSrc";
-    }
-    if ((rec.Type & SourcesList::RpmDir) != 0) {
-        os << "RpmDir";
-    }
-    if ((rec.Type & SourcesList::RpmSrcDir) != 0) {
-        os << "RpmSrcDir";
-    }
-    if ((rec.Type & SourcesList::Repomd) != 0) {
-        os << "Repomd";
-    }
-    if ((rec.Type & SourcesList::RepomdSrc) != 0) {
-        os << "RepomdSrc";
     }
     os << endl;
     os << "SourceFile: " << rec.SourceFile << endl;

--- a/backends/apt/apt-sourceslist.h
+++ b/backends/apt/apt-sourceslist.h
@@ -26,6 +26,10 @@
 #ifndef APT_SOURCESLIST_H
 #define APT_SOURCESLIST_H
 
+#include <apt-pkg/fileutl.h>
+#include <apt-pkg/tagfile.h>
+#include <apt-pkg/metaindex.h>
+
 #include <string>
 #include <list>
 
@@ -85,6 +89,12 @@ public:
 private:
     SourceRecord *AddSourceNode(SourceRecord &);
     VendorRecord *AddVendorNode(VendorRecord &);
+    bool OpenConfigurationFileFd(std::string const &File, FileFd &Fd);
+    bool FixupURI(string &URI) const;
+    bool ParseStanza(const char*Type,
+                     pkgTagSection &Tags,
+                     unsigned int const i,
+                     FileFd &Fd);
 
 public:
     SourceRecord *AddSource(RecType Type,
@@ -96,6 +106,8 @@ public:
     SourceRecord *AddEmptySource();
     void RemoveSource(SourceRecord *&);
     void SwapSources( SourceRecord *&, SourceRecord *& );
+    bool ReadSourceDeb822(string listpath);
+    bool ReadSourceOneLine(string listpath);
     bool ReadSourcePart(string listpath);
     bool ReadSourceDir(string Dir);
     bool ReadSources();

--- a/backends/apt/apt-sourceslist.h
+++ b/backends/apt/apt-sourceslist.h
@@ -48,22 +48,27 @@ public:
     struct SourceRecord {
         unsigned int Type;
         string VendorID;
-        string URI;
+        string PrimaryURI;
+        std::vector<std::string> URIs;
         string Dist;
         string *Sections;
         unsigned short NumSections;
+        string Comment;
+
+        string SourceFile;
+        uint Deb822StanzaIdx;
+
         string joinedSections();
         string niceName();
         string repoId();
         bool hasSection(const char *component);
-        string Comment;
-        string SourceFile;
 
         bool SetType(string);
         string GetType();
         bool SetURI(string);
+        bool SetURIs(const std::vector<std::string> &newURIs);
 
-        SourceRecord():Type(0), Sections(0), NumSections(0) {}
+        SourceRecord():Type(0), Sections(0), NumSections(0), Deb822StanzaIdx(0) {}
         ~SourceRecord() {
             if (Sections) {
                 delete [] Sections;
@@ -85,11 +90,10 @@ private:
     SourceRecord *AddSourceNode(SourceRecord &);
     VendorRecord *AddVendorNode(VendorRecord &);
     bool OpenConfigurationFileFd(std::string const &File, FileFd &Fd);
-    bool FixupURI(string &URI) const;
-    bool ParseStanza(const char*Type,
-                     pkgTagSection &Tags,
-                     unsigned int const i,
-                     FileFd &Fd);
+    bool ParseDeb822Stanza(const char*Type,
+                           pkgTagSection &Tags,
+                           unsigned int const stanzaIdx,
+                           FileFd &Fd);
     bool UpdateSourceLegacy(const std::string &filename);
     bool UpdateSourceDeb822(const std::string &filename);
 

--- a/backends/apt/apt-sourceslist.h
+++ b/backends/apt/apt-sourceslist.h
@@ -2,6 +2,7 @@
  *
  * Copyright (c) 1999 Patrick Cole <z@amused.net>
  *           (c) 2002 Synaptic development team
+*            (c) 2018-2025 Matthias Klumpp <matthias@tenstral.net>
  *
  * Author: Patrick Cole <z@amused.net>
  *         Michael Vogt <mvo@debian.org>
@@ -40,14 +41,8 @@ public:
     enum RecType {
         Deb = 1 << 0,
         DebSrc = 1 << 1,
-        Rpm = 1 << 2,
-        RpmSrc = 1 << 3,
-        Disabled = 1 << 4,
-        Comment = 1 << 5,
-        RpmDir = 1 << 6,
-        RpmSrcDir = 1 << 7,
-        Repomd = 1 << 8,
-        RepomdSrc = 1 << 9
+        Disabled = 1 << 2,
+        Comment = 1 << 3,
     };
 
     struct SourceRecord {

--- a/backends/apt/apt-sourceslist.h
+++ b/backends/apt/apt-sourceslist.h
@@ -102,7 +102,7 @@ public:
     void RemoveSource(SourceRecord *&);
     void SwapSources( SourceRecord *&, SourceRecord *& );
     bool ReadSourceDeb822(string listpath);
-    bool ReadSourceOneLine(string listpath);
+    bool ReadSourceLegacy(string listpath);
     bool ReadSourcePart(string listpath);
     bool ReadSourceDir(string Dir);
     bool ReadSources();

--- a/backends/apt/apt-sourceslist.h
+++ b/backends/apt/apt-sourceslist.h
@@ -90,6 +90,8 @@ private:
                      pkgTagSection &Tags,
                      unsigned int const i,
                      FileFd &Fd);
+    bool UpdateSourceLegacy(const std::string &filename);
+    bool UpdateSourceDeb822(const std::string &filename);
 
 public:
     SourceRecord *AddSource(RecType Type,

--- a/backends/apt/deb822.cpp
+++ b/backends/apt/deb822.cpp
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2024-2025 Matthias Klumpp <matthias@tenstral.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "deb822.h"
+
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <algorithm>
+
+
+Deb822File::Deb822File()
+{
+}
+
+bool Deb822File::isFieldStanza(const Stanza& stanza)
+{
+    return std::any_of(stanza.begin(), stanza.end(),
+                       [](const Line& l) { return l.isField(); });
+}
+
+Deb822File::Line Deb822File::parseDeb822Line(const std::string& line) const
+{
+    Deb822File::Line l;
+    l.content = line;
+
+    // we return empty and comment-lines verbatim
+    if (line.empty() || line[0] == '#')
+        return l;
+
+    if (std::isspace(line[0])) {
+        l.isContinuation = true;
+        return l;
+    }
+
+    const auto colonPos = line.find(':');
+    if (colonPos != std::string::npos && colonPos > 0) {
+        l.key = line.substr(0, colonPos);
+
+        // strip leading space
+        size_t valueStart = colonPos + 1;
+        while (valueStart < line.size() && std::isspace(line[valueStart]))
+            ++valueStart;
+
+        l.value = line.substr(valueStart);
+    }
+
+    return l;
+}
+
+bool Deb822File::loadFromStream(std::istream& stream)
+{
+    m_allStanzas.clear();
+    m_fieldStanzaIndices.clear();
+
+    Stanza stanza;
+    std::string line;
+    Line *lastField = nullptr;
+
+    while (std::getline(stream, line)) {
+        if (line.empty()) {
+            if (!stanza.empty()) {
+                size_t index = m_allStanzas.size();
+                m_allStanzas.push_back(stanza);
+                if (isFieldStanza(stanza)) {
+                    m_fieldStanzaIndices.push_back(index);
+                }
+
+                stanza.clear();
+                lastField = nullptr;
+            }
+            continue;
+        }
+
+        auto parsed = parseDeb822Line(line);
+
+        if (parsed.isContinuation && lastField) {
+            // append to last field value (with newline)
+            lastField->value += "\n" + parsed.content;
+        } else {
+            stanza.push_back(parsed);
+            if (parsed.isField())
+                lastField = &stanza.back();
+            else
+                lastField = nullptr;
+        }
+    }
+
+    if (!stanza.empty()) {
+        size_t index = m_allStanzas.size();
+        m_allStanzas.push_back(stanza);
+        if (isFieldStanza(stanza)) {
+            m_fieldStanzaIndices.push_back(index);
+        }
+    }
+
+    return true;
+}
+
+bool Deb822File::loadFromString(const std::string& content)
+{
+    std::istringstream stream(content);
+    return loadFromStream(stream);
+}
+
+bool Deb822File::load(const std::string& filename)
+{
+    std::ifstream file(filename);
+    if (!file) {
+        m_lastError = "Failed to open file: " + filename;
+        return false;
+    }
+    m_filename = filename;
+
+    return loadFromStream(file);
+}
+
+bool Deb822File::save(const std::string& filename)
+{
+    std::ofstream file(filename);
+    if (!file) {
+        m_lastError = "Failed to write file: " + filename;
+        return false;
+    }
+
+    for (size_t i = 0; i < m_allStanzas.size(); ++i) {
+        for (const auto& line : m_allStanzas[i])
+            file << line.content << "\n";
+
+        if (i + 1 < m_allStanzas.size())
+            file << "\n";
+    }
+
+    return true;
+}
+
+std::string Deb822File::lastError() const
+{
+    return m_lastError;
+}
+
+std::optional<std::string> Deb822File::getFieldValue(size_t stanzaIndex, const std::string& field, std::optional<std::string> defaultValue)
+{
+    if (stanzaIndex >= m_fieldStanzaIndices.size()) {
+        m_lastError = "Stanza index out of range";
+        return std::nullopt;
+    }
+
+    const Stanza& stanza = m_allStanzas[m_fieldStanzaIndices[stanzaIndex]];
+    for (const auto& line : stanza) {
+        if (line.key == field) {
+            return line.value;
+        }
+    }
+
+    return defaultValue;
+}
+
+bool Deb822File::modifyField(size_t stanzaIndex, const std::string& field, const std::string& newValue)
+{
+    if (stanzaIndex >= m_fieldStanzaIndices.size()) {
+        m_lastError = "Stanza index out of range";
+        return false;
+    }
+
+    Stanza& stanza = m_allStanzas[m_fieldStanzaIndices[stanzaIndex]];
+    for (auto it = stanza.begin(); it != stanza.end(); ++it) {
+        if (it->key == field) {
+            auto next = std::next(it);
+            while (next != stanza.end() && next->isContinuation)
+                next = stanza.erase(next);
+
+            it->value = newValue;
+            std::istringstream valstream(newValue);
+            std::string line;
+            std::getline(valstream, line);
+            it->content = field + ": " + line;
+
+            while (std::getline(valstream, line))
+                stanza.insert(next, Line{" " + line, "", "", true});
+
+            return true;
+        }
+    }
+
+    std::istringstream valstream(newValue);
+    std::string line;
+    std::getline(valstream, line);
+    stanza.push_back(Line{field + ": " + line, field, newValue, false});
+    while (std::getline(valstream, line))
+        stanza.push_back(Line{" " + line, "", "", true});
+
+    return true;
+}
+
+size_t Deb822File::stanzaCount() const
+{
+    return m_fieldStanzaIndices.size();
+}
+
+std::string Deb822File::toString() const
+{
+    std::ostringstream out;
+    for (size_t i = 0; i < m_allStanzas.size(); ++i) {
+        for (const auto& line : m_allStanzas[i])
+            out << line.content << "\n";
+
+        if (i + 1 < m_allStanzas.size())
+            out << "\n";
+    }
+
+    return out.str();
+}

--- a/backends/apt/deb822.h
+++ b/backends/apt/deb822.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2024-2025 Matthias Klumpp <matthias@tenstral.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+#include <vector>
+#include <string>
+#include <optional>
+
+/**
+ * Read & write a Deb822 file.
+ * This is the simplest possible parser for Deb822 files.
+ * Unlike pkgTagFile, it retains all comments and allows for
+ * non-destructive editing of Deb822 files.
+ */
+class Deb822File
+{
+public:
+    explicit Deb822File();
+
+    bool load(const std::string& filename);
+    bool loadFromStream(std::istream& stream);
+    bool loadFromString(const std::string& content);
+
+    bool save(const std::string& filename);
+
+    [[nodiscard]] std::string lastError() const;
+
+    [[nodiscard]] size_t stanzaCount() const;
+    [[nodiscard]] std::optional<std::string> getFieldValue(size_t stanzaIndex, const std::string& field,
+                                                           std::optional<std::string> defaultValue = std::nullopt);
+    bool modifyField(size_t stanza_index, const std::string& field, const std::string& newValue);
+
+    std::string toString() const;
+
+private:
+    struct Line {
+        std::string content;
+        std::string key;   /// empty if comment or continuation
+        std::string value; /// only valid if key is non-empty
+
+        bool isContinuation = false;
+        [[nodiscard]] bool isField() const { return !key.empty(); }
+    };
+
+    using Stanza = std::vector<Line>;
+
+    std::string m_filename;
+    std::string m_lastError;
+    std::vector<Stanza> m_allStanzas; // all stanzas, including comment-only ones
+    std::vector<size_t> m_fieldStanzaIndices; // map for stanzas with fields
+
+    static bool isFieldStanza(const Stanza& stanza);
+    Line parseDeb822Line(const std::string& line) const;
+};

--- a/backends/apt/deb822.h
+++ b/backends/apt/deb822.h
@@ -45,7 +45,10 @@ public:
     [[nodiscard]] size_t stanzaCount() const;
     [[nodiscard]] std::optional<std::string> getFieldValue(size_t stanzaIndex, const std::string& field,
                                                            std::optional<std::string> defaultValue = std::nullopt);
-    bool modifyField(size_t stanza_index, const std::string& field, const std::string& newValue);
+    bool updateField(size_t stanza_index, const std::string& field, const std::string& newValue);
+    bool deleteField(size_t stanzaIndex, const std::string& key);
+    bool deleteStanza(size_t index);
+    int duplicateStanza(size_t index);
 
     std::string toString() const;
 

--- a/backends/apt/meson.build
+++ b/backends/apt/meson.build
@@ -44,6 +44,8 @@ packagekit_backend_apt_module = shared_library(
   'apt-sourceslist.h',
   'apt-utils.cpp',
   'apt-utils.h',
+  'deb822.cpp',
+  'deb822.h',
   'deb-file.cpp',
   'deb-file.h',
   'gst-matcher.cpp',

--- a/backends/apt/pk-backend-apt.cpp
+++ b/backends/apt/pk-backend-apt.cpp
@@ -2,7 +2,8 @@
  *
  * Copyright (C) 2007-2008 Richard Hughes <richard@hughsie.com>
  * Copyright (C) 2009-2016 Daniel Nicoletti <dantti12@gmail.com>
- *               2016 Harald Sitter <sitter@kde.org>
+ * Copyright (C) 2016 Harald Sitter <sitter@kde.org>
+ * Copyright (C) 2018-2025 Matthias Klumpp <matthias@tenstral.net>
  *
  * Licensed under the GNU General Public License Version 2
  *
@@ -911,10 +912,7 @@ static void backend_repo_manager_thread(PkBackendJob *job, GVariant *params, gpo
 
         if (role == PK_ROLE_ENUM_GET_REPO_LIST) {
             if (pk_bitfield_contain(filters, PK_FILTER_ENUM_NOT_DEVELOPMENT) &&
-                    (souceRecord->Type & SourcesList::DebSrc ||
-                     souceRecord->Type & SourcesList::RpmSrc ||
-                     souceRecord->Type & SourcesList::RpmSrcDir ||
-                     souceRecord->Type & SourcesList::RepomdSrc)) {
+                    (souceRecord->Type & SourcesList::DebSrc)) {
                 continue;
             }
 

--- a/backends/apt/pk-backend-apt.cpp
+++ b/backends/apt/pk-backend-apt.cpp
@@ -900,35 +900,35 @@ static void backend_repo_manager_thread(PkBackendJob *job, GVariant *params, gpo
         return;
     }
 
-    for (SourcesList::SourceRecord *souceRecord : sourcesList.SourceRecords) {
+    for (SourcesList::SourceRecord *sourceRecord : sourcesList.SourceRecords) {
 
-        if (souceRecord->Type & SourcesList::Comment) {
+        if (sourceRecord->Type & SourcesList::Comment) {
             continue;
         }
 
-        string sections = souceRecord->joinedSections();
+        string sections = sourceRecord->joinedSections();
 
-        string repoId = souceRecord->repoId();
+        string repoId = sourceRecord->repoId();
 
         if (role == PK_ROLE_ENUM_GET_REPO_LIST) {
             if (pk_bitfield_contain(filters, PK_FILTER_ENUM_NOT_DEVELOPMENT) &&
-                    (souceRecord->Type & SourcesList::DebSrc)) {
+                    (sourceRecord->Type & SourcesList::DebSrc)) {
                 continue;
             }
 
             pk_backend_job_repo_detail(job,
                                        repoId.c_str(),
-                                       souceRecord->niceName().c_str(),
-                                       !(souceRecord->Type & SourcesList::Disabled));
+                                       sourceRecord->niceName().c_str(),
+                                       !(sourceRecord->Type & SourcesList::Disabled));
         } else if (repoId.compare(repo_id) == 0) {
             // Found the repo to enable/disable
             found = true;
 
             if (role == PK_ROLE_ENUM_REPO_ENABLE) {
                 if (enabled) {
-                    souceRecord->Type = souceRecord->Type & ~SourcesList::Disabled;
+                    sourceRecord->Type = sourceRecord->Type & ~SourcesList::Disabled;
                 } else {
-                    souceRecord->Type |= SourcesList::Disabled;
+                    sourceRecord->Type |= SourcesList::Disabled;
                 }
 
                 // Commit changes
@@ -944,7 +944,7 @@ static void backend_repo_manager_thread(PkBackendJob *job, GVariant *params, gpo
                         return;
                     }
 
-                    PkgList removePkgs = apt->getPackagesFromRepo(souceRecord);
+                    PkgList removePkgs = apt->getPackagesFromRepo(sourceRecord);
                     if (removePkgs.size() > 0) {
                         // Install/Update/Remove packages, or just simulate
                         bool ret;
@@ -964,7 +964,7 @@ static void backend_repo_manager_thread(PkBackendJob *job, GVariant *params, gpo
 
                 // Now if we are not simulating remove the repository
                 if (!pk_bitfield_contain(transaction_flags, PK_TRANSACTION_FLAG_ENUM_SIMULATE)) {
-                    sourcesList.RemoveSource(souceRecord);
+                    sourcesList.RemoveSource(sourceRecord);
 
                     // Commit changes
                     if (!sourcesList.UpdateSources()) {

--- a/backends/apt/tests/meson.build
+++ b/backends/apt/tests/meson.build
@@ -1,4 +1,7 @@
-apt_tests = executable(
+
+apt_test_data_dir = meson.current_source_dir() / 'testdata'
+
+apt_tests_exe = executable(
   'apt-tests',
   'apt-tests.cpp',
   'definitions.cpp',
@@ -12,6 +15,7 @@ apt_tests = executable(
   dependencies: [
     packagekit_glib2_dep,
     gstreamer_dep,
+    apt_pkg_dep,
   ],
   build_by_default: true,
   install: false,
@@ -19,5 +23,6 @@ apt_tests = executable(
 
 test(
   'apt-backend-tests',
-  apt_tests
+  apt_tests_exe,
+  args: [apt_test_data_dir],
 )

--- a/backends/apt/tests/testdata/sources/debian.sources
+++ b/backends/apt/tests/testdata/sources/debian.sources
@@ -4,6 +4,7 @@ Suites: testing
 Components: main contrib non-free-firmware non-free
 Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
 
+# I am a comment!
 Types: deb
 URIs: http://deb.debian.org/debian/
 Suites: experimental

--- a/backends/apt/tests/testdata/sources/debian.sources
+++ b/backends/apt/tests/testdata/sources/debian.sources
@@ -1,0 +1,12 @@
+Types: deb deb-src
+URIs: http://deb.debian.org/debian/
+Suites: testing
+Components: main contrib non-free-firmware non-free
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+
+Types: deb
+URIs: http://deb.debian.org/debian/
+Suites: experimental
+Components: main contrib non-free
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+Enabled: false

--- a/backends/apt/tests/testdata/sources/debian.sources
+++ b/backends/apt/tests/testdata/sources/debian.sources
@@ -4,10 +4,14 @@ Suites: testing
 Components: main contrib non-free-firmware non-free
 Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
 
+#
+# Just a comment block
+#
+
 # I am a comment!
 Types: deb
 URIs: http://deb.debian.org/debian/
 Suites: experimental
 Components: main contrib non-free
 Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
-Enabled: false
+Enabled: no

--- a/backends/apt/tests/testdata/sources/ignorethis.list.save
+++ b/backends/apt/tests/testdata/sources/ignorethis.list.save
@@ -1,0 +1,1 @@
+deb https://example.org/apt/ invalid main

--- a/backends/apt/tests/testdata/sources/mozilla.list
+++ b/backends/apt/tests/testdata/sources/mozilla.list
@@ -1,0 +1,3 @@
+deb [signed-by=/etc/apt/keyrings/packages.mozilla.org.asc] https://packages.mozilla.org/apt/ mozilla main 
+
+#deb [signed-by=/etc/apt/keyrings/packages.mozilla.org.asc] https://packages.mozilla.org/apt/ mozilla-disabled main


### PR DESCRIPTION
Honestly, the entire APT sources handling needs a full rewrite, and I was *so* close to doing it. Adding deb822 sources to the existing data model is like cramming a square piece into a smaller round hole.

This will work though, and hopefully when at some point we can drop support for legacy sources, all of this can be rewritten properly.
For now, keeping the old code working, and the old data model somewhat intact (which answers the not-so-simple "what even is a repository?" question for us...) was likely the right way to go.

When rewriting sources files, the code tries to be as non-destructive as possible, keeping comments etc. intact.
