### PR TITLE
apt: Fix updated and issued dates on changelog parsing

### DIFF
--- a/backends/apt/apt-utils.h
+++ b/backends/apt/apt-utils.h
@@ -82,4 +82,11 @@ string utilBuildPackageOriginId(pkgCache::VerFileIterator vf);
   */
 const char *toUtf8(const char *str);
 
+/**
+  * Changelog dates are in format RFC2822/RFC5322 compatible:
+  * "day-of-week, dd month yyyy hh:mm:ss +zzzz"
+  * Parses and converts to ISO8601 respecting the original timezone
+  */
+string changelogDateToIso8601 (const string &date_str);
+
 #endif

--- a/backends/apt/tests/apt-tests.cpp
+++ b/backends/apt/tests/apt-tests.cpp
@@ -24,6 +24,7 @@
 
 #include "deb822.h"
 #include "apt-sourceslist.h"
+#include "apt-utils.h"
 #include "gst-matcher.h"
 
 namespace fs = std::filesystem;
@@ -450,6 +451,26 @@ apt_test_sources_write (void)
     fs::remove_all(wtestSourcesDir);
 }
 
+static void
+apt_test_changelog_date (void)
+{
+    // Test dates in the format of debian changelog
+    // and the expected result in format ISO8601
+    const set<pair<string, string>> testDatesSet = {
+        {"Thu, 12 Sep 2024 22:51:37 +0200", "2024-09-12T22:51:37+02"},
+        {"Sat, 29 Mar 2025 09:34:52 -0700", "2025-03-29T09:34:52-07"},
+        {"Sun, 13 Jan 2023 11:33:31 +0000", "2023-01-13T11:33:31Z"},
+        // Intentionally wrong date or format
+        {"Sat, 30 Feb 2022 15:12:45 -0500", ""},
+        {"2025-05-20T20:47:45+01", ""},
+    };
+
+    for (const auto &testDate : testDatesSet) {
+        const string isoDate = changelogDateToIso8601(testDate.first);
+        g_assert_cmpstr(isoDate.c_str(), ==, testDate.second.c_str());
+    }
+}
+
 int
 main (int argc, char **argv)
 {
@@ -473,6 +494,7 @@ main (int argc, char **argv)
     g_test_add_func ("/apt/deb822/readwrite", apt_test_deb822);
     g_test_add_func ("/apt/sources/read", apt_test_sources_read);
     g_test_add_func ("/apt/sources/write", apt_test_sources_write);
+    g_test_add_func ("/apt/utils/changelog-date", apt_test_changelog_date);
 
     return g_test_run();
 }


### PR DESCRIPTION
Fixes the parsing of the changelog dates, which resulted on the `issued` and `updated` date parameters never getting filled.

According to `deb-changelog` specification, the dates in the apt changelog entries do not follow RFC1123 format (which doesn't handle timezones), buut is compatible with RFC2822/RFC5322, that is:
    "day-of-week, dd month yyyy hh:mm:ss +zzzz"

Also, rework the conditions to check first for the changelog date line (starts with " --") so it doesn't get shadowed by the general condition (starts with " ")

Some examples of the reported dates on the client side, by adding some debug output to discover:

```
"kde-cli-tools;4:6.3.4-0ubuntu1;amd64;ubuntu-plucky-universe"
Issued: QDateTime(2025-03-29 15:13:49.000 UTC-05:00 Qt::OffsetFromUTC -18000 s )
Updated: QDateTime(2025-04-02 08:54:06.000 UTC+01:00 Qt::OffsetFromUTC 3600 s )
"### 4:6.3.4-0ubuntu1\n\n * New upstream release (6.3.4)\n\n\n 
-- Rik Mills <rikmills@kde.org>  Wed, 02Apr 2025 08:54:06 +0100\n\n  \n
### 4:6.3.3-0ubuntu2\n\n * No-change rebuild for Qt 6.8.3 ([LP: #2103945](https://bugs.launchpad.net/bugs/2103945)).\n\n\n 
-- Simon Quigley <tsimonq2@ubuntu.com>  Sat, 29 Mar2025 15:13:49 -0500\n"

"ubuntu-release-upgrader-core;1:25.04.15;all;ubuntu-plucky-updates-main"
Issued: QDateTime(2025-04-24 11:20:23.000 UTC-04:00 Qt::OffsetFromUTC -14400 s )
Updated: QDateTime(Invalid)
" == 1:25.04.15 ==\n [ Nick Rosbrook ]\n * DistUpgradeController: exclude pre-write foreign packages from removal\n   (LP: #2107657)\n * data: account for ubuntustudio-desktop-core (LP: #2104859)\n * Run pre-build.sh: updating mirrors.\n [ Julian Andres Klode ]\n * Only upgrade libc6 first if there are no unexpected changes (LP: #2106202)\n\n 
-- Nick Rosbrook <enr0n@ubuntu.com>  Thu, 24 Apr 2025 11:20:23 -0400"
```