### PR TITLE
pkmon: Fix g_object_unref() assertion error

### DIFF
--- a/client/pk-monitor.c
+++ b/client/pk-monitor.c
@@ -414,6 +414,6 @@ main (int argc, char *argv[])
 	/* spin */
 	g_main_loop_run (loop);
 out:
-	g_object_unref (client);
+	g_clear_object (&client);
 	return retval;
 }


### PR DESCRIPTION
Fixes the following assertion failure.

```
$ pkmon --version
1.3.1

(pkmon:15069): GLib-GObject-CRITICAL **: 07:11:30.866: g_object_unref: assertion 'G_IS_OBJECT (object)' failed
```