### PR TITLE
contrib,ci,meson: Drop gobject-introspection and raise to glib2 >= 2.80

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ task:
     - sed 's|/quarterly|/latest|' /etc/pkg/FreeBSD.conf > /usr/local/etc/pkg/repos/FreeBSD.conf
     - env ASSUME_ALWAYS_YES=yes pkg update -f
     - env ASSUME_ALWAYS_YES=yes pkg install -y docbook-xsl-ns vala libxslt fontconfig polkit consolekit2
-        desktop-file-utils gettext meson ninja python3 glib gtk3 pkgconf sqlite3 gobject-introspection
+        desktop-file-utils gettext meson ninja python3 glib gtk3 pkgconf sqlite3
         jansson dbus bash
   build_script:
     - meson --auto-features=enabled -Db_colorout=never --buildtype debug -Dlocal_checkout=true -Dlocalstatedir=/var

--- a/contrib/PackageKit.spec.in
+++ b/contrib/PackageKit.spec.in
@@ -13,7 +13,7 @@ Requires: shared-mime-info
 Requires: systemd
 
 BuildRequires: python3-devel
-BuildRequires: glib2-devel >= 2.46.0
+BuildRequires: glib2-devel >= 2.80
 BuildRequires: xmlto
 BuildRequires: gtk-doc
 BuildRequires: sqlite-devel
@@ -30,7 +30,6 @@ BuildRequires: gstreamer1-plugins-base-devel
 BuildRequires: pango-devel
 BuildRequires: fontconfig-devel
 BuildRequires: systemd-devel
-BuildRequires: gobject-introspection-devel
 %if !0%{?rhel}
 BuildRequires: bash-completion
 %endif
@@ -73,7 +72,7 @@ cross-architecture API.
 %package glib
 Summary: GLib libraries for accessing PackageKit
 Requires: dbus >= 1.1.1
-Requires: gobject-introspection
+Requires: glib2 >= 2.80
 Obsoletes: PackageKit-libs < %{version}-%{release}
 Provides: PackageKit-libs = %{version}-%{release}
 

--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,7 @@ pkg = import('pkgconfig')
 
 source_root = meson.project_source_root()
 
-glib_req_version = '2.76'
+glib_req_version = '2.80'
 glib_req = '>= @0@'.format(glib_req_version)
 glib_major = glib_req_version.split('.')[0].to_int()
 glib_minor = glib_req_version.split('.')[1].to_int()

--- a/tests/ci/Dockerfile-debian
+++ b/tests/ci/Dockerfile-debian
@@ -14,13 +14,14 @@ RUN eatmydata apt-get install -yq --no-install-recommends \
 	docbook-xsl-ns \
 	gettext \
 	gir1.2-glib-2.0 \
-	gobject-introspection \
+	girepository-tools \
 	gtk-doc-tools \
 	libappstream-dev \
 	libapt-pkg-dev \
 	libarchive-dev \
-	libgirepository1.0-dev \
+	libgirepository-2.0-dev \
 	libglib2.0-dev \
+	libglib2.0-dev-bin \
 	libgstreamer-plugins-base1.0-dev \
 	libgtk-3-dev \
 	libjansson-dev \


### PR DESCRIPTION
At this point, nobody should be offering this with an older glib2 that does not provide the built-in implementation of the gi tools, so we can safely depend on that now.