### PR TITLE
doc: Delete MAINTAINERS file in favour of PackageKit.doap

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,1 +1,0 @@
-Richard Hughes <richard@hughsie.com>


### PR DESCRIPTION
It isn’t up to date, and if it was it would duplicate the information in PackageKit.doap, so I suggest just keeping the latter.

---

This is just a drive-by suggestion as I spotted the file is out of date. Feel free to close the PR if you don’t like the suggestion or have a different idea! :)