### PR TITLE
Move FailureAction= to the correct section

### DIFF
--- a/data/packagekit-offline-update.service.in
+++ b/data/packagekit-offline-update.service.in
@@ -8,8 +8,8 @@ Before=shutdown.target system-update.target
 # See packagekit.service
 ConditionPathExists=!/run/ostree-booted
 
+FailureAction=reboot
+
 [Service]
 Type=oneshot
 ExecStart=@libexecdir@/pk-offline-update
-
-FailureAction=reboot


### PR DESCRIPTION
[systemd commit 2c883d7](https://github.com/systemd/systemd/commit/2c883d7591f1545315a0c8ae5c487342f3cf9178) says "FailureAction= in [Service] is still supported but deprecated", and the documentation only mentions its presence in [Unit].

Move FailureAction= to [Unit], where it is more likely to remain supported.