### PR TITLE
Require polkit 0.114

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -17,10 +17,7 @@ gio_dep = dependency('gio-2.0')
 gio_unix_dep = dependency('gio-unix-2.0', version: '>=2.16.1')
 gmodule_dep = dependency('gmodule-2.0', version: '>=2.16.1')
 sqlite3_dep = dependency('sqlite3')
-polkit_dep = dependency('polkit-gobject-1', version: '>=0.98')
-if polkit_dep.version().version_compare('>=0.114')
-  add_project_arguments ('-DHAVE_POLKIT_0_114=1', language: 'c')
-endif
+polkit_dep = dependency('polkit-gobject-1', version: '>=0.114')
 
 libsystemd = []
 if get_option('systemd')

--- a/src/pk-engine.c
+++ b/src/pk-engine.c
@@ -51,11 +51,6 @@
 #include "pk-transaction.h"
 #include "pk-scheduler.h"
 
-#ifndef HAVE_POLKIT_0_114
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(PolkitAuthorizationResult, g_object_unref)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(PolkitSubject, g_object_unref)
-#endif
-
 static void     pk_engine_finalize	(GObject       *object);
 static void	pk_engine_set_locked (PkEngine *engine, gboolean is_locked);
 

--- a/src/pk-transaction.c
+++ b/src/pk-transaction.c
@@ -56,11 +56,6 @@
 #include "pk-transaction.h"
 #include "pk-transaction-private.h"
 
-#ifndef HAVE_POLKIT_0_114
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(PolkitAuthorizationResult, g_object_unref)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(PolkitDetails, g_object_unref)
-#endif
-
 static void     pk_transaction_finalize		(GObject	    *object);
 static void     pk_transaction_dispose		(GObject	    *object);
 


### PR DESCRIPTION
We can safely require this version from 2018 and remove our autoptr workarounds.