### PR TITLE
pk-control: Use g_debug() rather than g_warning() for proxy error

### DIFF
--- a/lib/packagekit-glib2/pk-control.c
+++ b/lib/packagekit-glib2/pk-control.c
@@ -879,7 +879,7 @@ pk_control_set_proxy_cb (GObject *source_object,
 	/* get the result */
 	value = g_dbus_proxy_call_finish (proxy, res, &error);
 	if (value == NULL) {
-		g_warning ("failed to set proxy: %s", error->message);
+		g_debug ("Failed to set proxy: %s", error->message);
 		g_task_return_error (task, g_steal_pointer (&error));
 		return;
 	}


### PR DESCRIPTION
The error is already propgated programmatically as a `GError`, which allows the caller to handle it as they see fit.

Additionally printing a warning message slightly undermines the caller’s ability to ignore errors here, as it will cause an abort if running with `G_DEBUG=fatal-warnings` (for example).

This is causing problems when running PackageKit in gnome-software’s CI, which doesn’t support proxy settings (as no logind session is running) — the tests are run with `G_DEBUG=fatal-warnings`, and this warning then becomes fatal.