### PR TITLE
backends: Hook up job user_data destroy func

### DIFF
--- a/src/pk-backend-job.c
+++ b/src/pk-backend-job.c
@@ -826,6 +826,7 @@ pk_backend_job_thread_create (PkBackendJob *job,
 	helper->backend = job->backend;
 	helper->func = func;
 	helper->user_data = user_data;
+	helper->destroy_func = destroy_func;
 
 	/* create a thread and unref it immediately as we do not need to join()
 	 * this at any stage */


### PR DESCRIPTION
pk_backend_job_thread_create accepts a user_data and associated destroy_func argument, but the destroy_func was ignored and thus user_data always leaked. Thankfully no backend seems to use any user_data.