### PR TITLE
alpm: Ignore new Sandbox configuration options

### DIFF
--- a/backends/alpm/pk-alpm-config.c
+++ b/backends/alpm/pk-alpm-config.c
@@ -614,6 +614,14 @@ pk_alpm_config_parse (PkAlpmConfig *config, const gchar *filename,
 			continue;
 		}
 
+		if (g_strcmp0 (key, "DisableSandboxFilesystem") == 0) {
+			continue;
+		}
+
+		if (g_strcmp0 (key, "DisableSandboxSyscalls") == 0) {
+			continue;
+		}
+
 		if (g_strcmp0 (key, "DownloadUser") == 0 && str != NULL) {
 			continue;
 		}


### PR DESCRIPTION
Pacman 7.1 introduced two new configuration options to allow some parts of the sandbox to be disabled. As these are not handled by PackageKit ignore them.