### PR TITLE
PkBackendJob: Fix clearing GDateTime pointer

### DIFF
--- a/src/pk-backend-job.c
+++ b/src/pk-backend-job.c
@@ -1186,13 +1186,13 @@ pk_backend_job_update_detail (PkBackendJob *job,
 		datetime = g_date_time_new_from_iso8601 (issued_text, NULL);
 		if (!datetime)
 			g_warning ("failed to parse issued '%s'", issued_text);
-		g_clear_object (&datetime);
+		g_clear_pointer (&datetime, g_date_time_unref);
 	}
 	if (updated_text != NULL) {
 		datetime = g_date_time_new_from_iso8601 (updated_text, NULL);
 		if (!datetime)
 			g_warning ("failed to parse updated '%s'", updated_text);
-		g_clear_object (&datetime);
+		g_clear_pointer (&datetime, g_date_time_unref);
 	}
 
 	/* form PkUpdateDetail struct */


### PR DESCRIPTION
A GDateTime struct cannot be unreferenced with g_object_unref.

Closes: #906

---

FYI: not well known in GLib to know if this :100: correct but it gives me:

```
[root@archlinux ~]# pkcon get-update-detail linux
Resolving                               [=========================]
Getting update details                  [=========================]
Finished                                [=========================]
Details about the update:
 Package: linux-6.17.4.arch2-1.x86_64
 Updates: linux;6.17.4.arch2-1;x86_64;installed
 Vendor: https://archlinux.org/packages/core/x86_64/linux/
 Update text: Update to a newer release
 Changes:
 State: stable
 Issued: 2025-10-19T19:21:18Z
 Updated: 2025-10-21T12:42:06Z
```

Which is better then v1.3.1!