### PR TITLE
pk-offline.c: Plug a memleak I introduced earlier

### DIFF
--- a/lib/packagekit-glib2/pk-offline.c
+++ b/lib/packagekit-glib2/pk-offline.c
@@ -446,7 +446,7 @@ pk_offline_get_prepared_ids (GError **error)
 {
 	g_autoptr(GError) error_local = NULL;
 	g_autofree gchar *data = NULL;
-	gchar **prepared_ids = NULL;
+	g_auto(GStrv) prepared_ids = NULL;
 	gsize prepared_ids_size;
 	g_autoptr(GKeyFile) keyfile = NULL;
 
@@ -485,7 +485,7 @@ pk_offline_get_prepared_ids (GError **error)
 	if (prepared_ids == NULL || prepared_ids_size == 0)
 		return NULL;
 
-	return prepared_ids;
+	return g_steal_pointer (&prepared_ids);
 }
 
 /**


### PR DESCRIPTION
From what I gather, we can't use `g_autofree` on this pointer, because it must be freed with `g_strfreev`. The `g_autoptr(Gstrv)` implementation doesn't exist either.

This is a follow-up to https://github.com/PackageKit/PackageKit/pull/852#pullrequestreview-3270248754