### PR TITLE
meson: Refine GLib requirement definition

### DIFF
--- a/lib/packagekit-glib2/pk-client-helper.c
+++ b/lib/packagekit-glib2/pk-client-helper.c
@@ -56,8 +56,6 @@
 
 static void     pk_client_helper_finalize	(GObject     *object);
 
-#define PK_CLIENT_HELPER_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), PK_TYPE_CLIENT_HELPER, PkClientHelperPrivate))
-
 /**
  * PkClientHelperPrivate:
  *
@@ -89,7 +87,7 @@ typedef struct
 	GSource				*stderr_channel_source;
 } PkClientHelperChild;
 
-G_DEFINE_TYPE (PkClientHelper, pk_client_helper, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_PRIVATE (PkClientHelper, pk_client_helper, G_TYPE_OBJECT)
 
 static void
 pk_client_helper_child_free (PkClientHelperChild *child)
@@ -135,12 +133,10 @@ pk_client_helper_child_free (PkClientHelperChild *child)
 gboolean
 pk_client_helper_stop (PkClientHelper *client_helper, GError **error)
 {
-	PkClientHelperPrivate *priv = NULL;
+	PkClientHelperPrivate *priv = pk_client_helper_get_instance_private (client_helper);
 
 	g_return_val_if_fail (PK_IS_CLIENT_HELPER (client_helper), FALSE);
 	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
-
-	priv = client_helper->priv;
 
 	/* make sure started */
 	g_return_val_if_fail (priv->socket_file != NULL, FALSE);
@@ -251,6 +247,7 @@ pk_client_helper_echo_stderr_cb (GIOChannel *source, GIOCondition condition, PkC
 static gboolean
 pk_client_helper_copy_conn_cb (GIOChannel *source, GIOCondition condition, PkClientHelperChild *child)
 {
+	PkClientHelperPrivate *helper_priv = pk_client_helper_get_instance_private (child->helper);
 	gchar data[1024];
 	gsize len = 0;
 	GIOStatus status;
@@ -286,7 +283,7 @@ pk_client_helper_copy_conn_cb (GIOChannel *source, GIOCondition condition, PkCli
 			   "only wrote %" G_GSIZE_FORMAT " bytes", len, written);
 		return G_SOURCE_REMOVE;
 	}
-	g_debug ("wrote %" G_GSIZE_FORMAT " bytes to stdin of %s", written, child->helper->priv->argv[0]);
+	g_debug ("wrote %" G_GSIZE_FORMAT " bytes to stdin of %s", written, helper_priv->argv[0]);
 
 	return G_SOURCE_CONTINUE;
 }
