### PR TITLE
apt: debconf-helper: Fix assertion errors

### DIFF
--- a/backends/apt/pk-debconf-helper.c
+++ b/backends/apt/pk-debconf-helper.c
@@ -30,7 +30,7 @@ int main(void)
 
 
 	if (sd_listen_fds (0) != 1) {
-			g_error("No or too many file descriptors received.\n");
+			g_error("No or too many file descriptors received.");
 			exit(1);
 	}
 
@@ -38,13 +38,13 @@ int main(void)
 	socket = g_socket_new_from_fd (fd, &error);
 
 	if (error != NULL) {
-		g_error ("%s\n", error->message);
+		g_error ("%s", error->message);
 		return 1;
 	}
 
 	helper = pk_client_helper_new ();
 	if (!pk_client_helper_start_with_socket (helper, socket, argv, envp, &error)) {
-		g_error ("%s\n", error->message);
+		g_error ("%s", error->message);
 		return 1;
 	}
 

--- a/backends/apt/pk-debconf-helper.c
+++ b/backends/apt/pk-debconf-helper.c
@@ -7,17 +7,18 @@
 static GMainLoop *main_loop = NULL;
 static PkClientHelper *helper = NULL;
 
-static gboolean exit_loop(gpointer user_data)
+static gboolean exit_loop (gpointer user_data)
 {
-	g_debug("Checking for active connections");
-	if (!pk_client_helper_is_active(helper)) {
-		g_message("No active connections, exiting");
-		g_main_loop_quit(main_loop);
+	g_debug ("Checking for active connections");
+
+	if (!pk_client_helper_is_active (helper)) {
+		g_message ("No active connections, exiting");
+		g_main_loop_quit (main_loop);
 	}
 	return TRUE;
 }
 
-int main(void)
+int main (void)
 {
 	g_auto(GStrv) argv = NULL;
 	g_auto(GStrv) envp = NULL;
@@ -28,10 +29,9 @@ int main(void)
 	main_loop = g_main_loop_new (NULL, FALSE);
 	pk_client_create_helper_argv_envp (&argv, &envp);
 
-
 	if (sd_listen_fds (0) != 1) {
-			g_error("No or too many file descriptors received.");
-			exit(1);
+		g_error ("No or too many file descriptors received.");
+		exit (1);
 	}
 
 	fd = SD_LISTEN_FDS_START + 0;
@@ -54,5 +54,6 @@ int main(void)
 
 	g_object_unref (helper);
 	g_main_loop_unref (main_loop);
+
 	return 0;
 }

--- a/backends/apt/pk-debconf-helper.c
+++ b/backends/apt/pk-debconf-helper.c
@@ -53,6 +53,6 @@ int main(void)
 	g_main_loop_run (main_loop);
 
 	g_object_unref (helper);
-	g_object_unref (main_loop);
+	g_main_loop_unref (main_loop);
 	return 0;
 }

--- a/lib/packagekit-glib2/pk-client-helper.c
+++ b/lib/packagekit-glib2/pk-client-helper.c
@@ -531,7 +531,7 @@ pk_client_helper_start_with_socket (PkClientHelper *client_helper,
 	priv->envp = g_strdupv (envp);
 
 	/* Set the socket */
-	priv->socket = socket;
+	g_set_object (&priv->socket, socket);
 
 	/* socket has data */
 	fd = g_socket_get_fd (priv->socket);


### PR DESCRIPTION
Fixes the following assertion errors when `pk-debconf-helper` exits.

```
Aug 19 19:45:19 debian pk-debconf-help[22042]: g_object_unref: assertion 'G_IS_OBJECT (object)' failed
Aug 19 19:45:19 debian pk-debconf-help[22042]: g_object_unref: assertion 'G_IS_OBJECT (object)' failed
```

Please refer commit log for more details.