### PR TITLE
apt: Handle gstreamer ()(64bit) suffix on any architecture

### DIFF
--- a/backends/apt/apt-job.cpp
+++ b/backends/apt/apt-job.cpp
@@ -626,13 +626,15 @@ void AptJob::providesCodec(PkgList &output, gchar **values)
         }
 
         arch = string(ver.Arch());
+        bool native = arch == "all" ||
+                      arch == m_cache->GetPkgCache()->NativeArch();
 
         pkgCache::VerFileIterator vf = ver.FileList();
         pkgRecords::Parser &rec = m_cache->GetPkgRecords()->Lookup(vf);
         const char *start, *stop;
         rec.GetRec(start, stop);
         string record(start, stop - start);
-        if (matcher.matches(record, arch)) {
+        if (matcher.matches(record, native)) {
             output.append(ver);
         }
     }

--- a/backends/apt/gst-matcher.h
+++ b/backends/apt/gst-matcher.h
@@ -34,7 +34,7 @@ typedef struct {
     string   data;
     string   opt;
     void    *caps;
-    string   arch;
+    bool     native;
 } Match;
 
 class GstMatcher
@@ -43,7 +43,7 @@ public:
     GstMatcher(gchar **values);
     ~GstMatcher();
 
-    bool matches(string record, string arch);
+    bool matches(string record, bool arch);
     bool hasMatches() const;
 
 private:

--- a/backends/apt/tests/apt-tests.cpp
+++ b/backends/apt/tests/apt-tests.cpp
@@ -123,12 +123,12 @@ static void
 apt_test_gst_matcher_with_caps (void)
 {
     {
-        /* Matches amd64-only */
+        /* Matches native architecture only */
         GstMatcher matcher(codec_strv("gstreamer1(decoder-audio/mpeg)(mpegversion=4)()(64bit)"));
         g_assert_true(matcher.hasMatches());
 
-        g_assert_true(matcher.matches(gst_plugins_bad_pkg, "amd64"));
-        g_assert_false(matcher.matches(gst_plugins_bad_pkg, "i386"));
+        g_assert_true(matcher.matches(gst_plugins_bad_pkg, TRUE /* native */));
+        g_assert_false(matcher.matches(gst_plugins_bad_pkg, FALSE /* native */));
     }
 
     {
@@ -136,9 +136,8 @@ apt_test_gst_matcher_with_caps (void)
         GstMatcher matcher(codec_strv("gstreamer1(decoder-audio/mpeg)(mpegversion=4)"));
         g_assert_true(matcher.hasMatches());
 
-        g_assert_true(matcher.matches(gst_plugins_bad_pkg, "amd64"));
-        g_assert_true(matcher.matches(gst_plugins_bad_pkg, "i386"));
-        g_assert_true(matcher.matches(gst_plugins_bad_pkg, "arm64"));
+        g_assert_true(matcher.matches(gst_plugins_bad_pkg, TRUE /* native */));
+        g_assert_true(matcher.matches(gst_plugins_bad_pkg, FALSE /* native */));
     }
 
     {
@@ -146,9 +145,9 @@ apt_test_gst_matcher_with_caps (void)
         GstMatcher matcher(codec_strv("gstreamer1(decoder-audio/mpeg)(mpegversion=4)"));
         g_assert_true(matcher.hasMatches());
 
-        g_assert_true(matcher.matches(gst_plugins_bad_pkg, "amd64"));
-        g_assert_false(matcher.matches(gst_plugins_ugly_pkg, "amd64"));
-        g_assert_false(matcher.matches("", "amd64"));
+        g_assert_true(matcher.matches(gst_plugins_bad_pkg, TRUE /* native */));
+        g_assert_false(matcher.matches(gst_plugins_ugly_pkg, TRUE /* native */));
+        g_assert_false(matcher.matches("", TRUE /* native */));
     }
 }
 
@@ -156,12 +155,12 @@ static void
 apt_test_gst_matcher_without_caps (void)
 {
     {
-        /* Matches amd64-only */
+        /* Matches native architecture only */
         GstMatcher matcher(codec_strv("gstreamer1(decoder-video/x-h265)()(64bit)"));
         g_assert_true(matcher.hasMatches());
 
-        g_assert_true(matcher.matches(gst_plugins_bad_pkg, "amd64"));
-        g_assert_false(matcher.matches(gst_plugins_bad_pkg, "i386"));
+        g_assert_true(matcher.matches(gst_plugins_bad_pkg, TRUE /* native */));
+        g_assert_false(matcher.matches(gst_plugins_bad_pkg, FALSE /* native */));
     }
 
     {
@@ -169,9 +168,8 @@ apt_test_gst_matcher_without_caps (void)
         GstMatcher matcher(codec_strv("gstreamer1(decoder-video/x-h265)"));
         g_assert_true(matcher.hasMatches());
 
-        g_assert_true(matcher.matches(gst_plugins_bad_pkg, "amd64"));
-        g_assert_true(matcher.matches(gst_plugins_bad_pkg, "i386"));
-        g_assert_true(matcher.matches(gst_plugins_bad_pkg, "arm64"));
+        g_assert_true(matcher.matches(gst_plugins_bad_pkg, TRUE /* native */));
+        g_assert_true(matcher.matches(gst_plugins_bad_pkg, FALSE /* native */));
     }
 
     {
@@ -179,9 +177,9 @@ apt_test_gst_matcher_without_caps (void)
         GstMatcher matcher(codec_strv("gstreamer1(decoder-video/x-h265)"));
         g_assert_true(matcher.hasMatches());
 
-        g_assert_true(matcher.matches(gst_plugins_bad_pkg, "amd64"));
-        g_assert_false(matcher.matches(gst_plugins_ugly_pkg, "amd64"));
-        g_assert_false(matcher.matches("", "amd64"));
+        g_assert_true(matcher.matches(gst_plugins_bad_pkg, TRUE /* native */));
+        g_assert_false(matcher.matches(gst_plugins_ugly_pkg, TRUE /* native */));
+        g_assert_false(matcher.matches("", TRUE /* native */));
     }
 }
 
@@ -192,14 +190,14 @@ apt_test_gst_matcher_bad_caps (void)
         GstMatcher matcher(codec_strv("gstreamer1(decoder-audio/mpeg)(mpegversion=5)()(64bit)"));
         g_assert_true(matcher.hasMatches());
 
-        g_assert_false(matcher.matches(gst_plugins_bad_pkg, "amd64"));
+        g_assert_false(matcher.matches(gst_plugins_bad_pkg, TRUE /* native */));
     }
 
     {
         GstMatcher matcher(codec_strv("gstreamer1(decoder-audio/mpeg)(mpegversion=5)"));
         g_assert_true(matcher.hasMatches());
 
-        g_assert_false(matcher.matches(gst_plugins_bad_pkg, "amd64"));
+        g_assert_false(matcher.matches(gst_plugins_bad_pkg, TRUE /* native */));
     }
 }
 


### PR DESCRIPTION
The ()(64bit) suffix is an RPM artifact, where it is used to distinguish between the primary and secondary architecture in a 2-arch system. It doesn't translate precisely to DPKG, where multi-arch is not limited to one secondary architecture. Let's use it the same way RPM would and only match the native arch.