### PR TITLE
pk-client: Fix a leak when cancelling a client task

### DIFF
--- a/lib/packagekit-glib2/pk-client.c
+++ b/lib/packagekit-glib2/pk-client.c
@@ -218,6 +218,8 @@ pk_client_state_remove (PkClient *client, PkClientState *state)
 static void
 pk_client_state_finish (PkClientState *state, GError *error)
 {
+	g_autoptr(GError) error_owned = g_steal_pointer (&error);
+
 	if (state->res == NULL)
 		return;
 
@@ -233,7 +235,7 @@ pk_client_state_finish (PkClientState *state, GError *error)
 		                       g_object_ref (state->results),
 		                       g_object_unref);
 	} else {
-		g_task_return_error (state->res, error);
+		g_task_return_error (state->res, g_steal_pointer (&error_owned));
 	}
 
 	/* remove any socket file */


### PR DESCRIPTION
This happens if one of the early return paths in
`pk_client_state_finish()` is taken — the `error` has been passed in as (transfer full) but isn’t then freed or stolen.

```
Direct leak of 256 byte(s) in 16 object(s) allocated from:
    #0 0x7f62d26e6f0b in malloc (/lib64/libasan.so.8+0xe6f0b) (BuildId: 7f1aa7e2e600e8c9d54ce6e3d36f3d31bfe7949a)
    #1 0x7f62d167b888 in g_malloc ../../source/glib/glib/gmem.c:100
    #2 0x7f62d16ab123 in g_slice_alloc ../../source/glib/glib/gslice.c:193
    #3 0x7f62d16ab16a in g_slice_alloc0 ../../source/glib/glib/gslice.c:217
    #4 0x7f62d1642092 in g_error_allocate ../../source/glib/glib/gerror.c:235
    #5 0x7f62d16420e4 in g_error_new_steal ../../source/glib/glib/gerror.c:249
    #6 0x7f62d1642471 in g_error_new_literal ../../source/glib/glib/gerror.c:347
    #7 0x7f62d18b7dee in pk_client_cancellable_cancel_cb ../../source/PackageKit/lib/packagekit-glib2/pk-client.c:360
    #8 0x7f62d253ae54 in g_cclosure_marshal_VOID__VOID ../../source/glib/gobject/gmarshal.c:117
    #9 0x7f62d2534d44 in g_closure_invoke ../../source/glib/gobject/gclosure.c:916
    #10 0x7f62d256e5cc in signal_emit_unlocked_R ../../source/glib/gobject/gsignal.c:3902
    #11 0x7f62d256cca7 in signal_emit_valist_unlocked ../../source/glib/gobject/gsignal.c:3534
    #12 0x7f62d256b044 in g_signal_emit_valist ../../source/glib/gobject/gsignal.c:3277
    #13 0x7f62d256d44e in g_signal_emit ../../source/glib/gobject/gsignal.c:3597
    #14 0x7f62d1a2f0e0 in g_cancellable_cancel ../../source/glib/gio/gcancellable.c:541
    #15 0x7f62d20adbd1 in gs_job_manager_shutdown_thread ../../source/gnome-software/lib/gs-job-manager.c:669
    #16 0x7f62d1aed6a5 in g_task_thread_pool_thread ../../source/glib/gio/gtask.c:1585
    #17 0x7f62d16c6826 in g_thread_pool_thread_proxy ../../source/glib/glib/gthreadpool.c:336
    #18 0x7f62d16c54e7 in g_thread_proxy ../../source/glib/glib/gthread.c:893
    #19 0x7f62d2628ee5 in asan_thread_start(void*) (/lib64/libasan.so.8+0x28ee5) (BuildId: 7f1aa7e2e600e8c9d54ce6e3d36f3d31bfe7949a)
```