### PR TITLE
meson: resolve warnings `-Wall`/`-Wextra`/`-Werror`

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('PackageKit', 'c',
   version : '1.3.2',
   license : 'LGPL-2.1+',
   meson_version : '>=1.0',
-  default_options : ['warning_level=2', 'c_std=gnu11'],
+  default_options : ['warning_level=2', 'c_std=gnu11', 'werror=true'],
 )
 
 gnome = import('gnome')
@@ -165,9 +165,6 @@ add_project_arguments(
 # maintainer mode is even stricter
 if get_option('maintainer')
     add_project_arguments(
-        '-Werror',
-        '-Wall',
-        '-Wextra',
         '-Wcast-align',
         '-Wno-uninitialized',
         '-Wempty-body',


### PR DESCRIPTION
The warnings:

```
meson.build:167: WARNING: Consider using the built-in werror option instead of using "-Werror".
meson.build:167: WARNING: Consider using the built-in warning_level option instead of using "-Wall".
meson.build:167: WARNING: Consider using the built-in warning_level option instead of using "-Wextra".
```

See https://mesonbuild.com/Builtin-options.html