### PR TITLE
dnf5-plugin: Link against libdnf5

### DIFF
--- a/backends/dnf/meson.build
+++ b/backends/dnf/meson.build
@@ -1,6 +1,6 @@
 appstream_dep = dependency('appstream', version: '>=0.14.0')
 dnf_dep = dependency('libdnf', version: '>=0.43.1')
-dnf5_dep = dependency('libdnf5').partial_dependency(includes: true, compile_args: true)
+dnf5_dep = dependency('libdnf5')
 libdnf5_version = dnf5_dep.version().split('.')
 rpm_dep = dependency('rpm')
 sdbus_cpp_dep = dependency('sdbus-c++')


### PR DESCRIPTION
There must have been a reason for me to not have linked libdnf5 when first authoring this module. I cannot remember that reason. It seems that it is now mandatory for plugins to link agiainst libdnf5.

rhbz#2399781