### PR TITLE
trivial: meson: use https for docbook

### DIFF
--- a/client/meson.build
+++ b/client/meson.build
@@ -51,7 +51,7 @@ if get_option('man_pages')
     command: [
       xsltproc,
       '--output', '@OUTPUT@',
-      'http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl',
+      'https://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl',
       '@INPUT@',
     ],
     install: true,
@@ -64,7 +64,7 @@ if get_option('man_pages')
     command: [
       xsltproc,
       '--output', '@OUTPUT@',
-      'http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl',
+      'https://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl',
       '@INPUT@',
     ],
     install: true,


### PR DESCRIPTION
The website moved permanently:

```console
$ curl 'http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl'
<html>
<head><title>301 Moved Permanently</title></head>
<body>
<center><h1>301 Moved Permanently</h1></center>
<hr><center>cloudflare</center>
</body>
</html>
$ curl 'https://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl'
<?xml version='1.0'?>
<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                xmlns:exsl="http://exslt.org/common"
                xmlns:ng="http://docbook.org/docbook-ng"
                xmlns:db="http://docbook.org/ns/docbook"
                exclude-result-prefixes="exsl"
                version='1.0'>
[...]
```