@@ -314,7 +311,7 @@ make_input_source (GIOChannel *channel, GSourceFunc func, gpointer user_data)
 static gboolean
 pk_client_helper_accept_connection_cb (GIOChannel *source, GIOCondition condition, PkClientHelper *client_helper)
 {
-	PkClientHelperPrivate *priv = client_helper->priv;
+	PkClientHelperPrivate *priv = pk_client_helper_get_instance_private (client_helper);
 	g_autoptr(GSocket) socket = NULL;
 	GPid pid;
 	gint standard_input = 0;
@@ -420,7 +417,7 @@ pk_client_helper_start (PkClientHelper *client_helper,
 {
 	guint i;
 	gboolean use_kde_helper = FALSE;
-	PkClientHelperPrivate *priv = NULL;
+	PkClientHelperPrivate *priv = pk_client_helper_get_instance_private (client_helper);
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(GSocketAddress) address = NULL;
 
@@ -429,8 +426,6 @@ pk_client_helper_start (PkClientHelper *client_helper,
 	g_return_val_if_fail (argv != NULL, FALSE);
 	g_return_val_if_fail (socket_filename != NULL, FALSE);
 	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
-
-	priv = client_helper->priv;
 
 	/* make sure not been started before */
 	g_return_val_if_fail (priv->argv == NULL, FALSE);
@@ -512,7 +507,7 @@ pk_client_helper_start_with_socket (PkClientHelper *client_helper,
 				    GError **error)
 {
 	gint fd;
-	PkClientHelperPrivate *priv = NULL;
+	PkClientHelperPrivate *priv = pk_client_helper_get_instance_private (client_helper);
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(GSocketAddress) address = NULL;
 
@@ -520,8 +515,6 @@ pk_client_helper_start_with_socket (PkClientHelper *client_helper,
 	g_return_val_if_fail (socket != NULL, FALSE);
 	g_return_val_if_fail (argv != NULL, FALSE);
 	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
-
-	priv = client_helper->priv;
 
 	/* make sure not been started before */
 	g_return_val_if_fail (priv->argv == NULL, FALSE);
@@ -553,11 +546,9 @@ pk_client_helper_start_with_socket (PkClientHelper *client_helper,
 gboolean
 pk_client_helper_is_active (PkClientHelper *client_helper)
 {
-	PkClientHelperPrivate *priv;
+	PkClientHelperPrivate *priv = pk_client_helper_get_instance_private (client_helper);
 
 	g_return_val_if_fail (PK_IS_CLIENT_HELPER (client_helper), FALSE);
-
-	priv = client_helper->priv;
 
 	for (guint i = 0; i < priv->children->len; i++) {
 		PkClientHelperChild *child = g_ptr_array_index (priv->children, i);
@@ -577,7 +568,6 @@ pk_client_helper_class_init (PkClientHelperClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS (klass);
 	object_class->finalize = pk_client_helper_finalize;
-	g_type_class_add_private (klass, sizeof (PkClientHelperPrivate));
 }
 
 /*
@@ -586,8 +576,10 @@ pk_client_helper_class_init (PkClientHelperClass *klass)
 static void
 pk_client_helper_init (PkClientHelper *client_helper)
 {
-	client_helper->priv = PK_CLIENT_HELPER_GET_PRIVATE (client_helper);
-	client_helper->priv->children = g_ptr_array_new_with_free_func ((GDestroyNotify) pk_client_helper_child_free);
+	PkClientHelperPrivate *priv = pk_client_helper_get_instance_private (client_helper);
+
+	client_helper->priv = priv;
+	priv->children = g_ptr_array_new_with_free_func ((GDestroyNotify) pk_client_helper_child_free);
 }
 
 /*
@@ -597,26 +589,25 @@ static void
 pk_client_helper_finalize (GObject *object)
 {
 	PkClientHelper *client_helper = PK_CLIENT_HELPER (object);
-	PkClientHelperPrivate *priv = client_helper->priv;
+	PkClientHelperPrivate *priv = pk_client_helper_get_instance_private (client_helper);
 
 	if (priv->socket_channel_source != NULL) {
 		g_source_destroy (priv->socket_channel_source);
-		g_source_unref (priv->socket_channel_source);
+		g_clear_pointer (&priv->socket_channel_source, g_source_unref);
 	}
 
-	g_strfreev (priv->argv);
-	g_strfreev (priv->envp);
+	g_clear_pointer (&priv->argv, g_strfreev);
+	g_clear_pointer (&priv->envp, g_strfreev);
 	if (priv->socket_file != NULL) {
 		g_file_delete (priv->socket_file, NULL, NULL);
-		g_object_unref (priv->socket_file);
+		g_clear_object (&priv->socket_file);
 	}
 	if (priv->socket != NULL) {
 		g_socket_close (priv->socket, NULL);
-		g_object_unref (priv->socket);
+		g_clear_object (&priv->socket);
 	}
-	if (priv->socket_channel != NULL)
-		g_io_channel_unref (priv->socket_channel);
-	g_ptr_array_unref (priv->children);
+	g_clear_pointer (&priv->socket_channel, g_io_channel_unref);
+	g_clear_pointer (&priv->children, g_ptr_array_unref);
 	if (priv->kde_helper_pid > 0)
 		kill (priv->kde_helper_pid, SIGQUIT);
 

--- a/lib/packagekit-glib2/pk-desktop.c
+++ b/lib/packagekit-glib2/pk-desktop.c
@@ -32,20 +32,6 @@
 #include <glib.h>
 #include <packagekit-glib2/pk-desktop.h>
 
-static void     pk_desktop_finalize	(GObject        *object);
-
-#define PK_DESKTOP_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), PK_TYPE_DESKTOP, PkDesktopPrivate))
-
-/**
- * PkDesktopPrivate:
- *
- * Private #PkDesktop data
- **/
-struct _PkDesktopPrivate
-{
-	gpointer		 dummy;
-};
-
 G_DEFINE_TYPE (PkDesktop, pk_desktop, G_TYPE_OBJECT)
 static gpointer pk_desktop_object = NULL;
 
@@ -141,9 +127,6 @@ pk_desktop_open_database (PkDesktop *desktop, GError **error)
 static void
 pk_desktop_class_init (PkDesktopClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS (klass);
-	object_class->finalize = pk_desktop_finalize;
-	g_type_class_add_private (klass, sizeof (PkDesktopPrivate));
 }
 
 /*
@@ -152,18 +135,7 @@ pk_desktop_class_init (PkDesktopClass *klass)
 static void
 pk_desktop_init (PkDesktop *desktop)
 {
-	desktop->priv = PK_DESKTOP_GET_PRIVATE (desktop);
-}
-
-/*
- * pk_desktop_finalize:
- **/
-static void
-pk_desktop_finalize (GObject *object)
-{
-	g_return_if_fail (object != NULL);
-	g_return_if_fail (PK_IS_DESKTOP (object));
-	G_OBJECT_CLASS (pk_desktop_parent_class)->finalize (object);
+	desktop->priv = NULL;
 }
 
 /**

--- a/lib/packagekit-glib2/pk-details.c
+++ b/lib/packagekit-glib2/pk-details.c
@@ -37,8 +37,6 @@
 
 static void     pk_details_finalize	(GObject     *object);
 
-#define PK_DETAILS_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), PK_TYPE_DETAILS, PkDetailsPrivate))
-
 /**
  * PkDetailsPrivate:
  *
@@ -69,7 +67,7 @@ enum {
 	PROP_LAST
 };
 
-G_DEFINE_TYPE (PkDetails, pk_details, PK_TYPE_SOURCE)
+G_DEFINE_TYPE_WITH_PRIVATE (PkDetails, pk_details, PK_TYPE_SOURCE)
 
 /**
  * pk_details_get_package_id:
@@ -84,8 +82,11 @@ G_DEFINE_TYPE (PkDetails, pk_details, PK_TYPE_SOURCE)
 const gchar *
 pk_details_get_package_id (PkDetails *details)
 {
+	PkDetailsPrivate *priv = pk_details_get_instance_private (details);
+
 	g_return_val_if_fail (details != NULL, NULL);
-	return details->priv->package_id;
+
+	return priv->package_id;
 }
 
 /**
@@ -101,8 +102,11 @@ pk_details_get_package_id (PkDetails *details)
 const gchar *
 pk_details_get_license (PkDetails *details)
 {
+	PkDetailsPrivate *priv = pk_details_get_instance_private (details);
+
 	g_return_val_if_fail (details != NULL, NULL);
-	return details->priv->license;
+
+	return priv->license;
 }
 
 /**
@@ -118,8 +122,11 @@ pk_details_get_license (PkDetails *details)
 PkGroupEnum
 pk_details_get_group (PkDetails *details)
 {
+	PkDetailsPrivate *priv = pk_details_get_instance_private (details);
+
 	g_return_val_if_fail (details != NULL, PK_GROUP_ENUM_UNKNOWN);
-	return details->priv->group;
+
+	return priv->group;
 }
 
 /**
@@ -135,8 +142,11 @@ pk_details_get_group (PkDetails *details)
 const gchar *
 pk_details_get_description (PkDetails *details)
 {
+	PkDetailsPrivate *priv = pk_details_get_instance_private (details);
+
 	g_return_val_if_fail (details != NULL, NULL);
-	return details->priv->description;
+
+	return priv->description;
 }
 
 /**
@@ -152,8 +162,11 @@ pk_details_get_description (PkDetails *details)
 const gchar *
 pk_details_get_url (PkDetails *details)
 {
+	PkDetailsPrivate *priv = pk_details_get_instance_private (details);
+
 	g_return_val_if_fail (details != NULL, NULL);
-	return details->priv->url;
+
+	return priv->url;
 }
 
 /**
@@ -169,8 +182,11 @@ pk_details_get_url (PkDetails *details)
 const gchar *
 pk_details_get_summary (PkDetails *details)
 {
+	PkDetailsPrivate *priv = pk_details_get_instance_private (details);
+
 	g_return_val_if_fail (details != NULL, NULL);
-	return details->priv->summary;
+
+	return priv->summary;
 }
 
 /**
@@ -187,8 +203,11 @@ pk_details_get_summary (PkDetails *details)
 guint64
 pk_details_get_size (PkDetails *details)
 {
+	PkDetailsPrivate *priv = pk_details_get_instance_private (details);
+
 	g_return_val_if_fail (details != NULL, G_MAXUINT64);
-	return details->priv->size;
+
+	return priv->size;
 }
 
 /**
@@ -204,8 +223,11 @@ pk_details_get_size (PkDetails *details)
 guint64
 pk_details_get_download_size (PkDetails *details)
 {
+	PkDetailsPrivate *priv = pk_details_get_instance_private (details);
+
 	g_return_val_if_fail (details != NULL, G_MAXUINT64);
-	return details->priv->download_size;
+
+	return priv->download_size;
 }
 
 /*
@@ -215,7 +237,7 @@ static void
 pk_details_get_property (GObject *object, guint prop_id, GValue *value, GParamSpec *pspec)
 {
 	PkDetails *details = PK_DETAILS (object);
-	PkDetailsPrivate *priv = details->priv;
+	PkDetailsPrivate *priv = pk_details_get_instance_private (details);
 
 	switch (prop_id) {
 	case PROP_PACKAGE_ID:
@@ -255,7 +277,7 @@ static void
 pk_details_set_property (GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec)
 {
 	PkDetails *details = PK_DETAILS (object);
-	PkDetailsPrivate *priv = details->priv;
+	PkDetailsPrivate *priv = pk_details_get_instance_private (details);
 
 	switch (prop_id) {
 	case PROP_PACKAGE_ID:
@@ -384,8 +406,6 @@ pk_details_class_init (PkDetailsClass *klass)
 				     0, G_MAXUINT64, G_MAXUINT64,
 				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_DOWNLOAD_SIZE, pspec);
-
-	g_type_class_add_private (klass, sizeof (PkDetailsPrivate));
 }
 
 /*
@@ -394,8 +414,10 @@ pk_details_class_init (PkDetailsClass *klass)
 static void
 pk_details_init (PkDetails *details)
 {
-	details->priv = PK_DETAILS_GET_PRIVATE (details);
-	details->priv->download_size = G_MAXUINT64;
+	PkDetailsPrivate *priv = pk_details_get_instance_private (details);
+
+	details->priv = priv;
+	priv->download_size = G_MAXUINT64;
 }
 
 /*
@@ -405,13 +427,13 @@ static void
 pk_details_finalize (GObject *object)
 {
 	PkDetails *details = PK_DETAILS (object);
-	PkDetailsPrivate *priv = details->priv;
+	PkDetailsPrivate *priv = pk_details_get_instance_private (details);
 
-	g_free (priv->package_id);
-	g_free (priv->license);
-	g_free (priv->description);
-	g_free (priv->url);
-	g_free (priv->summary);
+	g_clear_pointer (&priv->package_id, g_free);
+	g_clear_pointer (&priv->license, g_free);
+	g_clear_pointer (&priv->description, g_free);
+	g_clear_pointer (&priv->url, g_free);
+	g_clear_pointer (&priv->summary, g_free);
 
 	G_OBJECT_CLASS (pk_details_parent_class)->finalize (object);
 }

--- a/lib/packagekit-glib2/pk-distro-upgrade.c
+++ b/lib/packagekit-glib2/pk-distro-upgrade.c
@@ -38,8 +38,6 @@
 
 static void     pk_distro_upgrade_finalize	(GObject     *object);
 
-#define PK_DISTRO_UPGRADE_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), PK_TYPE_DISTRO_UPGRADE, PkDistroUpgradePrivate))
-
 /**
  * PkDistroUpgradePrivate:
  *
@@ -60,7 +58,7 @@ enum {
 	PROP_LAST
 };
 
-G_DEFINE_TYPE (PkDistroUpgrade, pk_distro_upgrade, PK_TYPE_SOURCE)
+G_DEFINE_TYPE_WITH_PRIVATE (PkDistroUpgrade, pk_distro_upgrade, PK_TYPE_SOURCE)
 
 /**
  * pk_distro_upgrade_get_id:
@@ -76,8 +74,11 @@ G_DEFINE_TYPE (PkDistroUpgrade, pk_distro_upgrade, PK_TYPE_SOURCE)
 const gchar *
 pk_distro_upgrade_get_id (PkDistroUpgrade *distro_upgrade)
 {
+	PkDistroUpgradePrivate *priv = pk_distro_upgrade_get_instance_private (distro_upgrade);
+
 	g_return_val_if_fail (PK_IS_DISTRO_UPGRADE (distro_upgrade), NULL);
-	return distro_upgrade->priv->name;
+
+	return priv->name;
 }
 
 /**
@@ -93,8 +94,11 @@ pk_distro_upgrade_get_id (PkDistroUpgrade *distro_upgrade)
 const gchar *
 pk_distro_upgrade_get_summary (PkDistroUpgrade *distro_upgrade)
 {
+	PkDistroUpgradePrivate *priv = pk_distro_upgrade_get_instance_private (distro_upgrade);
+
 	g_return_val_if_fail (PK_IS_DISTRO_UPGRADE (distro_upgrade), NULL);
-	return distro_upgrade->priv->summary;
+
+	return priv->summary;
 }
 
 /**
@@ -110,8 +114,11 @@ pk_distro_upgrade_get_summary (PkDistroUpgrade *distro_upgrade)
 PkDistroUpgradeEnum
 pk_distro_upgrade_get_state (PkDistroUpgrade *distro_upgrade)
 {
+	PkDistroUpgradePrivate *priv = pk_distro_upgrade_get_instance_private (distro_upgrade);
+
 	g_return_val_if_fail (PK_IS_DISTRO_UPGRADE (distro_upgrade), PK_DISTRO_UPGRADE_ENUM_UNKNOWN);
-	return distro_upgrade->priv->state;
+
+	return priv->state;
 }
 
 
@@ -122,7 +129,7 @@ static void
 pk_distro_upgrade_get_property (GObject *object, guint prop_id, GValue *value, GParamSpec *pspec)
 {
 	PkDistroUpgrade *distro_upgrade = PK_DISTRO_UPGRADE (object);
-	PkDistroUpgradePrivate *priv = distro_upgrade->priv;
+	PkDistroUpgradePrivate *priv = pk_distro_upgrade_get_instance_private (distro_upgrade);
 
 	switch (prop_id) {
 	case PROP_STATE:
@@ -147,7 +154,7 @@ static void
 pk_distro_upgrade_set_property (GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec)
 {
 	PkDistroUpgrade *distro_upgrade = PK_DISTRO_UPGRADE (object);
-	PkDistroUpgradePrivate *priv = distro_upgrade->priv;
+	PkDistroUpgradePrivate *priv = pk_distro_upgrade_get_instance_private (distro_upgrade);
 
 	switch (prop_id) {
 	case PROP_STATE:
@@ -155,11 +162,11 @@ pk_distro_upgrade_set_property (GObject *object, guint prop_id, const GValue *va
 		break;
 	case PROP_NAME:
 		g_free (priv->name);
-		priv->name = g_strdup (g_value_get_string (value));
+		priv->name = g_value_dup_string (value);
 		break;
 	case PROP_SUMMARY:
 		g_free (priv->summary);
-		priv->summary = g_strdup (g_value_get_string (value));
+		priv->summary = g_value_dup_string (value);
 		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -208,8 +215,6 @@ pk_distro_upgrade_class_init (PkDistroUpgradeClass *klass)
 				     NULL,
 				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_SUMMARY, pspec);
-
-	g_type_class_add_private (klass, sizeof (PkDistroUpgradePrivate));
 }
 
 /*
@@ -218,7 +223,7 @@ pk_distro_upgrade_class_init (PkDistroUpgradeClass *klass)
 static void
 pk_distro_upgrade_init (PkDistroUpgrade *distro_upgrade)
 {
-	distro_upgrade->priv = PK_DISTRO_UPGRADE_GET_PRIVATE (distro_upgrade);
+	distro_upgrade->priv = pk_distro_upgrade_get_instance_private (distro_upgrade);
 }
 
 /*
@@ -228,10 +233,10 @@ static void
 pk_distro_upgrade_finalize (GObject *object)
 {
 	PkDistroUpgrade *distro_upgrade = PK_DISTRO_UPGRADE (object);
-	PkDistroUpgradePrivate *priv = distro_upgrade->priv;
+	PkDistroUpgradePrivate *priv = pk_distro_upgrade_get_instance_private (distro_upgrade);
 
-	g_free (priv->name);
-	g_free (priv->summary);
+	g_clear_pointer (&priv->name, g_free);
+	g_clear_pointer (&priv->summary, g_free);
 
 	G_OBJECT_CLASS (pk_distro_upgrade_parent_class)->finalize (object);
 }

--- a/lib/packagekit-glib2/pk-eula-required.c
+++ b/lib/packagekit-glib2/pk-eula-required.c
@@ -36,8 +36,6 @@
 
 static void     pk_eula_required_finalize	(GObject     *object);
 
-#define PK_EULA_REQUIRED_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), PK_TYPE_EULA_REQUIRED, PkEulaRequiredPrivate))
-
 /**
  * PkEulaRequiredPrivate:
  *
@@ -60,7 +58,7 @@ enum {
 	PROP_LAST
 };
 
-G_DEFINE_TYPE (PkEulaRequired, pk_eula_required, PK_TYPE_SOURCE)
+G_DEFINE_TYPE_WITH_PRIVATE (PkEulaRequired, pk_eula_required, PK_TYPE_SOURCE)
 
 /**
  * pk_eula_required_get_eula_id:
@@ -75,8 +73,11 @@ G_DEFINE_TYPE (PkEulaRequired, pk_eula_required, PK_TYPE_SOURCE)
 const gchar *
 pk_eula_required_get_eula_id (PkEulaRequired *eula_required)
 {
+	PkEulaRequiredPrivate *priv = pk_eula_required_get_instance_private (eula_required);
+
 	g_return_val_if_fail (PK_IS_EULA_REQUIRED (eula_required), NULL);
-	return eula_required->priv->eula_id;
+
+	return priv->eula_id;
 }
 
 /**
@@ -92,8 +93,11 @@ pk_eula_required_get_eula_id (PkEulaRequired *eula_required)
 const gchar *
 pk_eula_required_get_package_id (PkEulaRequired *eula_required)
 {
+	PkEulaRequiredPrivate *priv = pk_eula_required_get_instance_private (eula_required);
+
 	g_return_val_if_fail (PK_IS_EULA_REQUIRED (eula_required), NULL);
-	return eula_required->priv->package_id;
+
+	return priv->package_id;
 }
 
 /**
@@ -109,8 +113,11 @@ pk_eula_required_get_package_id (PkEulaRequired *eula_required)
 const gchar *
 pk_eula_required_get_vendor_name (PkEulaRequired *eula_required)
 {
+	PkEulaRequiredPrivate *priv = pk_eula_required_get_instance_private (eula_required);
+
 	g_return_val_if_fail (PK_IS_EULA_REQUIRED (eula_required), NULL);
-	return eula_required->priv->vendor_name;
+
+	return priv->vendor_name;
 }
 
 /**
@@ -126,8 +133,11 @@ pk_eula_required_get_vendor_name (PkEulaRequired *eula_required)
 const gchar *
 pk_eula_required_get_license_agreement (PkEulaRequired *eula_required)
 {
+	PkEulaRequiredPrivate *priv = pk_eula_required_get_instance_private (eula_required);
+
 	g_return_val_if_fail (PK_IS_EULA_REQUIRED (eula_required), NULL);
-	return eula_required->priv->license_agreement;
+
+	return priv->license_agreement;
 }
 
 /*
@@ -137,7 +147,7 @@ static void
 pk_eula_required_get_property (GObject *object, guint prop_id, GValue *value, GParamSpec *pspec)
 {
 	PkEulaRequired *eula_required = PK_EULA_REQUIRED (object);
-	PkEulaRequiredPrivate *priv = eula_required->priv;
+	PkEulaRequiredPrivate *priv = pk_eula_required_get_instance_private (eula_required);
 
 	switch (prop_id) {
 	case PROP_EULA_ID:
@@ -165,24 +175,24 @@ static void
 pk_eula_required_set_property (GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec)
 {
 	PkEulaRequired *eula_required = PK_EULA_REQUIRED (object);
-	PkEulaRequiredPrivate *priv = eula_required->priv;
+	PkEulaRequiredPrivate *priv = pk_eula_required_get_instance_private (eula_required);
 
 	switch (prop_id) {
 	case PROP_EULA_ID:
 		g_free (priv->eula_id);
-		priv->eula_id = g_strdup (g_value_get_string (value));
+		priv->eula_id = g_value_dup_string (value);
 		break;
 	case PROP_PACKAGE_ID:
 		g_free (priv->package_id);
-		priv->package_id = g_strdup (g_value_get_string (value));
+		priv->package_id = g_value_dup_string (value);
 		break;
 	case PROP_VENDOR_NAME:
 		g_free (priv->vendor_name);
-		priv->vendor_name = g_strdup (g_value_get_string (value));
+		priv->vendor_name = g_value_dup_string (value);
 		break;
 	case PROP_LICENSE_AGREEMENT:
 		g_free (priv->license_agreement);
-		priv->license_agreement = g_strdup (g_value_get_string (value));
+		priv->license_agreement = g_value_dup_string (value);
 		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -249,8 +259,6 @@ pk_eula_required_class_init (PkEulaRequiredClass *klass)
 				     NULL,
 				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_LICENSE_AGREEMENT, pspec);
-
-	g_type_class_add_private (klass, sizeof (PkEulaRequiredPrivate));
 }
 
 /*
@@ -259,7 +267,7 @@ pk_eula_required_class_init (PkEulaRequiredClass *klass)
 static void
 pk_eula_required_init (PkEulaRequired *eula_required)
 {
-	eula_required->priv = PK_EULA_REQUIRED_GET_PRIVATE (eula_required);
+	eula_required->priv = pk_eula_required_get_instance_private (eula_required);
 }
 
 /*
@@ -269,12 +277,12 @@ static void
 pk_eula_required_finalize (GObject *object)
 {
 	PkEulaRequired *eula_required = PK_EULA_REQUIRED (object);
-	PkEulaRequiredPrivate *priv = eula_required->priv;
+	PkEulaRequiredPrivate *priv = pk_eula_required_get_instance_private (eula_required);
 
-	g_free (priv->eula_id);
-	g_free (priv->package_id);
-	g_free (priv->vendor_name);
-	g_free (priv->license_agreement);
+	g_clear_pointer (&priv->eula_id, g_free);
+	g_clear_pointer (&priv->package_id, g_free);
+	g_clear_pointer (&priv->vendor_name, g_free);
+	g_clear_pointer (&priv->license_agreement, g_free);
 
 	G_OBJECT_CLASS (pk_eula_required_parent_class)->finalize (object);
 }

--- a/lib/packagekit-glib2/pk-item-progress.c
+++ b/lib/packagekit-glib2/pk-item-progress.c
@@ -37,8 +37,6 @@
 
 static void     pk_item_progress_finalize	(GObject     *object);
 
-#define PK_ITEM_PROGRESS_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), PK_TYPE_ITEM_PROGRESS, PkItemProgressPrivate))
-
 /**
  * PkItemProgressPrivate:
  *
@@ -59,7 +57,7 @@ enum {
 	PROP_LAST
 };
 
-G_DEFINE_TYPE (PkItemProgress, pk_item_progress, PK_TYPE_SOURCE)
+G_DEFINE_TYPE_WITH_PRIVATE (PkItemProgress, pk_item_progress, PK_TYPE_SOURCE)
 
 /**
  * pk_item_progress_get_status:
@@ -72,7 +70,11 @@ G_DEFINE_TYPE (PkItemProgress, pk_item_progress, PK_TYPE_SOURCE)
 PkStatusEnum
 pk_item_progress_get_status (PkItemProgress *item_progress)
 {
-	return item_progress->priv->status;
+	PkItemProgressPrivate *priv = pk_item_progress_get_instance_private (item_progress);
+
+	g_return_val_if_fail (PK_IS_ITEM_PROGRESS (item_progress), PK_STATUS_ENUM_UNKNOWN);
+
+	return priv->status;
 }
 
 /**
@@ -86,7 +88,11 @@ pk_item_progress_get_status (PkItemProgress *item_progress)
 guint
 pk_item_progress_get_percentage (PkItemProgress *item_progress)
 {
-	return item_progress->priv->percentage;
+	PkItemProgressPrivate *priv = pk_item_progress_get_instance_private (item_progress);
+
+	g_return_val_if_fail (PK_IS_ITEM_PROGRESS (item_progress), 0);
+
+	return priv->percentage;
 }
 
 /**
@@ -100,7 +106,11 @@ pk_item_progress_get_percentage (PkItemProgress *item_progress)
 const gchar *
 pk_item_progress_get_package_id (PkItemProgress *item_progress)
 {
-	return item_progress->priv->package_id;
+	PkItemProgressPrivate *priv = pk_item_progress_get_instance_private (item_progress);
+
+	g_return_val_if_fail (PK_IS_ITEM_PROGRESS (item_progress), NULL);
+
+	return priv->package_id;
 }
 
 /*
@@ -110,7 +120,7 @@ static void
 pk_item_progress_get_property (GObject *object, guint prop_id, GValue *value, GParamSpec *pspec)
 {
 	PkItemProgress *item_progress = PK_ITEM_PROGRESS (object);
-	PkItemProgressPrivate *priv = item_progress->priv;
+	PkItemProgressPrivate *priv = pk_item_progress_get_instance_private (item_progress);
 
 	switch (prop_id) {
 	case PROP_PACKAGE_ID:
@@ -135,12 +145,12 @@ static void
 pk_item_progress_set_property (GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec)
 {
 	PkItemProgress *item_progress = PK_ITEM_PROGRESS (object);
-	PkItemProgressPrivate *priv = item_progress->priv;
+	PkItemProgressPrivate *priv = pk_item_progress_get_instance_private (item_progress);
 
 	switch (prop_id) {
 	case PROP_PACKAGE_ID:
 		g_free (priv->package_id);
-		priv->package_id = g_strdup (g_value_get_string (value));
+		priv->package_id = g_value_dup_string (value);
 		break;
 	case PROP_STATUS:
 		priv->status = g_value_get_uint (value);
@@ -195,8 +205,6 @@ pk_item_progress_class_init (PkItemProgressClass *klass)
 				   0, G_MAXUINT, 0,
 				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_PERCENTAGE, pspec);
-
-	g_type_class_add_private (klass, sizeof (PkItemProgressPrivate));
 }
 
 /*
@@ -205,7 +213,7 @@ pk_item_progress_class_init (PkItemProgressClass *klass)
 static void
 pk_item_progress_init (PkItemProgress *item_progress)
 {
-	item_progress->priv = PK_ITEM_PROGRESS_GET_PRIVATE (item_progress);
+	item_progress->priv = pk_item_progress_get_instance_private (item_progress);
 }
 
 /*
@@ -215,9 +223,9 @@ static void
 pk_item_progress_finalize (GObject *object)
 {
 	PkItemProgress *item_progress = PK_ITEM_PROGRESS (object);
-	PkItemProgressPrivate *priv = item_progress->priv;
+	PkItemProgressPrivate *priv = pk_item_progress_get_instance_private (item_progress);
 
-	g_free (priv->package_id);
+	g_clear_pointer (&priv->package_id, g_free);
 
 	G_OBJECT_CLASS (pk_item_progress_parent_class)->finalize (object);
 }

--- a/lib/packagekit-glib2/pk-media-change-required.c
+++ b/lib/packagekit-glib2/pk-media-change-required.c
@@ -38,8 +38,6 @@
 
 static void     pk_media_change_required_finalize	(GObject     *object);
 
-#define PK_MEDIA_CHANGE_REQUIRED_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), PK_TYPE_MEDIA_CHANGE_REQUIRED, PkMediaChangeRequiredPrivate))
-
 /**
  * PkMediaChangeRequiredPrivate:
  *
@@ -60,7 +58,7 @@ enum {
 	PROP_LAST
 };
 
-G_DEFINE_TYPE (PkMediaChangeRequired, pk_media_change_required, PK_TYPE_SOURCE)
+G_DEFINE_TYPE_WITH_PRIVATE (PkMediaChangeRequired, pk_media_change_required, PK_TYPE_SOURCE)
 
 /*
  * pk_media_change_required_get_property:
@@ -69,7 +67,7 @@ static void
 pk_media_change_required_get_property (GObject *object, guint prop_id, GValue *value, GParamSpec *pspec)
 {
 	PkMediaChangeRequired *media_change_required = PK_MEDIA_CHANGE_REQUIRED (object);
-	PkMediaChangeRequiredPrivate *priv = media_change_required->priv;
+	PkMediaChangeRequiredPrivate *priv = pk_media_change_required_get_instance_private (media_change_required);
 
 	switch (prop_id) {
 	case PROP_MEDIA_TYPE:
@@ -94,7 +92,7 @@ static void
 pk_media_change_required_set_property (GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec)
 {
 	PkMediaChangeRequired *media_change_required = PK_MEDIA_CHANGE_REQUIRED (object);
-	PkMediaChangeRequiredPrivate *priv = media_change_required->priv;
+	PkMediaChangeRequiredPrivate *priv = pk_media_change_required_get_instance_private (media_change_required);
 
 	switch (prop_id) {
 	case PROP_MEDIA_TYPE:
@@ -102,11 +100,11 @@ pk_media_change_required_set_property (GObject *object, guint prop_id, const GVa
 		break;
 	case PROP_MEDIA_ID:
 		g_free (priv->media_id);
-		priv->media_id = g_strdup (g_value_get_string (value));
+		priv->media_id = g_value_dup_string (value);
 		break;
 	case PROP_MEDIA_TEXT:
 		g_free (priv->media_text);
-		priv->media_text = g_strdup (g_value_get_string (value));
+		priv->media_text = g_value_dup_string (value);
 		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -155,8 +153,6 @@ pk_media_change_required_class_init (PkMediaChangeRequiredClass *klass)
 				     NULL,
 				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_MEDIA_TEXT, pspec);
-
-	g_type_class_add_private (klass, sizeof (PkMediaChangeRequiredPrivate));
 }
 
 /*
@@ -165,7 +161,7 @@ pk_media_change_required_class_init (PkMediaChangeRequiredClass *klass)
 static void
 pk_media_change_required_init (PkMediaChangeRequired *media_change_required)
 {
-	media_change_required->priv = PK_MEDIA_CHANGE_REQUIRED_GET_PRIVATE (media_change_required);
+	media_change_required->priv = pk_media_change_required_get_instance_private (media_change_required);
 }
 
 /*
@@ -175,10 +171,10 @@ static void
 pk_media_change_required_finalize (GObject *object)
 {
 	PkMediaChangeRequired *media_change_required = PK_MEDIA_CHANGE_REQUIRED (object);
-	PkMediaChangeRequiredPrivate *priv = media_change_required->priv;
+	PkMediaChangeRequiredPrivate *priv = pk_media_change_required_get_instance_private (media_change_required);
 
-	g_free (priv->media_id);
-	g_free (priv->media_text);
+	g_clear_pointer (&priv->media_id, g_free);
+	g_clear_pointer (&priv->media_text, g_free);
 
 	G_OBJECT_CLASS (pk_media_change_required_parent_class)->finalize (object);
 }

--- a/lib/packagekit-glib2/pk-repo-detail.c
+++ b/lib/packagekit-glib2/pk-repo-detail.c
@@ -36,8 +36,6 @@
 
 static void     pk_repo_detail_finalize	(GObject     *object);
 
-#define PK_REPO_DETAIL_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), PK_TYPE_REPO_DETAIL, PkRepoDetailPrivate))
-
 /**
  * PkRepoDetailPrivate:
  *
@@ -58,7 +56,7 @@ enum {
 	PROP_LAST
 };
 
-G_DEFINE_TYPE (PkRepoDetail, pk_repo_detail, PK_TYPE_SOURCE)
+G_DEFINE_TYPE_WITH_PRIVATE (PkRepoDetail, pk_repo_detail, PK_TYPE_SOURCE)
 
 /**
  * pk_repo_detail_get_id:
@@ -73,8 +71,11 @@ G_DEFINE_TYPE (PkRepoDetail, pk_repo_detail, PK_TYPE_SOURCE)
 const gchar *
 pk_repo_detail_get_id (PkRepoDetail *repo_detail)
 {
+	PkRepoDetailPrivate *priv = pk_repo_detail_get_instance_private (repo_detail);
+
 	g_return_val_if_fail (PK_IS_REPO_DETAIL (repo_detail), NULL);
-	return repo_detail->priv->repo_id;
+
+	return priv->repo_id;
 }
 
 /**
@@ -90,8 +91,11 @@ pk_repo_detail_get_id (PkRepoDetail *repo_detail)
 const gchar *
 pk_repo_detail_get_description (PkRepoDetail *repo_detail)
 {
+	PkRepoDetailPrivate *priv = pk_repo_detail_get_instance_private (repo_detail);
+
 	g_return_val_if_fail (PK_IS_REPO_DETAIL (repo_detail), NULL);
-	return repo_detail->priv->description;
+
+	return priv->description;
 }
 
 /**
@@ -107,8 +111,11 @@ pk_repo_detail_get_description (PkRepoDetail *repo_detail)
 gboolean
 pk_repo_detail_get_enabled (PkRepoDetail *repo_detail)
 {
+	PkRepoDetailPrivate *priv = pk_repo_detail_get_instance_private (repo_detail);
+
 	g_return_val_if_fail (PK_IS_REPO_DETAIL (repo_detail), FALSE);
-	return repo_detail->priv->enabled;
+
+	return priv->enabled;
 }
 
 /*
@@ -118,7 +125,7 @@ static void
 pk_repo_detail_get_property (GObject *object, guint prop_id, GValue *value, GParamSpec *pspec)
 {
 	PkRepoDetail *repo_detail = PK_REPO_DETAIL (object);
-	PkRepoDetailPrivate *priv = repo_detail->priv;
+	PkRepoDetailPrivate *priv = pk_repo_detail_get_instance_private (repo_detail);
 
 	switch (prop_id) {
 	case PROP_REPO_ID:
@@ -143,16 +150,16 @@ static void
 pk_repo_detail_set_property (GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec)
 {
 	PkRepoDetail *repo_detail = PK_REPO_DETAIL (object);
-	PkRepoDetailPrivate *priv = repo_detail->priv;
+	PkRepoDetailPrivate *priv = pk_repo_detail_get_instance_private (repo_detail);
 
 	switch (prop_id) {
 	case PROP_REPO_ID:
 		g_free (priv->repo_id);
-		priv->repo_id = g_strdup (g_value_get_string (value));
+		priv->repo_id = g_value_dup_string (value);
 		break;
 	case PROP_DESCRIPTION:
 		g_free (priv->description);
-		priv->description = g_strdup (g_value_get_string (value));
+		priv->description = g_value_dup_string (value);
 		break;
 	case PROP_ENABLED:
 		priv->enabled = g_value_get_boolean (value);
@@ -204,8 +211,6 @@ pk_repo_detail_class_init (PkRepoDetailClass *klass)
 				      FALSE,
 				      G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_ENABLED, pspec);
-
-	g_type_class_add_private (klass, sizeof (PkRepoDetailPrivate));
 }
 
 /*
@@ -214,7 +219,7 @@ pk_repo_detail_class_init (PkRepoDetailClass *klass)
 static void
 pk_repo_detail_init (PkRepoDetail *repo_detail)
 {
-	repo_detail->priv = PK_REPO_DETAIL_GET_PRIVATE (repo_detail);
+	repo_detail->priv = pk_repo_detail_get_instance_private (repo_detail);
 }
 
 /*
@@ -224,10 +229,10 @@ static void
 pk_repo_detail_finalize (GObject *object)
 {
 	PkRepoDetail *repo_detail = PK_REPO_DETAIL (object);
-	PkRepoDetailPrivate *priv = repo_detail->priv;
+	PkRepoDetailPrivate *priv = pk_repo_detail_get_instance_private (repo_detail);
 
-	g_free (priv->repo_id);
-	g_free (priv->description);
+	g_clear_pointer (&priv->repo_id, g_free);
+	g_clear_pointer (&priv->description, g_free);
 
 	G_OBJECT_CLASS (pk_repo_detail_parent_class)->finalize (object);
 }

--- a/lib/packagekit-glib2/pk-repo-signature-required.c
+++ b/lib/packagekit-glib2/pk-repo-signature-required.c
@@ -38,8 +38,6 @@
 
 static void     pk_repo_signature_required_finalize	(GObject     *object);
 
-#define PK_REPO_SIGNATURE_REQUIRED_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), PK_TYPE_REPO_SIGNATURE_REQUIRED, PkRepoSignatureRequiredPrivate))
-
 /**
  * PkRepoSignatureRequiredPrivate:
  *
@@ -70,7 +68,7 @@ enum {
 	PROP_LAST
 };
 
-G_DEFINE_TYPE (PkRepoSignatureRequired, pk_repo_signature_required, PK_TYPE_SOURCE)
+G_DEFINE_TYPE_WITH_PRIVATE (PkRepoSignatureRequired, pk_repo_signature_required, PK_TYPE_SOURCE)
 
 /*
  * pk_repo_signature_required_get_property:
@@ -79,7 +77,7 @@ static void
 pk_repo_signature_required_get_property (GObject *object, guint prop_id, GValue *value, GParamSpec *pspec)
 {
 	PkRepoSignatureRequired *repo_signature_required = PK_REPO_SIGNATURE_REQUIRED (object);
-	PkRepoSignatureRequiredPrivate *priv = repo_signature_required->priv;
+	PkRepoSignatureRequiredPrivate *priv = pk_repo_signature_required_get_instance_private (repo_signature_required);
 
 	switch (prop_id) {
 	case PROP_PACKAGE_ID:
@@ -119,36 +117,36 @@ static void
 pk_repo_signature_required_set_property (GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec)
 {
 	PkRepoSignatureRequired *repo_signature_required = PK_REPO_SIGNATURE_REQUIRED (object);
-	PkRepoSignatureRequiredPrivate *priv = repo_signature_required->priv;
+	PkRepoSignatureRequiredPrivate *priv = pk_repo_signature_required_get_instance_private (repo_signature_required);
 
 	switch (prop_id) {
 	case PROP_PACKAGE_ID:
 		g_free (priv->package_id);
-		priv->package_id = g_strdup (g_value_get_string (value));
+		priv->package_id = g_value_dup_string (value);
 		break;
 	case PROP_REPOSITORY_NAME:
 		g_free (priv->repository_name);
-		priv->repository_name = g_strdup (g_value_get_string (value));
+		priv->repository_name = g_value_dup_string (value);
 		break;
 	case PROP_KEY_URL:
 		g_free (priv->key_url);
-		priv->key_url = g_strdup (g_value_get_string (value));
+		priv->key_url = g_value_dup_string (value);
 		break;
 	case PROP_KEY_USERID:
 		g_free (priv->key_userid);
-		priv->key_userid = g_strdup (g_value_get_string (value));
+		priv->key_userid = g_value_dup_string (value);
 		break;
 	case PROP_KEY_ID:
 		g_free (priv->key_id);
-		priv->key_id = g_strdup (g_value_get_string (value));
+		priv->key_id = g_value_dup_string (value);
 		break;
 	case PROP_KEY_FINGERPRINT:
 		g_free (priv->key_fingerprint);
-		priv->key_fingerprint = g_strdup (g_value_get_string (value));
+		priv->key_fingerprint = g_value_dup_string (value);
 		break;
 	case PROP_KEY_TIMESTAMP:
 		g_free (priv->key_timestamp);
-		priv->key_timestamp = g_strdup (g_value_get_string (value));
+		priv->key_timestamp = g_value_dup_string (value);
 		break;
 	case PROP_TYPE:
 		priv->type = g_value_get_enum (value);
@@ -250,8 +248,6 @@ pk_repo_signature_required_class_init (PkRepoSignatureRequiredClass *klass)
 				   PK_TYPE_SIG_TYPE_ENUM, PK_SIGTYPE_ENUM_UNKNOWN,
 				   G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_TYPE, pspec);
-
-	g_type_class_add_private (klass, sizeof (PkRepoSignatureRequiredPrivate));
 }
 
 /*
@@ -260,7 +256,7 @@ pk_repo_signature_required_class_init (PkRepoSignatureRequiredClass *klass)
 static void
 pk_repo_signature_required_init (PkRepoSignatureRequired *repo_signature_required)
 {
-	repo_signature_required->priv = PK_REPO_SIGNATURE_REQUIRED_GET_PRIVATE (repo_signature_required);
+	repo_signature_required->priv = pk_repo_signature_required_get_instance_private (repo_signature_required);
 }
 
 /*
@@ -270,15 +266,15 @@ static void
 pk_repo_signature_required_finalize (GObject *object)
 {
 	PkRepoSignatureRequired *repo_signature_required = PK_REPO_SIGNATURE_REQUIRED (object);
-	PkRepoSignatureRequiredPrivate *priv = repo_signature_required->priv;
+	PkRepoSignatureRequiredPrivate *priv = pk_repo_signature_required_get_instance_private (repo_signature_required);
 
-	g_free (priv->package_id);
-	g_free (priv->repository_name);
-	g_free (priv->key_url);
-	g_free (priv->key_userid);
-	g_free (priv->key_id);
-	g_free (priv->key_fingerprint);
-	g_free (priv->key_timestamp);
+	g_clear_pointer (&priv->package_id, g_free);
+	g_clear_pointer (&priv->repository_name, g_free);
+	g_clear_pointer (&priv->key_url, g_free);
+	g_clear_pointer (&priv->key_userid, g_free);
+	g_clear_pointer (&priv->key_id, g_free);
+	g_clear_pointer (&priv->key_fingerprint, g_free);
+	g_clear_pointer (&priv->key_timestamp, g_free);
 
 	G_OBJECT_CLASS (pk_repo_signature_required_parent_class)->finalize (object);
 }

--- a/lib/packagekit-glib2/pk-require-restart.c
+++ b/lib/packagekit-glib2/pk-require-restart.c
@@ -38,8 +38,6 @@
 
 static void     pk_require_restart_finalize	(GObject     *object);
 
-#define PK_REQUIRE_RESTART_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), PK_TYPE_REQUIRE_RESTART, PkRequireRestartPrivate))
-
 /**
  * PkRequireRestartPrivate:
  *
@@ -58,7 +56,7 @@ enum {
 	PROP_LAST
 };
 
-G_DEFINE_TYPE (PkRequireRestart, pk_require_restart, PK_TYPE_SOURCE)
+G_DEFINE_TYPE_WITH_PRIVATE (PkRequireRestart, pk_require_restart, PK_TYPE_SOURCE)
 
 /*
  * pk_require_restart_get_property:
@@ -67,7 +65,7 @@ static void
 pk_require_restart_get_property (GObject *object, guint prop_id, GValue *value, GParamSpec *pspec)
 {
 	PkRequireRestart *require_restart = PK_REQUIRE_RESTART (object);
-	PkRequireRestartPrivate *priv = require_restart->priv;
+	PkRequireRestartPrivate *priv = pk_require_restart_get_instance_private (require_restart);
 
 	switch (prop_id) {
 	case PROP_RESTART:
@@ -89,7 +87,7 @@ static void
 pk_require_restart_set_property (GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec)
 {
 	PkRequireRestart *require_restart = PK_REQUIRE_RESTART (object);
-	PkRequireRestartPrivate *priv = require_restart->priv;
+	PkRequireRestartPrivate *priv = pk_require_restart_get_instance_private (require_restart);
 
 	switch (prop_id) {
 	case PROP_RESTART:
@@ -97,7 +95,7 @@ pk_require_restart_set_property (GObject *object, guint prop_id, const GValue *v
 		break;
 	case PROP_PACKAGE_ID:
 		g_free (priv->package_id);
-		priv->package_id = g_strdup (g_value_get_string (value));
+		priv->package_id = g_value_dup_string (value);
 		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -136,8 +134,6 @@ pk_require_restart_class_init (PkRequireRestartClass *klass)
 				     NULL,
 				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_PACKAGE_ID, pspec);
-
-	g_type_class_add_private (klass, sizeof (PkRequireRestartPrivate));
 }
 
 /*
@@ -146,7 +142,7 @@ pk_require_restart_class_init (PkRequireRestartClass *klass)
 static void
 pk_require_restart_init (PkRequireRestart *require_restart)
 {
-	require_restart->priv = PK_REQUIRE_RESTART_GET_PRIVATE (require_restart);
+	require_restart->priv = pk_require_restart_get_instance_private (require_restart);
 }
 
 /*
@@ -156,9 +152,9 @@ static void
 pk_require_restart_finalize (GObject *object)
 {
 	PkRequireRestart *require_restart = PK_REQUIRE_RESTART (object);
-	PkRequireRestartPrivate *priv = require_restart->priv;
+	PkRequireRestartPrivate *priv = pk_require_restart_get_instance_private (require_restart);
 
-	g_free (priv->package_id);
+	g_clear_pointer (&priv->package_id, g_free);
 
 	G_OBJECT_CLASS (pk_require_restart_parent_class)->finalize (object);
 }

--- a/lib/packagekit-glib2/pk-source.c
+++ b/lib/packagekit-glib2/pk-source.c
@@ -37,8 +37,6 @@
 
 static void     pk_source_finalize	(GObject     *object);
 
-#define PK_SOURCE_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), PK_TYPE_SOURCE, PkSourcePrivate))
-
 /**
  * PkSourcePrivate:
  *
@@ -57,7 +55,7 @@ enum {
 	PROP_LAST
 };
 
-G_DEFINE_TYPE (PkSource, pk_source, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_PRIVATE (PkSource, pk_source, G_TYPE_OBJECT)
 
 /*
  * pk_source_get_property:
@@ -66,7 +64,7 @@ static void
 pk_source_get_property (GObject *object, guint prop_id, GValue *value, GParamSpec *pspec)
 {
 	PkSource *source = PK_SOURCE (object);
-	PkSourcePrivate *priv = source->priv;
+	PkSourcePrivate *priv = pk_source_get_instance_private (source);
 
 	switch (prop_id) {
 	case PROP_ROLE:
@@ -88,7 +86,7 @@ static void
 pk_source_set_property (GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec)
 {
 	PkSource *source = PK_SOURCE (object);
-	PkSourcePrivate *priv = source->priv;
+	PkSourcePrivate *priv = pk_source_get_instance_private (source);
 
 	switch (prop_id) {
 	case PROP_ROLE:
@@ -96,7 +94,7 @@ pk_source_set_property (GObject *object, guint prop_id, const GValue *value, GPa
 		break;
 	case PROP_TRANSACTION_ID:
 		g_free (priv->transaction_id);
-		priv->transaction_id = g_strdup (g_value_get_string (value));
+		priv->transaction_id = g_value_dup_string (value);
 		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -135,8 +133,6 @@ pk_source_class_init (PkSourceClass *klass)
 				     NULL,
 				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_TRANSACTION_ID, pspec);
-
-	g_type_class_add_private (klass, sizeof (PkSourcePrivate));
 }
 
 /*
@@ -145,7 +141,7 @@ pk_source_class_init (PkSourceClass *klass)
 static void
 pk_source_init (PkSource *source)
 {
-	source->priv = PK_SOURCE_GET_PRIVATE (source);
+	source->priv = pk_source_get_instance_private (source);
 }
 
 /*
@@ -155,9 +151,9 @@ static void
 pk_source_finalize (GObject *object)
 {
 	PkSource *source = PK_SOURCE (object);
-	PkSourcePrivate *priv = source->priv;
+	PkSourcePrivate *priv = pk_source_get_instance_private (source);
 
-	g_free (priv->transaction_id);
+	g_clear_pointer (&priv->transaction_id, g_free);
 
 	G_OBJECT_CLASS (pk_source_parent_class)->finalize (object);
 }

--- a/lib/packagekit-glib2/pk-task-text.c
+++ b/lib/packagekit-glib2/pk-task-text.c
@@ -31,18 +31,10 @@
 
 #include "pk-task-text.h"
 #include "pk-console-shared.h"
-static void     pk_task_text_finalize	(GObject     *object);
 
-#define PK_TASK_TEXT_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), PK_TYPE_TASK_TEXT, PkTaskTextPrivate))
-
-/**
- * PkTaskTextPrivate:
- *
- * Private #PkTaskText data
- **/
-struct _PkTaskTextPrivate
+struct _PkTaskText
 {
-	gpointer		 user_data;
+ PkTask parent;
 };
 
 G_DEFINE_TYPE (PkTaskText, pk_task_text, PK_TYPE_TASK)
@@ -54,10 +46,6 @@ static void
 pk_task_text_untrusted_question (PkTask *task, guint request, PkResults *results)
 {
 	gboolean ret;
-	PkTaskTextPrivate *priv = PK_TASK_TEXT(task)->priv;
-
-	/* set some user data, for no reason */
-	priv->user_data = NULL;
 
 	/* clear new line */
 	g_print ("\n");
@@ -91,10 +79,6 @@ pk_task_text_key_question (PkTask *task, guint request, PkResults *results)
 	gchar *key_fingerprint;
 	gchar *key_timestamp;
 	PkRepoSignatureRequired *item;
-	PkTaskTextPrivate *priv = PK_TASK_TEXT(task)->priv;
-
-	/* set some user data, for no reason */
-	priv->user_data = NULL;
 
 	/* clear new line */
 	g_print ("\n");
@@ -172,10 +156,6 @@ pk_task_text_eula_question (PkTask *task, guint request, PkResults *results)
 	guint i;
 	gboolean ret;
 	GPtrArray *array;
-	PkTaskTextPrivate *priv = PK_TASK_TEXT(task)->priv;
-
-	/* set some user data, for no reason */
-	priv->user_data = NULL;
 
 	/* clear new line */
 	g_print ("\n");
@@ -230,10 +210,6 @@ pk_task_text_media_change_question (PkTask *task, guint request, PkResults *resu
 	gchar *media_id;
 	PkMediaTypeEnum media_type;
 	gchar *media_text;
-	PkTaskTextPrivate *priv = PK_TASK_TEXT(task)->priv;
-
-	/* set some user data, for no reason */
-	priv->user_data = NULL;
 
 	/* clear new line */
 	g_print ("\n");
@@ -351,12 +327,8 @@ pk_task_text_simulate_question (PkTask *task, guint request, PkResults *results)
 	GList *l;
 	PkPackage *package;
 	GPtrArray *array;
-	PkTaskTextPrivate *priv = PK_TASK_TEXT(task)->priv;
 	g_autoptr(GHashTable) table = NULL;
 	g_autoptr(GList) list = NULL;
-
-	/* set some user data, for no reason */
-	priv->user_data = NULL;
 
 	/* clear new line */
 	g_print ("\n");
@@ -436,17 +408,13 @@ pk_task_text_simulate_question (PkTask *task, guint request, PkResults *results)
 static void
 pk_task_text_class_init (PkTaskTextClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS (klass);
 	PkTaskClass *task_class = PK_TASK_CLASS (klass);
 
-	object_class->finalize = pk_task_text_finalize;
 	task_class->untrusted_question = pk_task_text_untrusted_question;
 	task_class->key_question = pk_task_text_key_question;
 	task_class->eula_question = pk_task_text_eula_question;
 	task_class->media_change_question = pk_task_text_media_change_question;
 	task_class->simulate_question = pk_task_text_simulate_question;
-
-	g_type_class_add_private (klass, sizeof (PkTaskTextPrivate));
 }
 
 /*
@@ -456,20 +424,6 @@ pk_task_text_class_init (PkTaskTextClass *klass)
 static void
 pk_task_text_init (PkTaskText *task)
 {
-	task->priv = PK_TASK_TEXT_GET_PRIVATE (task);
-	task->priv->user_data = NULL;
-}
-
-/*
- * pk_task_text_finalize:
- * @object: The object to finalize
- **/
-static void
-pk_task_text_finalize (GObject *object)
-{
-	PkTaskText *task = PK_TASK_TEXT (object);
-	task->priv->user_data = NULL;
-	G_OBJECT_CLASS (pk_task_text_parent_class)->finalize (object);
 }
 
 /**

--- a/lib/packagekit-glib2/pk-task-text.h
+++ b/lib/packagekit-glib2/pk-task-text.h
@@ -27,30 +27,10 @@
 
 G_BEGIN_DECLS
 
-#define PK_TYPE_TASK_TEXT		(pk_task_text_get_type ())
-#define PK_TASK_TEXT(o)			(G_TYPE_CHECK_INSTANCE_CAST ((o), PK_TYPE_TASK_TEXT, PkTaskText))
-#define PK_TASK_TEXT_CLASS(k)		(G_TYPE_CHECK_CLASS_CAST((k), PK_TYPE_TASK_TEXT, PkTaskTextClass))
-#define PK_IS_TASK_TEXT(o)		(G_TYPE_CHECK_INSTANCE_TYPE ((o), PK_TYPE_TASK_TEXT))
-#define PK_IS_TASK_TEXT_CLASS(k)	(G_TYPE_CHECK_CLASS_TYPE ((k), PK_TYPE_TASK_TEXT))
-#define PK_TASK_TEXT_GET_CLASS(o)	(G_TYPE_INSTANCE_GET_CLASS ((o), PK_TYPE_TASK_TEXT, PkTaskTextClass))
+#define PK_TYPE_TASK_TEXT (pk_task_text_get_type ())
+G_DECLARE_FINAL_TYPE (PkTaskText, pk_task_text, PK, TASK_TEXT, PkTask)
 
-typedef struct _PkTaskTextPrivate	PkTaskTextPrivate;
-typedef struct _PkTaskText		PkTaskText;
-typedef struct _PkTaskTextClass		PkTaskTextClass;
-
-struct _PkTaskText
-{
-	 PkTask				 parent;
-	 PkTaskTextPrivate		*priv;
-};
-
-struct _PkTaskTextClass
-{
-	PkTaskClass			 parent_class;
-};
-
-GType		 pk_task_text_get_type				(void);
-PkTaskText	*pk_task_text_new				(void);
+PkTaskText	*pk_task_text_new (void);
 
 G_END_DECLS
 

--- a/lib/packagekit-glib2/pk-task-wrapper.c
+++ b/lib/packagekit-glib2/pk-task-wrapper.c
@@ -27,18 +27,9 @@
 
 #include "pk-task-wrapper.h"
 
-static void     pk_task_wrapper_finalize	(GObject     *object);
-
-#define PK_TASK_WRAPPER_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), PK_TYPE_TASK_WRAPPER, PkTaskWrapperPrivate))
-
-/**
- * PkTaskWrapperPrivate:
- *
- * Private #PkTaskWrapper data
- **/
-struct _PkTaskWrapperPrivate
+struct _PkTaskWrapper
 {
-	gpointer		 user_data;
+ PkTask parent;
 };
 
 G_DEFINE_TYPE (PkTaskWrapper, pk_task_wrapper, PK_TYPE_TASK)
@@ -49,11 +40,6 @@ G_DEFINE_TYPE (PkTaskWrapper, pk_task_wrapper, PK_TYPE_TASK)
 static void
 pk_task_wrapper_untrusted_question (PkTask *task, guint request, PkResults *results)
 {
-	PkTaskWrapperPrivate *priv = PK_TASK_WRAPPER(task)->priv;
-
-	/* set some user data, for no reason */
-	priv->user_data = NULL;
-
 	g_print ("UNTRUSTED\n");
 
 	/* just accept without asking */
@@ -66,11 +52,6 @@ pk_task_wrapper_untrusted_question (PkTask *task, guint request, PkResults *resu
 static void
 pk_task_wrapper_key_question (PkTask *task, guint request, PkResults *results)
 {
-	PkTaskWrapperPrivate *priv = PK_TASK_WRAPPER(task)->priv;
-
-	/* set some user data, for no reason */
-	priv->user_data = NULL;
-
 	/* just accept without asking */
 	pk_task_user_accepted (task, request);
 }
@@ -81,11 +62,6 @@ pk_task_wrapper_key_question (PkTask *task, guint request, PkResults *results)
 static void
 pk_task_wrapper_eula_question (PkTask *task, guint request, PkResults *results)
 {
-	PkTaskWrapperPrivate *priv = PK_TASK_WRAPPER(task)->priv;
-
-	/* set some user data, for no reason */
-	priv->user_data = NULL;
-
 	/* just accept without asking */
 	pk_task_user_accepted (task, request);
 }
@@ -96,11 +72,6 @@ pk_task_wrapper_eula_question (PkTask *task, guint request, PkResults *results)
 static void
 pk_task_wrapper_media_change_question (PkTask *task, guint request, PkResults *results)
 {
-	PkTaskWrapperPrivate *priv = PK_TASK_WRAPPER(task)->priv;
-
-	/* set some user data, for no reason */
-	priv->user_data = NULL;
-
 	/* just accept without asking */
 	pk_task_user_accepted (task, request);
 }
@@ -114,12 +85,8 @@ pk_task_wrapper_simulate_question (PkTask *task, guint request, PkResults *resul
 	guint i;
 	const gchar *package_id;
 	PkPackage *package;
-	PkTaskWrapperPrivate *priv = PK_TASK_WRAPPER(task)->priv;
 	g_autoptr(PkPackageSack) sack = NULL;
 	g_autoptr(GPtrArray) array = NULL;
-
-	/* set some user data, for no reason */
-	priv->user_data = NULL;
 
 	/* get data */
 	sack = pk_results_get_package_sack (results);
@@ -145,17 +112,13 @@ pk_task_wrapper_simulate_question (PkTask *task, guint request, PkResults *resul
 static void
 pk_task_wrapper_class_init (PkTaskWrapperClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS (klass);
 	PkTaskClass *task_class = PK_TASK_CLASS (klass);
 
-	object_class->finalize = pk_task_wrapper_finalize;
 	task_class->untrusted_question = pk_task_wrapper_untrusted_question;
 	task_class->key_question = pk_task_wrapper_key_question;
 	task_class->eula_question = pk_task_wrapper_eula_question;
 	task_class->media_change_question = pk_task_wrapper_media_change_question;
 	task_class->simulate_question = pk_task_wrapper_simulate_question;
-
-	g_type_class_add_private (klass, sizeof (PkTaskWrapperPrivate));
 }
 
 /*
@@ -165,20 +128,6 @@ pk_task_wrapper_class_init (PkTaskWrapperClass *klass)
 static void
 pk_task_wrapper_init (PkTaskWrapper *task)
 {
-	task->priv = PK_TASK_WRAPPER_GET_PRIVATE (task);
-	task->priv->user_data = NULL;
-}
-
-/*
- * pk_task_wrapper_finalize:
- * @object: The object to finalize
- **/
-static void
-pk_task_wrapper_finalize (GObject *object)
-{
-	PkTaskWrapper *task = PK_TASK_WRAPPER (object);
-	task->priv->user_data = NULL;
-	G_OBJECT_CLASS (pk_task_wrapper_parent_class)->finalize (object);
 }
 
 /**

--- a/lib/packagekit-glib2/pk-task-wrapper.h
+++ b/lib/packagekit-glib2/pk-task-wrapper.h
@@ -27,30 +27,10 @@
 
 G_BEGIN_DECLS
 
-#define PK_TYPE_TASK_WRAPPER		(pk_task_wrapper_get_type ())
-#define PK_TASK_WRAPPER(o)		(G_TYPE_CHECK_INSTANCE_CAST ((o), PK_TYPE_TASK_WRAPPER, PkTaskWrapper))
-#define PK_TASK_WRAPPER_CLASS(k)	(G_TYPE_CHECK_CLASS_CAST((k), PK_TYPE_TASK_WRAPPER, PkTaskWrapperClass))
-#define PK_IS_TASK_WRAPPER(o)		(G_TYPE_CHECK_INSTANCE_TYPE ((o), PK_TYPE_TASK_WRAPPER))
-#define PK_IS_TASK_WRAPPER_CLASS(k)	(G_TYPE_CHECK_CLASS_TYPE ((k), PK_TYPE_TASK_WRAPPER))
-#define PK_TASK_WRAPPER_GET_CLASS(o)	(G_TYPE_INSTANCE_GET_CLASS ((o), PK_TYPE_TASK_WRAPPER, PkTaskWrapperClass))
+#define PK_TYPE_TASK_WRAPPER (pk_task_wrapper_get_type ())
+G_DECLARE_FINAL_TYPE (PkTaskWrapper, pk_task_wrapper, PK, TASK_WRAPPER, PkTask)
 
-typedef struct _PkTaskWrapperPrivate	PkTaskWrapperPrivate;
-typedef struct _PkTaskWrapper		PkTaskWrapper;
-typedef struct _PkTaskWrapperClass	PkTaskWrapperClass;
-
-struct _PkTaskWrapper
-{
-	 PkTask				 parent;
-	 PkTaskWrapperPrivate		*priv;
-};
-
-struct _PkTaskWrapperClass
-{
-	PkTaskClass			 parent_class;
-};
-
-GType		 pk_task_wrapper_get_type			(void);
-PkTaskWrapper	*pk_task_wrapper_new				(void);
+PkTaskWrapper	*pk_task_wrapper_new (void);
 
 G_END_DECLS
 

--- a/lib/packagekit-glib2/pk-transaction-past.c
+++ b/lib/packagekit-glib2/pk-transaction-past.c
@@ -39,8 +39,6 @@
 
 static void     pk_transaction_past_finalize	(GObject     *object);
 
-#define PK_TRANSACTION_PAST_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), PK_TYPE_TRANSACTION_PAST, PkTransactionPastPrivate))
-
 /**
  * PkTransactionPastPrivate:
  *
@@ -71,7 +69,7 @@ enum {
 	PROP_LAST
 };
 
-G_DEFINE_TYPE (PkTransactionPast, pk_transaction_past, PK_TYPE_SOURCE)
+G_DEFINE_TYPE_WITH_PRIVATE (PkTransactionPast, pk_transaction_past, PK_TYPE_SOURCE)
 
 /**
  * pk_transaction_past_get_id:
@@ -86,8 +84,11 @@ G_DEFINE_TYPE (PkTransactionPast, pk_transaction_past, PK_TYPE_SOURCE)
 const gchar *
 pk_transaction_past_get_id (PkTransactionPast *past)
 {
+	PkTransactionPastPrivate *priv = pk_transaction_past_get_instance_private (past);
+
 	g_return_val_if_fail (PK_IS_TRANSACTION_PAST (past), NULL);
-	return past->priv->tid;
+
+	return priv->tid;
 }
 
 /**
@@ -103,8 +104,11 @@ pk_transaction_past_get_id (PkTransactionPast *past)
 const gchar *
 pk_transaction_past_get_timespec (PkTransactionPast *past)
 {
+	PkTransactionPastPrivate *priv = pk_transaction_past_get_instance_private (past);
+
 	g_return_val_if_fail (PK_IS_TRANSACTION_PAST (past), NULL);
-	return past->priv->timespec;
+
+	return priv->timespec;
 }
 
 /**
@@ -120,10 +124,14 @@ pk_transaction_past_get_timespec (PkTransactionPast *past)
 GDateTime *
 pk_transaction_past_get_datetime (PkTransactionPast *past)
 {
+	PkTransactionPastPrivate *priv = pk_transaction_past_get_instance_private (past);
+
 	g_return_val_if_fail (PK_IS_TRANSACTION_PAST (past), NULL);
-	if (past->priv->timespec == NULL)
+
+	if (priv->timespec == NULL)
 		return NULL;
-	return pk_iso8601_to_datetime (past->priv->timespec);
+
+	return pk_iso8601_to_datetime (priv->timespec);
 }
 
 /**
@@ -165,8 +173,11 @@ pk_transaction_past_get_timestamp (PkTransactionPast *past)
 gboolean
 pk_transaction_past_get_succeeded (PkTransactionPast *past)
 {
+	PkTransactionPastPrivate *priv = pk_transaction_past_get_instance_private (past);
+
 	g_return_val_if_fail (PK_IS_TRANSACTION_PAST (past), FALSE);
-	return past->priv->succeeded;
+
+	return priv->succeeded;
 }
 
 /**
@@ -182,8 +193,11 @@ pk_transaction_past_get_succeeded (PkTransactionPast *past)
 PkRoleEnum
 pk_transaction_past_get_role (PkTransactionPast *past)
 {
+	PkTransactionPastPrivate *priv = pk_transaction_past_get_instance_private (past);
+
 	g_return_val_if_fail (PK_IS_TRANSACTION_PAST (past), PK_ROLE_ENUM_UNKNOWN);
-	return past->priv->role;
+
+	return priv->role;
 }
 
 /**
@@ -199,8 +213,11 @@ pk_transaction_past_get_role (PkTransactionPast *past)
 guint
 pk_transaction_past_get_duration (PkTransactionPast *past)
 {
+	PkTransactionPastPrivate *priv = pk_transaction_past_get_instance_private (past);
+
 	g_return_val_if_fail (PK_IS_TRANSACTION_PAST (past), 0);
-	return past->priv->duration;
+
+	return priv->duration;
 }
 
 /**
@@ -216,8 +233,10 @@ pk_transaction_past_get_duration (PkTransactionPast *past)
 const gchar *
 pk_transaction_past_get_data (PkTransactionPast *past)
 {
+	PkTransactionPastPrivate *priv = pk_transaction_past_get_instance_private (past);
+
 	g_return_val_if_fail (PK_IS_TRANSACTION_PAST (past), NULL);
-	return past->priv->data;
+	return priv->data;
 }
 
 /**
@@ -301,16 +320,16 @@ static void
 pk_transaction_past_set_property (GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec)
 {
 	PkTransactionPast *transaction_past = PK_TRANSACTION_PAST (object);
-	PkTransactionPastPrivate *priv = transaction_past->priv;
+	PkTransactionPastPrivate *priv = pk_transaction_past_get_instance_private (transaction_past);
 
 	switch (prop_id) {
 	case PROP_TID:
 		g_free (priv->tid);
-		priv->tid = g_strdup (g_value_get_string (value));
+		priv->tid = g_value_dup_string (value);
 		break;
 	case PROP_TIMESPEC:
 		g_free (priv->timespec);
-		priv->timespec = g_strdup (g_value_get_string (value));
+		priv->timespec = g_value_dup_string (value);
 		break;
 	case PROP_SUCCEEDED:
 		priv->succeeded = g_value_get_boolean (value);
@@ -323,14 +342,14 @@ pk_transaction_past_set_property (GObject *object, guint prop_id, const GValue *
 		break;
 	case PROP_DATA:
 		g_free (priv->data);
-		priv->data = g_strdup (g_value_get_string (value));
+		priv->data = g_value_dup_string (value);
 		break;
 	case PROP_UID:
 		priv->uid = g_value_get_uint (value);
 		break;
 	case PROP_CMDLINE:
 		g_free (priv->cmdline);
-		priv->cmdline = g_strdup (g_value_get_string (value));
+		priv->cmdline = g_value_dup_string (value);
 		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -429,8 +448,6 @@ pk_transaction_past_class_init (PkTransactionPastClass *klass)
 				     NULL,
 				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_CMDLINE, pspec);
-
-	g_type_class_add_private (klass, sizeof (PkTransactionPastPrivate));
 }
 
 /*
@@ -439,7 +456,7 @@ pk_transaction_past_class_init (PkTransactionPastClass *klass)
 static void
 pk_transaction_past_init (PkTransactionPast *transaction_past)
 {
-	transaction_past->priv = PK_TRANSACTION_PAST_GET_PRIVATE (transaction_past);
+	transaction_past->priv = pk_transaction_past_get_instance_private (transaction_past);
 }
 
 /*
@@ -449,12 +466,12 @@ static void
 pk_transaction_past_finalize (GObject *object)
 {
 	PkTransactionPast *transaction_past = PK_TRANSACTION_PAST (object);
-	PkTransactionPastPrivate *priv = transaction_past->priv;
+	PkTransactionPastPrivate *priv = pk_transaction_past_get_instance_private (transaction_past);
 
-	g_free (priv->tid);
-	g_free (priv->timespec);
-	g_free (priv->data);
-	g_free (priv->cmdline);
+	g_clear_pointer (&priv->tid, g_free);
+	g_clear_pointer (&priv->timespec, g_free);
+	g_clear_pointer (&priv->data, g_free);
+	g_clear_pointer (&priv->cmdline, g_free);
 
 	G_OBJECT_CLASS (pk_transaction_past_parent_class)->finalize (object);
 }

--- a/lib/packagekit-glib2/pk-update-detail.c
+++ b/lib/packagekit-glib2/pk-update-detail.c
@@ -37,8 +37,6 @@
 
 static void     pk_update_detail_finalize	(GObject     *object);
 
-#define PK_UPDATE_DETAIL_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), PK_TYPE_UPDATE_DETAIL, PkUpdateDetailPrivate))
-
 /**
  * PkUpdateDetailPrivate:
  *
@@ -77,7 +75,7 @@ enum {
 	PROP_LAST
 };
 
-G_DEFINE_TYPE (PkUpdateDetail, pk_update_detail, PK_TYPE_SOURCE)
+G_DEFINE_TYPE_WITH_PRIVATE (PkUpdateDetail, pk_update_detail, PK_TYPE_SOURCE)
 /**
  * pk_update_detail_get_package_id:
  * @update_detail: a #PkUpdateDetail instance
@@ -91,8 +89,11 @@ G_DEFINE_TYPE (PkUpdateDetail, pk_update_detail, PK_TYPE_SOURCE)
 const gchar *
 pk_update_detail_get_package_id (PkUpdateDetail *update_detail)
 {
+	PkUpdateDetailPrivate *priv = pk_update_detail_get_instance_private (update_detail);
+
 	g_return_val_if_fail (update_detail != NULL, NULL);
-	return update_detail->priv->package_id;
+
+	return priv->package_id;
 }
 
 /**
@@ -108,8 +109,11 @@ pk_update_detail_get_package_id (PkUpdateDetail *update_detail)
 gchar **
 pk_update_detail_get_updates (PkUpdateDetail *update_detail)
 {
+	PkUpdateDetailPrivate *priv = pk_update_detail_get_instance_private (update_detail);
+
 	g_return_val_if_fail (update_detail != NULL, NULL);
-	return update_detail->priv->updates;
+
+	return priv->updates;
 }
 
 /**
@@ -125,8 +129,11 @@ pk_update_detail_get_updates (PkUpdateDetail *update_detail)
 gchar **
 pk_update_detail_get_obsoletes (PkUpdateDetail *update_detail)
 {
+	PkUpdateDetailPrivate *priv = pk_update_detail_get_instance_private (update_detail);
+
 	g_return_val_if_fail (update_detail != NULL, NULL);
-	return update_detail->priv->obsoletes;
+
+	return priv->obsoletes;
 }
 
 /**
@@ -142,8 +149,11 @@ pk_update_detail_get_obsoletes (PkUpdateDetail *update_detail)
 gchar **
 pk_update_detail_get_vendor_urls (PkUpdateDetail *update_detail)
 {
+	PkUpdateDetailPrivate *priv = pk_update_detail_get_instance_private (update_detail);
+
 	g_return_val_if_fail (update_detail != NULL, NULL);
-	return update_detail->priv->vendor_urls;
+
+	return priv->vendor_urls;
 }
 
 /**
@@ -159,8 +169,11 @@ pk_update_detail_get_vendor_urls (PkUpdateDetail *update_detail)
 gchar **
 pk_update_detail_get_bugzilla_urls (PkUpdateDetail *update_detail)
 {
+	PkUpdateDetailPrivate *priv = pk_update_detail_get_instance_private (update_detail);
+
 	g_return_val_if_fail (update_detail != NULL, NULL);
-	return update_detail->priv->bugzilla_urls;
+
+	return priv->bugzilla_urls;
 }
 
 /**
@@ -176,8 +189,11 @@ pk_update_detail_get_bugzilla_urls (PkUpdateDetail *update_detail)
 gchar **
 pk_update_detail_get_cve_urls (PkUpdateDetail *update_detail)
 {
+	PkUpdateDetailPrivate *priv = pk_update_detail_get_instance_private (update_detail);
+
 	g_return_val_if_fail (update_detail != NULL, NULL);
-	return update_detail->priv->cve_urls;
+
+	return priv->cve_urls;
 }
 
 /**
@@ -193,8 +209,11 @@ pk_update_detail_get_cve_urls (PkUpdateDetail *update_detail)
 PkRestartEnum
 pk_update_detail_get_restart (PkUpdateDetail *update_detail)
 {
+	PkUpdateDetailPrivate *priv = pk_update_detail_get_instance_private (update_detail);
+
 	g_return_val_if_fail (update_detail != NULL, PK_RESTART_ENUM_UNKNOWN);
-	return update_detail->priv->restart;
+
+	return priv->restart;
 }
 
 /**
@@ -210,8 +229,11 @@ pk_update_detail_get_restart (PkUpdateDetail *update_detail)
 const gchar *
 pk_update_detail_get_update_text (PkUpdateDetail *update_detail)
 {
+	PkUpdateDetailPrivate *priv = pk_update_detail_get_instance_private (update_detail);
+
 	g_return_val_if_fail (update_detail != NULL, NULL);
-	return update_detail->priv->update_text;
+
+	return priv->update_text;
 }
 
 /**
@@ -227,8 +249,11 @@ pk_update_detail_get_update_text (PkUpdateDetail *update_detail)
 const gchar *
 pk_update_detail_get_changelog (PkUpdateDetail *update_detail)
 {
+	PkUpdateDetailPrivate *priv = pk_update_detail_get_instance_private (update_detail);
+
 	g_return_val_if_fail (update_detail != NULL, NULL);
-	return update_detail->priv->changelog;
+
+	return priv->changelog;
 }
 
 /**
@@ -244,8 +269,11 @@ pk_update_detail_get_changelog (PkUpdateDetail *update_detail)
 PkUpdateStateEnum
 pk_update_detail_get_state (PkUpdateDetail *update_detail)
 {
+	PkUpdateDetailPrivate *priv = pk_update_detail_get_instance_private (update_detail);
+
 	g_return_val_if_fail (update_detail != NULL, PK_UPDATE_STATE_ENUM_UNKNOWN);
-	return update_detail->priv->state;
+
+	return priv->state;
 }
 
 /**
@@ -261,8 +289,11 @@ pk_update_detail_get_state (PkUpdateDetail *update_detail)
 const gchar *
 pk_update_detail_get_issued (PkUpdateDetail *update_detail)
 {
+	PkUpdateDetailPrivate *priv = pk_update_detail_get_instance_private (update_detail);
+
 	g_return_val_if_fail (update_detail != NULL, NULL);
-	return update_detail->priv->issued;
+
+	return priv->issued;
 }
 
 /**
@@ -278,8 +309,11 @@ pk_update_detail_get_issued (PkUpdateDetail *update_detail)
 const gchar *
 pk_update_detail_get_updated (PkUpdateDetail *update_detail)
 {
+	PkUpdateDetailPrivate *priv = pk_update_detail_get_instance_private (update_detail);
+
 	g_return_val_if_fail (update_detail != NULL, NULL);
-	return update_detail->priv->updated;
+
+	return priv->updated;
 }
 
 /*
@@ -289,7 +323,7 @@ static void
 pk_update_detail_get_property (GObject *object, guint prop_id, GValue *value, GParamSpec *pspec)
 {
 	PkUpdateDetail *update_detail = PK_UPDATE_DETAIL (object);
-	PkUpdateDetailPrivate *priv = update_detail->priv;
+	PkUpdateDetailPrivate *priv = pk_update_detail_get_instance_private (update_detail);
 
 	switch (prop_id) {
 	case PROP_PACKAGE_ID:
@@ -341,54 +375,54 @@ static void
 pk_update_detail_set_property (GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec)
 {
 	PkUpdateDetail *update_detail = PK_UPDATE_DETAIL (object);
-	PkUpdateDetailPrivate *priv = update_detail->priv;
+	PkUpdateDetailPrivate *priv = pk_update_detail_get_instance_private (update_detail);
 
 	switch (prop_id) {
 	case PROP_PACKAGE_ID:
 		g_free (priv->package_id);
-		priv->package_id = g_strdup (g_value_get_string (value));
+		priv->package_id = g_value_dup_string (value);
 		break;
 	case PROP_UPDATES:
 		g_strfreev (priv->updates);
-		priv->updates = g_strdupv (g_value_get_boxed (value));
+		priv->updates = g_value_dup_boxed (value);
 		break;
 	case PROP_OBSOLETES:
 		g_strfreev (priv->obsoletes);
-		priv->obsoletes = g_strdupv (g_value_get_boxed (value));
+		priv->obsoletes = g_value_dup_boxed (value);
 		break;
 	case PROP_VENDOR_URLS:
 		g_strfreev (priv->vendor_urls);
-		priv->vendor_urls = g_strdupv (g_value_get_boxed (value));
+		priv->vendor_urls = g_value_dup_boxed (value);
 		break;
 	case PROP_BUGZILLA_URLS:
 		g_strfreev (priv->bugzilla_urls);
-		priv->bugzilla_urls = g_strdupv (g_value_get_boxed (value));
+		priv->bugzilla_urls = g_value_dup_boxed (value);
 		break;
 	case PROP_CVE_URLS:
 		g_strfreev (priv->cve_urls);
-		priv->cve_urls = g_strdupv (g_value_get_boxed (value));
+		priv->cve_urls = g_value_dup_boxed (value);
 		break;
 	case PROP_RESTART:
 		priv->restart = g_value_get_enum (value);
 		break;
 	case PROP_UPDATE_TEXT:
 		g_free (priv->update_text);
-		priv->update_text = g_strdup (g_value_get_string (value));
+		priv->update_text = g_value_dup_string (value);
 		break;
 	case PROP_CHANGELOG:
 		g_free (priv->changelog);
-		priv->changelog = g_strdup (g_value_get_string (value));
+		priv->changelog = g_value_dup_string (value);
 		break;
 	case PROP_STATE:
 		priv->state = g_value_get_enum (value);
 		break;
 	case PROP_ISSUED:
 		g_free (priv->issued);
-		priv->issued = g_strdup (g_value_get_string (value));
+		priv->issued = g_value_dup_string (value);
 		break;
 	case PROP_UPDATED:
 		g_free (priv->updated);
-		priv->updated = g_strdup (g_value_get_string (value));
+		priv->updated = g_value_dup_string (value);
 		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -527,8 +561,6 @@ pk_update_detail_class_init (PkUpdateDetailClass *klass)
 				     NULL,
 				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 	g_object_class_install_property (object_class, PROP_UPDATED, pspec);
-
-	g_type_class_add_private (klass, sizeof (PkUpdateDetailPrivate));
 }
 
 /*
@@ -537,7 +569,7 @@ pk_update_detail_class_init (PkUpdateDetailClass *klass)
 static void
 pk_update_detail_init (PkUpdateDetail *update_detail)
 {
-	update_detail->priv = PK_UPDATE_DETAIL_GET_PRIVATE (update_detail);
+	update_detail->priv = pk_update_detail_get_instance_private (update_detail);
 }
 
 /*
@@ -547,18 +579,18 @@ static void
 pk_update_detail_finalize (GObject *object)
 {
 	PkUpdateDetail *update_detail = PK_UPDATE_DETAIL (object);
-	PkUpdateDetailPrivate *priv = update_detail->priv;
+	PkUpdateDetailPrivate *priv = pk_update_detail_get_instance_private (update_detail);
 
-	g_free (priv->package_id);
-	g_strfreev (priv->updates);
-	g_strfreev (priv->obsoletes);
-	g_strfreev (priv->vendor_urls);
-	g_strfreev (priv->bugzilla_urls);
-	g_free (priv->cve_urls);
-	g_free (priv->update_text);
-	g_free (priv->changelog);
-	g_free (priv->issued);
-	g_free (priv->updated);
+	g_clear_pointer (&priv->package_id, g_free);
+	g_clear_pointer (&priv->updates, g_strfreev);
+	g_clear_pointer (&priv->obsoletes, g_strfreev);
+	g_clear_pointer (&priv->vendor_urls, g_strfreev);
+	g_clear_pointer (&priv->bugzilla_urls, g_strfreev);
+	g_clear_pointer (&priv->cve_urls, g_free);
+	g_clear_pointer (&priv->update_text, g_free);
+	g_clear_pointer (&priv->changelog, g_free);
+	g_clear_pointer (&priv->issued, g_free);
+	g_clear_pointer (&priv->updated, g_free);
 
 	G_OBJECT_CLASS (pk_update_detail_parent_class)->finalize (object);
 }

--- a/meson.build
+++ b/meson.build
@@ -11,11 +11,16 @@ pkg = import('pkgconfig')
 
 source_root = meson.project_source_root()
 
-glib_dep = dependency('glib-2.0', version: '>=2.76')
-gobject_dep = dependency('gobject-2.0')
-gio_dep = dependency('gio-2.0')
-gio_unix_dep = dependency('gio-unix-2.0', version: '>=2.16.1')
-gmodule_dep = dependency('gmodule-2.0', version: '>=2.16.1')
+glib_req_version = '2.76'
+glib_req = '>= @0@'.format(glib_req_version)
+glib_major = glib_req_version.split('.')[0].to_int()
+glib_minor = glib_req_version.split('.')[1].to_int()
+
+glib_dep = dependency('glib-2.0', version: glib_req)
+gobject_dep = dependency('gobject-2.0', version: glib_req)
+gio_dep = dependency('gio-2.0', version: glib_req)
+gio_unix_dep = dependency('gio-unix-2.0', version: glib_req)
+gmodule_dep = dependency('gmodule-2.0', version: glib_req)
 sqlite3_dep = dependency('sqlite3')
 polkit_dep = dependency('polkit-gobject-1', version: '>=0.114')
 
@@ -61,8 +66,10 @@ endif
 # Ensure functions like realpath(3) and other "default" functions are available
 add_project_arguments ('-D_DEFAULT_SOURCE', language: 'c')
 
-# Avoid g_simple_async_result deprecation warnings in glib 2.46+
-add_project_arguments ('-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_44', language: 'c')
+add_project_arguments (
+  '-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_@0@_@1@'.format(glib_major, glib_minor),
+  language: 'c'
+)
 
 # allow the daemon to include library files directly
 add_project_arguments ('-DPK_COMPILATION', language: ['c', 'cpp'])

--- a/src/pk-backend-job.c
+++ b/src/pk-backend-job.c
@@ -1163,7 +1163,7 @@ pk_backend_job_update_detail (PkBackendJob *job,
 			      const gchar *issued_text,
 			      const gchar *updated_text)
 {
-	GTimeVal timeval;
+	g_autoptr(GDateTime) datetime = NULL;
 	g_autoptr(PkUpdateDetail) item = NULL;
 
 	g_return_if_fail (PK_IS_BACKEND_JOB (job));
@@ -1183,12 +1183,16 @@ pk_backend_job_update_detail (PkBackendJob *job,
 
 	/* check the issued dates are valid */
 	if (issued_text != NULL) {
-		if (!g_time_val_from_iso8601 (issued_text, &timeval))
+		datetime = g_date_time_new_from_iso8601 (issued_text, NULL);
+		if (!datetime)
 			g_warning ("failed to parse issued '%s'", issued_text);
+		g_clear_object (&datetime);
 	}
 	if (updated_text != NULL) {
-		if (!g_time_val_from_iso8601 (updated_text, &timeval))
+		datetime = g_date_time_new_from_iso8601 (updated_text, NULL);
+		if (!datetime)
 			g_warning ("failed to parse updated '%s'", updated_text);
+		g_clear_object (&datetime);
 	}
 
 	/* form PkUpdateDetail struct */

--- a/src/pk-backend-job.h
+++ b/src/pk-backend-job.h
@@ -30,6 +30,8 @@
 G_BEGIN_DECLS
 
 #define PK_TYPE_BACKEND_JOB		(pk_backend_job_get_type ())
+G_DECLARE_FINAL_TYPE (PkBackendJob, pk_backend_job, PK, BACKEND_JOB, GObject)
+
 #define PK_BACKEND_JOB(o)		(G_TYPE_CHECK_INSTANCE_CAST ((o), PK_TYPE_BACKEND_JOB, PkBackendJob))
 #define PK_BACKEND_JOB_CLASS(k)		(G_TYPE_CHECK_CLASS_CAST((k), PK_TYPE_BACKEND_JOB, PkBackendJobClass))
 #define PK_IS_BACKEND_JOB(o)		(G_TYPE_CHECK_INSTANCE_TYPE ((o), PK_TYPE_BACKEND_JOB))
@@ -65,22 +67,6 @@ typedef enum {
 	PK_BACKEND_SIGNAL_LAST
 } PkBackendJobSignal;
 
-typedef struct
-{
-	GObject			 parent;
-	PkBackendJobPrivate	*priv;
-} PkBackendJob;
-
-typedef struct
-{
-	GObjectClass	parent_class;
-} PkBackendJobClass;
-
-#ifdef G_DEFINE_AUTOPTR_CLEANUP_FUNC
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(PkBackendJob, g_object_unref)
-#endif
-
-GType		 pk_backend_job_get_type		(void);
 PkBackendJob	*pk_backend_job_new			(GKeyFile		*conf);
 
 void		 pk_backend_job_disconnect_vfuncs	(PkBackendJob	*job);

--- a/src/pk-backend-spawn.h
+++ b/src/pk-backend-spawn.h
@@ -28,29 +28,11 @@
 G_BEGIN_DECLS
 
 #define PK_TYPE_BACKEND_SPAWN		(pk_backend_spawn_get_type ())
-#define PK_BACKEND_SPAWN(o)		(G_TYPE_CHECK_INSTANCE_CAST ((o), PK_TYPE_BACKEND_SPAWN, PkBackendSpawn))
-#define PK_BACKEND_SPAWN_CLASS(k)	(G_TYPE_CHECK_CLASS_CAST((k), PK_TYPE_BACKEND_SPAWN, PkBackendSpawnClass))
-#define PK_IS_BACKEND_SPAWN(o)		(G_TYPE_CHECK_INSTANCE_TYPE ((o), PK_TYPE_BACKEND_SPAWN))
-#define PK_IS_BACKEND_SPAWN_CLASS(k)	(G_TYPE_CHECK_CLASS_TYPE ((k), PK_TYPE_BACKEND_SPAWN))
-#define PK_BACKEND_SPAWN_GET_CLASS(o)	(G_TYPE_INSTANCE_GET_CLASS ((o), PK_TYPE_BACKEND_SPAWN, PkBackendSpawnClass))
+G_DECLARE_FINAL_TYPE (PkBackendSpawn, pk_backend_spawn, PK, BACKEND_SPAWN, GObject)
 
 #define PK_BACKEND_SPAWN_FILENAME_DELIM	"|"
 
-typedef struct PkBackendSpawnPrivate PkBackendSpawnPrivate;
-
-typedef struct
-{
-	 GObject		 parent;
-	 PkBackendSpawnPrivate	*priv;
-} PkBackendSpawn;
-
-typedef struct
-{
-	GObjectClass	parent_class;
-} PkBackendSpawnClass;
-
 /* general */
-GType		 pk_backend_spawn_get_type		(void);
 PkBackendSpawn	*pk_backend_spawn_new			(GKeyFile		*conf);
 gboolean	 pk_backend_spawn_helper		(PkBackendSpawn	*backend_spawn,
 							 PkBackendJob	*job,

--- a/src/pk-backend.h
+++ b/src/pk-backend.h
@@ -42,28 +42,7 @@
 G_BEGIN_DECLS
 
 #define PK_TYPE_BACKEND		(pk_backend_get_type ())
-#define PK_BACKEND(o)		(G_TYPE_CHECK_INSTANCE_CAST ((o), PK_TYPE_BACKEND, PkBackend))
-#define PK_BACKEND_CLASS(k)	(G_TYPE_CHECK_CLASS_CAST((k), PK_TYPE_BACKEND, PkBackendClass))
-#define PK_IS_BACKEND(o)	(G_TYPE_CHECK_INSTANCE_TYPE ((o), PK_TYPE_BACKEND))
-#define PK_IS_BACKEND_CLASS(k)	(G_TYPE_CHECK_CLASS_TYPE ((k), PK_TYPE_BACKEND))
-#define PK_BACKEND_GET_CLASS(o)	(G_TYPE_INSTANCE_GET_CLASS ((o), PK_TYPE_BACKEND, PkBackendClass))
-
-typedef struct PkBackendPrivate PkBackendPrivate;
-
-typedef struct
-{
-	 GObject		 parent;
-	 PkBackendPrivate	*priv;
-} PkBackend;
-
-typedef struct
-{
-	GObjectClass		 parent_class;
-} PkBackendClass;
-
-#ifdef G_DEFINE_AUTOPTR_CLEANUP_FUNC
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(PkBackend, g_object_unref)
-#endif
+G_DECLARE_FINAL_TYPE (PkBackend, pk_backend, PK, BACKEND, GObject)
 
 /**
  * PK_BACKEND_PERCENTAGE_INVALID:
@@ -72,10 +51,9 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(PkBackend, g_object_unref)
  */
 #define PK_BACKEND_PERCENTAGE_INVALID		101
 
-GType		 pk_backend_get_type			(void);
 PkBackend	*pk_backend_new				(GKeyFile		*conf);
 
-/* utililties */
+/* utilities */
 gboolean	 pk_backend_load			(PkBackend	*backend,
 							 GError		**error)
 							 G_GNUC_WARN_UNUSED_RESULT;

--- a/src/pk-dbus.h
+++ b/src/pk-dbus.h
@@ -27,30 +27,8 @@
 G_BEGIN_DECLS
 
 #define PK_TYPE_DBUS		(pk_dbus_get_type ())
-#define PK_DBUS(o)		(G_TYPE_CHECK_INSTANCE_CAST ((o), PK_TYPE_DBUS, PkDbus))
-#define PK_DBUS_CLASS(k)	(G_TYPE_CHECK_CLASS_CAST((k), PK_TYPE_DBUS, PkDbusClass))
-#define PK_IS_DBUS(o)		(G_TYPE_CHECK_INSTANCE_TYPE ((o), PK_TYPE_DBUS))
-#define PK_IS_DBUS_CLASS(k)	(G_TYPE_CHECK_CLASS_TYPE ((k), PK_TYPE_DBUS))
-#define PK_DBUS_GET_CLASS(o)	(G_TYPE_INSTANCE_GET_CLASS ((o), PK_TYPE_DBUS, PkDbusClass))
+G_DECLARE_FINAL_TYPE (PkDbus, pk_dbus, PK, DBUS, GObject)
 
-typedef struct PkDbusPrivate PkDbusPrivate;
-
-typedef struct
-{
-	GObject			 parent;
-	PkDbusPrivate		*priv;
-} PkDbus;
-
-typedef struct
-{
-	GObjectClass		 parent_class;
-} PkDbusClass;
-
-#ifdef G_DEFINE_AUTOPTR_CLEANUP_FUNC
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(PkDbus, g_object_unref)
-#endif
-
-GType		 pk_dbus_get_type		(void);
 PkDbus		*pk_dbus_new			(void);
 gboolean	 pk_dbus_connect		(PkDbus		*dbus,
 						 GError		**error);

--- a/src/pk-engine.h
+++ b/src/pk-engine.h
@@ -31,30 +31,10 @@
 G_BEGIN_DECLS
 
 #define PK_TYPE_ENGINE		(pk_engine_get_type ())
-#define PK_ENGINE(o)		(G_TYPE_CHECK_INSTANCE_CAST ((o), PK_TYPE_ENGINE, PkEngine))
-#define PK_ENGINE_CLASS(k)	(G_TYPE_CHECK_CLASS_CAST((k), PK_TYPE_ENGINE, PkEngineClass))
-#define PK_IS_ENGINE(o)	 	(G_TYPE_CHECK_INSTANCE_TYPE ((o), PK_TYPE_ENGINE))
-#define PK_IS_ENGINE_CLASS(k)	(G_TYPE_CHECK_CLASS_TYPE ((k), PK_TYPE_ENGINE))
-#define PK_ENGINE_GET_CLASS(o)	(G_TYPE_INSTANCE_GET_CLASS ((o), PK_TYPE_ENGINE, PkEngineClass))
-#define PK_ENGINE_ERROR		(pk_engine_error_quark ())
+G_DECLARE_FINAL_TYPE (PkEngine, pk_engine, PK, ENGINE, GObject)
+
+#define PK_ENGINE_ERROR	(pk_engine_error_quark ())
 #define PK_ENGINE_TYPE_ERROR	(pk_engine_error_get_type ())
-
-typedef struct PkEnginePrivate PkEnginePrivate;
-
-typedef struct
-{
-	 GObject		 parent;
-	 PkEnginePrivate	*priv;
-} PkEngine;
-
-typedef struct
-{
-	GObjectClass	parent_class;
-} PkEngineClass;
-
-#ifdef G_DEFINE_AUTOPTR_CLEANUP_FUNC
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(PkEngine, g_object_unref)
-#endif
 
 typedef enum
 {
@@ -71,8 +51,7 @@ typedef enum
 
 GQuark		 pk_engine_error_quark			(void);
 GType		 pk_engine_error_get_type		(void);
-GType		 pk_engine_get_type		  	(void);
-PkEngine	*pk_engine_new				(GKeyFile		*conf);
+PkEngine	*pk_engine_new				(GKeyFile	*conf);
 
 guint		 pk_engine_get_seconds_idle		(PkEngine	*engine);
 gboolean	 pk_engine_load_backend			(PkEngine	*engine,

--- a/src/pk-scheduler.h
+++ b/src/pk-scheduler.h
@@ -30,32 +30,12 @@
 G_BEGIN_DECLS
 
 #define PK_TYPE_SCHEDULER		(pk_scheduler_get_type ())
-#define PK_SCHEDULER(o)			(G_TYPE_CHECK_INSTANCE_CAST ((o), PK_TYPE_SCHEDULER, PkScheduler))
-#define PK_SCHEDULER_CLASS(k)		(G_TYPE_CHECK_CLASS_CAST((k), PK_TYPE_SCHEDULER, PkSchedulerClass))
-#define PK_IS_SCHEDULER(o)	 	(G_TYPE_CHECK_INSTANCE_TYPE ((o), PK_TYPE_SCHEDULER))
-#define PK_IS_SCHEDULER_CLASS(k)	(G_TYPE_CHECK_CLASS_TYPE ((k), PK_TYPE_SCHEDULER))
-#define PK_SCHEDULER_GET_CLASS(o)	(G_TYPE_INSTANCE_GET_CLASS ((o), PK_TYPE_SCHEDULER, PkSchedulerClass))
+G_DECLARE_FINAL_TYPE (PkScheduler, pk_scheduler, PK, SCHEDULER, GObject)
+
 #define PK_SCHEDULER_ERROR		(pk_scheduler_error_quark ())
-#define PK_SCHEDULER_TYPE_ERROR		(pk_scheduler_error_get_type ())
+#define PK_SCHEDULER_TYPE_ERROR	(pk_scheduler_error_get_type ())
 
-typedef struct PkSchedulerPrivate PkSchedulerPrivate;
 
-typedef struct
-{
-	 GObject		 parent;
-	 PkSchedulerPrivate	*priv;
-} PkScheduler;
-
-typedef struct
-{
-	GObjectClass		 parent_class;
-} PkSchedulerClass;
-
-#ifdef G_DEFINE_AUTOPTR_CLEANUP_FUNC
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(PkScheduler, g_object_unref)
-#endif
-
-GType		 pk_scheduler_get_type	  	(void);
 PkScheduler	*pk_scheduler_new		(GKeyFile	*conf);
 
 gboolean	 pk_scheduler_create		(PkScheduler	*scheduler,

--- a/src/pk-spawn.h
+++ b/src/pk-spawn.h
@@ -27,30 +27,10 @@
 G_BEGIN_DECLS
 
 #define PK_TYPE_SPAWN		(pk_spawn_get_type ())
-#define PK_SPAWN(o)		(G_TYPE_CHECK_INSTANCE_CAST ((o), PK_TYPE_SPAWN, PkSpawn))
-#define PK_SPAWN_CLASS(k)	(G_TYPE_CHECK_CLASS_CAST((k), PK_TYPE_SPAWN, PkSpawnClass))
-#define PK_IS_SPAWN(o)	 	(G_TYPE_CHECK_INSTANCE_TYPE ((o), PK_TYPE_SPAWN))
-#define PK_IS_SPAWN_CLASS(k)	(G_TYPE_CHECK_CLASS_TYPE ((k), PK_TYPE_SPAWN))
-#define PK_SPAWN_GET_CLASS(o)	(G_TYPE_INSTANCE_GET_CLASS ((o), PK_TYPE_SPAWN, PkSpawnClass))
+G_DECLARE_FINAL_TYPE (PkSpawn, pk_spawn, PK, SPAWN, GObject)
+
 #define PK_SPAWN_ERROR		(pk_spawn_error_quark ())
 #define PK_SPAWN_TYPE_ERROR	(pk_spawn_error_get_type ())
-
-typedef struct PkSpawnPrivate PkSpawnPrivate;
-
-typedef struct
-{
-	 GObject		 parent;
-	 PkSpawnPrivate		*priv;
-} PkSpawn;
-
-typedef struct
-{
-	GObjectClass	parent_class;
-} PkSpawnClass;
-
-#ifdef G_DEFINE_AUTOPTR_CLEANUP_FUNC
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(PkSpawn, g_object_unref)
-#endif
 
 /**
  * PkSpawnExitType:
@@ -73,7 +53,6 @@ typedef enum {
 	PK_SPAWN_ARGV_FLAGS_LAST
 } PkSpawnArgvFlags;
 
-GType		 pk_spawn_get_type			(void);
 PkSpawn		*pk_spawn_new				(GKeyFile		*conf);
 
 gboolean	 pk_spawn_argv				(PkSpawn	*spawn,

--- a/src/pk-transaction-db.h
+++ b/src/pk-transaction-db.h
@@ -28,30 +28,8 @@
 G_BEGIN_DECLS
 
 #define PK_TYPE_TRANSACTION_DB		(pk_transaction_db_get_type ())
-#define PK_TRANSACTION_DB(o)		(G_TYPE_CHECK_INSTANCE_CAST ((o), PK_TYPE_TRANSACTION_DB, PkTransactionDb))
-#define PK_TRANSACTION_DB_CLASS(k)	(G_TYPE_CHECK_CLASS_CAST((k), PK_TYPE_TRANSACTION_DB, PkTransactionDbClass))
-#define PK_IS_TRANSACTION_DB(o)		(G_TYPE_CHECK_INSTANCE_TYPE ((o), PK_TYPE_TRANSACTION_DB))
-#define PK_IS_TRANSACTION_DB_CLASS(k)	(G_TYPE_CHECK_CLASS_TYPE ((k), PK_TYPE_TRANSACTION_DB))
-#define PK_TRANSACTION_DB_GET_CLASS(o)	(G_TYPE_INSTANCE_GET_CLASS ((o), PK_TYPE_TRANSACTION_DB, PkTransactionDbClass))
+G_DECLARE_FINAL_TYPE (PkTransactionDb, pk_transaction_db, PK, TRANSACTION_DB, GObject)
 
-typedef struct PkTransactionDbPrivate PkTransactionDbPrivate;
-
-typedef struct
-{
-	 GObject		 parent;
-	 PkTransactionDbPrivate	*priv;
-} PkTransactionDb;
-
-typedef struct
-{
-	GObjectClass	parent_class;
-} PkTransactionDbClass;
-
-#ifdef G_DEFINE_AUTOPTR_CLEANUP_FUNC
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(PkTransactionDb, g_object_unref)
-#endif
-
-GType		 pk_transaction_db_get_type		(void);
 PkTransactionDb	*pk_transaction_db_new			(void);
 gboolean	 pk_transaction_db_load			(PkTransactionDb	*tdb,
 							 GError			**error);

--- a/src/pk-transaction.h
+++ b/src/pk-transaction.h
@@ -31,26 +31,11 @@
 G_BEGIN_DECLS
 
 #define PK_TYPE_TRANSACTION		(pk_transaction_get_type ())
-#define PK_TRANSACTION(o)		(G_TYPE_CHECK_INSTANCE_CAST ((o), PK_TYPE_TRANSACTION, PkTransaction))
-#define PK_IS_TRANSACTION(o)	 	(G_TYPE_CHECK_INSTANCE_TYPE ((o), PK_TYPE_TRANSACTION))
+G_DECLARE_FINAL_TYPE (PkTransaction, pk_transaction, PK, TRANSACTION, GObject)
+
 #define PK_TRANSACTION_ERROR		(pk_transaction_error_quark ())
 
 typedef struct PkTransactionPrivate PkTransactionPrivate;
-
-typedef struct
-{
-	 GObject		 parent;
-	 PkTransactionPrivate	*priv;
-} PkTransaction;
-
-typedef struct
-{
-	GObjectClass	parent_class;
-} PkTransactionClass;
-
-#ifdef G_DEFINE_AUTOPTR_CLEANUP_FUNC
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(PkTransaction, g_object_unref)
-#endif
 
 /* these have to be kept in order */
 typedef enum {
@@ -64,7 +49,6 @@ typedef enum {
 } PkTransactionState;
 
 GQuark		 pk_transaction_error_quark			(void);
-GType		 pk_transaction_get_type			(void);
 PkTransaction	*pk_transaction_new				(GKeyFile		*conf,
 								 GDBusNodeInfo	*introspection);
 


### PR DESCRIPTION
Set all GLib libraries as requiring the same version, always keep the MIN/MAX macro definition as the same as the version requirement.