### PR TITLE
alpm: Use 'pk_backend_job_details_full()' to report download size

### DIFF
--- a/backends/alpm/pk-alpm-packages.c
+++ b/backends/alpm/pk-alpm-packages.c
@@ -228,7 +228,6 @@ pk_backend_get_details_thread (PkBackendJob *job, GVariant* params, gpointer p)
 		GString *licenses;
 		PkGroupEnum group;
 		const gchar *desc, *url;
-		gulong size;
 
 		if (pk_backend_job_is_cancelled (job))
 			break;
@@ -254,14 +253,9 @@ pk_backend_get_details_thread (PkBackendJob *job, GVariant* params, gpointer p)
 		desc = alpm_pkg_get_desc (pkg);
 		url = alpm_pkg_get_url (pkg);
 
-		if (alpm_pkg_get_origin (pkg) == ALPM_PKG_FROM_LOCALDB) {
-			size = alpm_pkg_get_isize (pkg);
-		} else {
-			size = alpm_pkg_download_size (pkg);
-		}
-
-		pk_backend_job_details (job, *packages, NULL, licenses->str, group,
-					desc, url, size);
+		pk_backend_job_details_full (job, *packages, NULL, licenses->str, group,
+					     desc, url, alpm_pkg_get_isize (pkg),
+					     alpm_pkg_download_size (pkg));
 		g_string_free (licenses, TRUE);
 	}
 


### PR DESCRIPTION
Tested on latest archlinux.

- `gnome-software` package is installed.
- `gnome-builder` package is not installed.

### Reference data:

```
[sid@archlinux pkg]$ pacman -Qi gnome-software | grep ^Installed
Installed Size  : 15.89 MiB

[sid@archlinux pkg]$ ls -l /var/cache/pacman/pkg/gnome-builder-48.3-1-x86_64.pkg.tar.zst
-rw-r--r-- 1 root root 11107151 Aug 16 05:33 /var/cache/pacman/pkg/gnome-builder-48.3-1-x86_64.pkg.tar.zst

[sid@archlinux pkg]$ pacman -Qi -p /var/cache/pacman/pkg/gnome-builder-48.3-1-x86_64.pkg.tar.zst | grep ^Installed
Installed Size  : 27.08 MiB
```

### Without fix:

```
[sid@archlinux pkg]$ pkcon get-details gnome-software
Resolving                               [=========================]         
Getting details                         [=========================]         
Finished                                [=========================]         
Package description
  package:     gnome-software-48.4-1.x86_64
  summary:     (null)
  license:     GPL-2.0-or-later
  group:       desktop-gnome
  description: Allows you to find and install new apps
  size:        16664639 bytes
  url:         https://apps.gnome.org/Software
```

```
[sid@archlinux pkg]$ pkcon get-details gnome-builder
Resolving                               [=========================]         
Getting details                         [=========================]         
Querying                                [=========================]         
Finished                                [=========================]         
Package description
  package:     gnome-builder-48.3-1.x86_64
  summary:     (null)
  license:     GPL-3.0-or-later
  group:       desktop-gnome
  description: An IDE for writing GNOME-based software
  size:        0 bytes
  url:         https://apps.gnome.org/Builder/
```

```
[sid@archlinux pkg]$ pkcon get-details /var/cache/pacman/pkg/gnome-builder-48.3-1-x86_64.pkg.tar.zst
Getting details                         [=========================]         
Finished                                [=========================]         
Fatal error: GetDetailsLocal not supported by backend
```

### With fix:

```
[sid@archlinux pkg]$ pkcon get-details gnome-software
Resolving                               [=========================]         
Getting details                         [=========================]         
Querying                                [=========================]         
Finished                                [=========================]         
Package description
  package:        gnome-software-48.4-1.x86_64
  summary:        (null)
  license:        GPL-2.0-or-later
  group:          desktop-gnome
  size:           16.7 MB (16,664,639 bytes)
  download size:  0 bytes
  url:            https://apps.gnome.org/Software
  description:    Allows you to find and install new apps
```

```
[sid@archlinux pkg]$ pkcon get-details gnome-builder
Resolving                               [=========================]         
Getting details                         [=========================]         
Finished                                [=========================]         
Package description
  package:        gnome-builder-48.3-1.x86_64
  summary:        (null)
  license:        GPL-3.0-or-later
  group:          desktop-gnome
  size:           28.4 MB (28,390,605 bytes)
  download size:  11.1 MB (11,107,151 bytes)
  url:            https://apps.gnome.org/Builder/
  description:    An IDE for writing GNOME-based software
```