### PR TITLE
apt: Match gstreamer plugins more accurately

### DIFF
--- a/backends/apt/gst-matcher.cpp
+++ b/backends/apt/gst-matcher.cpp
@@ -160,8 +160,8 @@ bool GstMatcher::matches(string record, string arch)
                     continue;
                 }
 
-                // if the record is capable of intersect them we found the package
-                bool provides = gst_caps_can_intersect(static_cast<GstCaps*>(match.caps), caps);
+                // if the record is compatible then we found the package
+                bool provides = gst_caps_is_always_compatible(static_cast<GstCaps*>(match.caps), caps);
                 gst_caps_unref(caps);
 
                 if (provides) {


### PR DESCRIPTION
gst_caps_can_intersect will return true if the intersection is non-void. What we want instead is to ensure that the query caps are a subset of the package record caps, so that all of the requested capabilities are satisfied. GStreamer conveniently calls this `gst_caps_is_always_compatible`, which is self explainatory.

There is a caveat: if the query contains a structure that is not found in the matching record, the method will still return true. That is technically not accurate, but also the query will never be hyper-specific[1] so it is pointless to try and write a precisely accurate matcher.

[1]: GStreamer strips out most capabilities when querying https://github.com/GStreamer/gstreamer/blob/24dcc0a009eed42df417a90601391e7de9fc1781/subprojects/gst-plugins-base/gst-libs/gst/pbutils/missing-plugins.c#L149C1-L149C20