### PR TITLE
Draft: Change package-id format to split "origin" and "data" into separate fields

### DIFF
--- a/backends/alpm/pk-alpm-packages.c
+++ b/backends/alpm/pk-alpm-packages.c
@@ -47,7 +47,7 @@ pk_alpm_pkg_build_id (alpm_pkg_t *pkg)
 		repo = "installed";
 	}
 
-	return pk_package_id_build (name, version, arch, repo);
+	return pk_package_id_build (name, version, arch, repo, NULL);
 }
 
 void
@@ -76,7 +76,7 @@ pk_alpm_find_pkg (PkBackendJob *job, const gchar *package_id, GError **error)
 	g_return_val_if_fail (package_id != NULL, NULL);
 
 	package = pk_package_id_split (package_id);
-	repo_id = package[PK_PACKAGE_ID_DATA];
+	repo_id = package[PK_PACKAGE_ID_ORIGIN];
 
 	/* find the database to search in */
 	if (g_strcmp0 (repo_id, "installed") == 0) {

--- a/backends/alpm/pk-alpm-sync.c
+++ b/backends/alpm/pk-alpm-sync.c
@@ -42,7 +42,7 @@ pk_alpm_transaction_sync_targets (PkBackendJob *job, const gchar **packages, gbo
 
 	for (; *packages != NULL; ++packages) {
 		g_auto(GStrv) package = pk_package_id_split (*packages);
-		gchar *repo = package[PK_PACKAGE_ID_DATA];
+		gchar *repo = package[PK_PACKAGE_ID_ORIGIN];
 		gchar *name = package[PK_PACKAGE_ID_NAME];
 		alpm_pkg_t *dep_to_remove;
 

--- a/backends/apt/apt-job.cpp
+++ b/backends/apt/apt-job.cpp
@@ -1577,7 +1577,7 @@ void AptJob::emitPackageFilesLocal(const gchar *file)
     }
 
     g_autofree gchar *package_id = pk_package_id_build(
-        deb.packageName().c_str(), deb.version().c_str(), deb.architecture().c_str(), file);
+        deb.packageName().c_str(), deb.version().c_str(), deb.architecture().c_str(), file, nullptr);
 
     g_autoptr(GPtrArray) files = g_ptr_array_new_with_free_func(g_free);
     for (auto cFile : deb.files()) {

--- a/backends/dnf/dnf-backend.c
+++ b/backends/dnf/dnf-backend.c
@@ -261,7 +261,7 @@ dnf_get_filter_for_ids (gchar **package_ids)
 
 	for (i = 0; package_ids[i] != NULL && (!installed || !available); i++) {
 		g_auto(GStrv) split = pk_package_id_split (package_ids[i]);
-		if (g_strcmp0 (split[PK_PACKAGE_ID_DATA], "installed") == 0)
+		if (g_strcmp0 (split[PK_PACKAGE_ID_ORIGIN], "installed") == 0)
 			installed = TRUE;
 		else
 			available = TRUE;

--- a/backends/dnf/pk-backend-dnf.c
+++ b/backends/dnf/pk-backend-dnf.c
@@ -1791,7 +1791,7 @@ dnf_utils_find_package_ids (DnfSack *sack, gchar **package_ids, GError **error)
 		g_auto(GStrv) split = NULL;
 		hy_query_clear (query);
 		split = pk_package_id_split (package_ids[i]);
-		reponame = split[PK_PACKAGE_ID_DATA];
+		reponame = split[PK_PACKAGE_ID_ORIGIN];
 		if (g_strcmp0 (reponame, "installed") == 0 ||
 		    g_str_has_prefix (reponame, "installed:"))
 			reponame = HY_SYSTEM_REPO_NAME;

--- a/backends/dummy/pk-backend-dummy.c
+++ b/backends/dummy/pk-backend-dummy.c
@@ -142,14 +142,14 @@ pk_backend_depends_on (PkBackend *backend, PkBackendJob *job, PkBitfield filters
 {
 	pk_backend_job_set_status (job, PK_STATUS_ENUM_QUERY);
 
-	if (g_strcmp0 (package_ids[0], "scribus;1.3.4-1.fc8;i386;fedora") == 0) {
+	if (g_strcmp0 (package_ids[0], "scribus;1.3.4-1.fc8;i386;fedora;") == 0) {
 		pk_backend_job_package (job, PK_INFO_ENUM_AVAILABLE,
-					"scribus-clipart;1.3.4-1.fc8;i386;fedora", "Clipart for scribus");
+					"scribus-clipart;1.3.4-1.fc8;i386;fedora;", "Clipart for scribus");
 	} else {
 		pk_backend_job_package (job, PK_INFO_ENUM_INSTALLED,
-					"glib2;2.14.0;i386;fedora", "The GLib library");
+					"glib2;2.14.0;i386;fedora;", "The GLib library");
 		pk_backend_job_package (job, PK_INFO_ENUM_AVAILABLE,
-					"gtk2;gtk2-2.11.6-6.fc8;i386;fedora", "GTK+ Libraries for GIMP");
+					"gtk2;gtk2-2.11.6-6.fc8;i386;fedora;", "GTK+ Libraries for GIMP");
 	}
 	pk_backend_job_finished (job);
 }
@@ -159,7 +159,7 @@ pk_backend_get_details_local (PkBackend *backend, PkBackendJob *job, gchar **fil
 {
 	pk_backend_job_set_status (job, PK_STATUS_ENUM_QUERY);
 	pk_backend_job_set_percentage (job, 0);
-	pk_backend_job_details (job, "powertop;1.8-1.fc8;i386;fedora", "Power consumption monitor", "GPL2", PK_GROUP_ENUM_PROGRAMMING,
+	pk_backend_job_details (job, "powertop;1.8-1.fc8;i386;fedora;", "Power consumption monitor", "GPL2", PK_GROUP_ENUM_PROGRAMMING,
 				"PowerTOP is a tool that finds the software component(s) that make your "
 				"computer use more power than necessary while it is idle.", "http://live.gnome.org/powertop", 101*1024, 0);
 	pk_backend_job_set_percentage (job, 100);
@@ -175,7 +175,7 @@ pk_backend_get_files_local (PkBackend *backend, PkBackendJob *job, gchar **_file
 				 NULL };
 	pk_backend_job_set_status (job, PK_STATUS_ENUM_QUERY);
 	pk_backend_job_set_percentage (job, 0);
-	pk_backend_job_files (job, "test;0.01;i386;local", (gchar **) files);
+	pk_backend_job_files (job, "test;0.01;i386;local;", (gchar **) files);
 	pk_backend_job_set_percentage (job, 100);
 	pk_backend_job_finished (job);
 }
@@ -194,31 +194,31 @@ pk_backend_get_details (PkBackend *backend, PkBackendJob *job, gchar **package_i
 	len = g_strv_length (package_ids);
 	for (i = 0; i < len; i++) {
 		package_id = package_ids[i];
-		if (g_strcmp0 (package_id, "powertop;1.8-1.fc8;i386;fedora") == 0) {
-			pk_backend_job_details (job, "powertop;1.8-1.fc8;i386;fedora", "Power consumption monitor",
+		if (g_strcmp0 (package_id, "powertop;1.8-1.fc8;i386;fedora;") == 0) {
+			pk_backend_job_details (job, "powertop;1.8-1.fc8;i386;fedora;", "Power consumption monitor",
 						"GPL2", PK_GROUP_ENUM_PROGRAMMING,
 						"PowerTOP is a tool that finds the software component(s) that make your "
 						"computer use more power than necessary while it is idle.", "http://live.gnome.org/powertop", 101*1024, G_MAXUINT64);
-		} else if (g_strcmp0 (package_id, "kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed") == 0) {
-			pk_backend_job_details (job, "kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed",
+		} else if (g_strcmp0 (package_id, "kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed;") == 0) {
+			pk_backend_job_details (job, "kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed;",
 						"The Linux kernel (the core of the Linux operating system)",
 						"GPL2", PK_GROUP_ENUM_PROGRAMMING,
 						"The kernel package contains the Linux kernel (vmlinuz), the core of any "
 						"Linux operating system.  The kernel handles the basic functions of the "
 						"operating system: memory allocation, process allocation, device input "
 						"and output, etc.", "http://www.kernel.org", 33*1024*1024, G_MAXUINT64);
-		} else if (g_strcmp0 (package_id, "gtkhtml2;2.19.1-4.fc8;i386;fedora") == 0) {
+		} else if (g_strcmp0 (package_id, "gtkhtml2;2.19.1-4.fc8;i386;fedora;") == 0) {
 			pk_backend_job_details (job, "gtkhtml2;2.19.1-4.fc8;i386;fedora", "An HTML widget for GTK+ 2.0",
 						"GPL2", PK_GROUP_ENUM_PROGRAMMING,
 						"GtkHTML2 (sometimes called libgtkhtml) is a widget for displaying html "
 						"pages.", "http://live.gnome.org/gtkhtml", 133*1024, G_MAXUINT64);
-		} else if (g_strcmp0 (package_id, "vino;2.24.2.fc9;i386;fedora") == 0) {
-			pk_backend_job_details (job, "vino;2.24.2.fc9;i386;fedora", "Remote desktop server for the desktop",
+		} else if (g_strcmp0 (package_id, "vino;2.24.2.fc9;i386;fedora;") == 0) {
+			pk_backend_job_details (job, "vino;2.24.2.fc9;i386;fedora;", "Remote desktop server for the desktop",
 						"GPL2", PK_GROUP_ENUM_PROGRAMMING,
 						"Vino is a VNC server for GNOME. It allows remote users to "
 						"connect to a running GNOME session using VNC.", "http://live.gnome.org/powertop", 3*1024*1024, G_MAXUINT64);
-		} else if (g_strcmp0 (package_id, "gnome-power-manager;2.6.19;i386;fedora") == 0) {
-			pk_backend_job_details (job, "gnome-power-manager;2.6.19;i386;fedora", "GNOME power management service",
+		} else if (g_strcmp0 (package_id, "gnome-power-manager;2.6.19;i386;fedora;") == 0) {
+			pk_backend_job_details (job, "gnome-power-manager;2.6.19;i386;fedora;", "GNOME power management service",
 						"GPL2", PK_GROUP_ENUM_PROGRAMMING,
 						"GNOME Power Manager uses the information and facilities provided by HAL "
 						"displaying icons and handling user callbacks in an interactive GNOME session.\n"
@@ -226,7 +226,7 @@ pk_backend_get_details (PkBackend *backend, PkBackendJob *job, gchar **package_i
 						"change preferences.", "http://projects.gnome.org/gnome-power-manager/", 13*1024*1024, G_MAXUINT64);
 		//TODO: add other packages
 		} else {
-			pk_backend_job_details (job, "scribus;1.3.4-1.fc8;i386;fedora", 
+			pk_backend_job_details (job, "scribus;1.3.4-1.fc8;i386;fedora;",
 						"Scribus is an desktop open source page layout program",
 						"GPL2", PK_GROUP_ENUM_PROGRAMMING,
 						"Scribus is an desktop *open source* page layöut program with "
@@ -270,16 +270,16 @@ pk_backend_get_files (PkBackend *backend, PkBackendJob *job, gchar **package_ids
 	len = g_strv_length (package_ids);
 	for (i = 0; i < len; i++) {
 		package_id = package_ids[i];
-		if (g_strcmp0 (package_id, "powertop;1.8-1.fc8;i386;fedora") == 0) {
+		if (g_strcmp0 (package_id, "powertop;1.8-1.fc8;i386;fedora;") == 0) {
 			to_strv[0] = "/usr/share/man/man1/boo";
 			to_strv[1] = "/usr/bin/xchat-gnome";
 			to_strv[2] = NULL;
-		} else if (g_strcmp0 (package_id, "kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed") == 0) {
+		} else if (g_strcmp0 (package_id, "kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed;") == 0) {
 			to_strv[0] = "/usr/share/man/man1";
 			to_strv[1] = "/usr/share/man/man1/gnome-power-manager.1.gz";
 			to_strv[2] = "/usr/lib/firefox-3.5.7/firefox";
 			to_strv[3] = NULL;
-		} else if (g_strcmp0 (package_id, "gtkhtml2;2.19.1-4.fc8;i386;fedora") == 0) {
+		} else if (g_strcmp0 (package_id, "gtkhtml2;2.19.1-4.fc8;i386;fedora;") == 0) {
 			to_strv[0] = "/usr/share/man/man1";
 			to_strv[1] = "/usr/bin/ck-xinit-session";
 			to_strv[2] = "/lib/libselinux.so.1";
@@ -299,9 +299,9 @@ pk_backend_required_by (PkBackend *backend, PkBackendJob *job, PkBitfield filter
 {
 	pk_backend_job_set_status (job, PK_STATUS_ENUM_QUERY);
 	pk_backend_job_package (job, PK_INFO_ENUM_INSTALLED,
-				"glib2;2.14.0;i386;fedora", "The GLib library");
+				"glib2;2.14.0;i386;fedora;", "The GLib library");
 	pk_backend_job_package (job, PK_INFO_ENUM_INSTALLED,
-				"gtk2;gtk2-2.11.6-6.fc8;i386;fedora", "GTK+ Libraries for GIMP");
+				"gtk2;gtk2-2.11.6-6.fc8;i386;fedora;", "GTK+ Libraries for GIMP");
 	pk_backend_job_finished (job);
 }
 
@@ -343,7 +343,7 @@ pk_backend_get_update_detail_timeout (gpointer data)
 		const gchar *to_array3[] = { NULL, NULL, NULL };
 		const gchar *to_array4[] = { NULL, NULL, NULL };
 		package_id = priv->package_ids[i];
-		if (g_strcmp0 (package_id, "powertop;1.8-1.fc8;i386;fedora") == 0) {
+		if (g_strcmp0 (package_id, "powertop;1.8-1.fc8;i386;fedora;") == 0) {
 			to_array1[0] = "powertop;1.7-1.fc8;i386;installed";
 			to_array2[0] = "http://www.distro-update.org/page?moo";
 			to_array3[0] = "http://bgzilla.fd.org/result.php?#12344";
@@ -357,7 +357,7 @@ pk_backend_get_update_detail_timeout (gpointer data)
 						      "Update to newest upstream source",
 						      changelog, PK_UPDATE_STATE_ENUM_STABLE,
 						      "2009-11-17T09:19:00", "2009-11-19T09:19:00");
-		} else if (g_strcmp0 (package_id, "kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed") == 0) {
+		} else if (g_strcmp0 (package_id, "kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed;") == 0) {
 			to_array1[0] = "kernel;2.6.22-0.104.rc3.git6.fc8;i386;installed";
 			to_array1[1] = "kernel;2.6.22-0.105.rc3.git7.fc8;i386;installed";
 			to_array2[0] = "http://www.distro-update.org/page?moo";
@@ -378,7 +378,7 @@ pk_backend_get_update_detail_timeout (gpointer data)
 						      PK_UPDATE_STATE_ENUM_UNSTABLE,
 						      "2008-06-28T09:19:00",
 						      NULL);
-		} else if (g_strcmp0 (package_id, "gtkhtml2;2.19.1-4.fc8;i386;fedora") == 0) {
+		} else if (g_strcmp0 (package_id, "gtkhtml2;2.19.1-4.fc8;i386;fedora;") == 0) {
 			to_array1[0] = "gtkhtml2;2.18.1-22.fc8;i386;installed";
 			to_array2[0] = "http://www.distro-update.org/page?moo";
 			to_array3[0] = "http://bgzilla.gnome.org/result.php?#9876";
@@ -398,7 +398,7 @@ pk_backend_get_update_detail_timeout (gpointer data)
 						      "2008-07-25T09:19:00",
 						      NULL);
 
-		} else if (g_strcmp0 (package_id, "vino;2.24.2.fc9;i386;fedora") == 0) {
+		} else if (g_strcmp0 (package_id, "vino;2.24.2.fc9;i386;fedora;") == 0) {
 			to_array1[0] = "vino;2.24.1.fc9;i386;fedora";
 			pk_backend_job_update_detail (job, package_id,
 						      (gchar**) to_array1,
@@ -444,23 +444,23 @@ pk_backend_get_updates_timeout (gpointer data)
 	if (priv->use_blocked) {
 		if (!priv->updated_powertop && !priv->updated_kernel && !priv->updated_gtkhtml) {
 			pk_backend_job_package (job, PK_INFO_ENUM_BLOCKED,
-						"vino;2.24.2.fc9;i386;fedora",
+						"vino;2.24.2.fc9;i386;fedora;",
 						"Remote desktop server for the desktop");
 		}
 	}
 	if (!priv->updated_powertop) {
 		pk_backend_job_package (job, PK_INFO_ENUM_NORMAL,
-					"powertop;1.8-1.fc8;i386;fedora",
+					"powertop;1.8-1.fc8;i386;fedora;",
 					"Power consumption monitor");
 	}
 	if (!priv->updated_kernel) {
 		pk_backend_job_package (job, PK_INFO_ENUM_BUGFIX,
-					"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed",
+					"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed;",
 					"The Linux kernel (the core of the Linux operating system)");
 	}
 	if (!priv->updated_gtkhtml) {
 		pk_backend_job_package (job, PK_INFO_ENUM_SECURITY,
-					"gtkhtml2;2.19.1-4.fc8;i386;fedora",
+					"gtkhtml2;2.19.1-4.fc8;i386;fedora;",
 					"An HTML widget for GTK+ 2.0");
 	}
 	pk_backend_job_finished (job);
@@ -510,18 +510,18 @@ pk_backend_install_thread (PkBackendJob *job, GVariant *params, gpointer user_da
 		if (job_data->progress_percentage == 30) {
 			pk_backend_job_set_allow_cancel (job, FALSE);
 			pk_backend_job_package (job, PK_INFO_ENUM_INSTALLING,
-						"gtkhtml2;2.19.1-4.fc8;i386;fedora",
+						"gtkhtml2;2.19.1-4.fc8;i386;fedora;",
 						"An HTML widget for GTK+ 2.0");
 			pk_backend_job_set_status (job, PK_STATUS_ENUM_INSTALL);
 		}
 
 		if (job_data->progress_percentage == 50) {
 			pk_backend_job_package (job, PK_INFO_ENUM_INSTALLING,
-						"gtkhtml2-devel;2.19.1-0.fc8;i386;fedora",
+						"gtkhtml2-devel;2.19.1-0.fc8;i386;fedora;",
 						"Devel files for gtkhtml");
 			/* this duplicate package should be ignored */
 			pk_backend_job_package (job, PK_INFO_ENUM_INSTALLING,
-						"gtkhtml2-devel;2.19.1-0.fc8;i386;fedora", NULL);
+						"gtkhtml2-devel;2.19.1-0.fc8;i386;fedora;", NULL);
 			pk_backend_job_set_status (job, PK_STATUS_ENUM_INSTALL);
 		}
 
@@ -550,28 +550,28 @@ pk_backend_install_packages (PkBackend *backend, PkBackendJob *job, PkBitfield t
 		pk_backend_job_set_status (job, PK_STATUS_ENUM_DEP_RESOLVE);
 
 		pk_backend_job_package (job, PK_INFO_ENUM_REMOVING,
-					"powertop;1.8-1.fc8;i386;fedora", "Power consumption monitor");
+					"powertop;1.8-1.fc8;i386;fedora;", "Power consumption monitor");
 
 		pk_backend_job_package (job, PK_INFO_ENUM_INSTALLING,
-					"gtk2;2.11.6-6.fc8;i386;fedora", "GTK+ Libraries for GIMP");
+					"gtk2;2.11.6-6.fc8;i386;fedora;", "GTK+ Libraries for GIMP");
 
 		pk_backend_job_package (job, PK_INFO_ENUM_UPDATING,
-					"lib7;7.0.1-6.fc13;i386;fedora", "C Libraries");
+					"lib7;7.0.1-6.fc13;i386;fedora;", "C Libraries");
 
 		pk_backend_job_package (job, PK_INFO_ENUM_REINSTALLING,
-					"libssl;3.5.7-2.fc13;i386;fedora", "SSL Libraries");
+					"libssl;3.5.7-2.fc13;i386;fedora;", "SSL Libraries");
 
 		pk_backend_job_package (job, PK_INFO_ENUM_DOWNGRADING,
-					"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed", "The Linux kernel (the core of the Linux operating system)");
+					"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed;", "The Linux kernel (the core of the Linux operating system)");
 
 		pk_backend_job_package (job, PK_INFO_ENUM_UPDATING,
-					"gtkhtml2;2.19.1-4.fc8;i386;fedora", "An HTML widget for GTK+ 2.0");
+					"gtkhtml2;2.19.1-4.fc8;i386;fedora;", "An HTML widget for GTK+ 2.0");
 
 		pk_backend_job_finished (job);
 		return;
 	}
 
-	if (g_strcmp0 (package_ids[0], "vips-doc;7.12.4-2.fc8;noarch;linva") == 0) {
+	if (g_strcmp0 (package_ids[0], "vips-doc;7.12.4-2.fc8;noarch;linva;") == 0) {
 		if (priv->use_gpg && !priv->has_signature) {
 			pk_backend_job_repo_signature_required (job, package_ids[0], "updates",
 								"http://example.com/gpgkey",
@@ -622,7 +622,7 @@ pk_backend_install_packages (PkBackend *backend, PkBackendJob *job, PkBitfield t
 		}
 	}
 
-	if ((g_strcmp0 (package_ids[0], "foobar;1.1.0;i386;debian") != 0) && (g_strcmp0 (package_ids[0], "libawesome;42;i386;debian") != 0)) {
+	if ((g_strcmp0 (package_ids[0], "foobar;1.1.0;i386;debian;manual") != 0) && (g_strcmp0 (package_ids[0], "libawesome;42;i386;debian;manual") != 0)) {
 		if (priv->use_trusted && pk_bitfield_contain (transaction_flags, PK_TRANSACTION_FLAG_ENUM_ONLY_TRUSTED)) {
 			pk_backend_job_error_code (job, PK_ERROR_ENUM_CANNOT_INSTALL_REPO_UNSIGNED,
 						"Can't install as untrusted");
@@ -646,7 +646,7 @@ pk_backend_install_packages (PkBackend *backend, PkBackendJob *job, PkBitfield t
 	pk_backend_job_set_allow_cancel (job, TRUE);
 	job_data->progress_percentage = 0;
 	pk_backend_job_package (job, PK_INFO_ENUM_DOWNLOADING,
-				"gtkhtml2;2.19.1-4.fc8;i386;fedora",
+				"gtkhtml2;2.19.1-4.fc8;i386;fedora;",
 				"An HTML widget for GTK+ 2.0");
 
 	pk_backend_job_thread_create (job, pk_backend_install_thread, NULL, NULL);
@@ -770,40 +770,40 @@ pk_backend_resolve_thread (PkBackendJob *job, GVariant *params, gpointer user_da
 	/* each one has a different detail for testing */
 	len = g_strv_length (search);
 	for (i = 0; i < len; i++) {
-		if (g_strcmp0 (search[i], "vips-doc") == 0 || g_strcmp0 (search[i], "vips-doc;7.12.4-2.fc8;noarch;linva") == 0) {
+		if (g_strcmp0 (search[i], "vips-doc") == 0 || g_strcmp0 (search[i], "vips-doc;7.12.4-2.fc8;noarch;linva;") == 0) {
 			if (!pk_bitfield_contain (filters, PK_FILTER_ENUM_INSTALLED)) {
 				pk_backend_job_package (job, PK_INFO_ENUM_AVAILABLE,
-							"vips-doc;7.12.4-2.fc8;noarch;linva",
+							"vips-doc;7.12.4-2.fc8;noarch;linva;",
 							"The vips documentation package.");
 			}
-		} else if (g_strcmp0 (search[i], "glib2") == 0 || g_strcmp0 (search[i], "glib2;2.14.0;i386;fedora") == 0) {
+		} else if (g_strcmp0 (search[i], "glib2") == 0 || g_strcmp0 (search[i], "glib2;2.14.0;i386;fedora;") == 0) {
 			if (!pk_bitfield_contain (filters, PK_FILTER_ENUM_NOT_INSTALLED)) {
 				pk_backend_job_package (job, PK_INFO_ENUM_INSTALLED,
-							"glib2;2.14.0;i386;fedora",
+							"glib2;2.14.0;i386;fedora;",
 							"The GLib library");
 			}
-		} else if (g_strcmp0 (search[i], "powertop") == 0 || g_strcmp0 (search[i], "powertop;1.8-1.fc8;i386;fedora") == 0)
+		} else if (g_strcmp0 (search[i], "powertop") == 0 || g_strcmp0 (search[i], "powertop;1.8-1.fc8;i386;fedora;") == 0)
 			pk_backend_job_package (job, PK_INFO_ENUM_INSTALLED,
-						"powertop;1.8-1.fc8;i386;fedora",
+						"powertop;1.8-1.fc8;i386;fedora;",
 						"Power consumption monitor");
-		else if (g_strcmp0 (search[i], "kernel") == 0 || g_strcmp0 (search[i], "kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed") == 0)
+		else if (g_strcmp0 (search[i], "kernel") == 0 || g_strcmp0 (search[i], "kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed;") == 0)
 			pk_backend_job_package (job, PK_INFO_ENUM_INSTALLED,
-						"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed",
+						"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed;",
 						"The Linux kernel (the core of the Linux operating system)");
-		else if (g_strcmp0 (search[i], "gtkhtml2") == 0 || g_strcmp0 (search[i], "gtkhtml2;2.19.1-4.fc8;i386;fedora") == 0)
+		else if (g_strcmp0 (search[i], "gtkhtml2") == 0 || g_strcmp0 (search[i], "gtkhtml2;2.19.1-4.fc8;i386;fedora;") == 0)
 			pk_backend_job_package (job, PK_INFO_ENUM_INSTALLED,
-						"gtkhtml2;2.19.1-4.fc8;i386;fedora",
+						"gtkhtml2;2.19.1-4.fc8;i386;fedora;",
 						"An HTML widget for GTK+ 2.0");
-		else if (g_strcmp0 (search[i], "foobar") == 0 || g_strcmp0 (search[i], "foobar;1.1.0;i386;debian") == 0) {
+		else if (g_strcmp0 (search[i], "foobar") == 0 || g_strcmp0 (search[i], "foobar;1.1.0;i386;debian;") == 0) {
 			if (!pk_bitfield_contain (filters, PK_FILTER_ENUM_INSTALLED)) {
 				pk_backend_job_package (job, PK_INFO_ENUM_AVAILABLE,
-							"foobar;1.1.0;i386;debian",
+							"foobar;1.1.0;i386;debian;",
 							"The awesome FooBar application");
 			}
-		} else if (g_strcmp0 (search[i], "libawesome") == 0 || g_strcmp0 (search[i], "libawesome;42;i386;debian") == 0) {
+		} else if (g_strcmp0 (search[i], "libawesome") == 0 || g_strcmp0 (search[i], "libawesome;42;i386;debian;") == 0) {
 			if (!pk_bitfield_contain (filters, PK_FILTER_ENUM_INSTALLED)) {
 				pk_backend_job_package (job, PK_INFO_ENUM_AVAILABLE,
-							"libawesome;42;i386;debian",
+							"libawesome;42;i386;debian;",
 							"Simple library for warping reality");
 			}
 		}
@@ -851,7 +851,7 @@ pk_backend_search_details_thread (PkBackendJob *job, GVariant *params, gpointer 
 	pk_backend_job_set_status (job, PK_STATUS_ENUM_QUERY);
 	pk_backend_job_set_allow_cancel (job, TRUE);
 	pk_backend_job_package (job, PK_INFO_ENUM_AVAILABLE,
-				"vips-doc;7.12.4-2.fc8;noarch;linva",
+				"vips-doc;7.12.4-2.fc8;noarch;linva;",
 				"The vips \"documentation\" package.");
 }
 
@@ -868,11 +868,11 @@ pk_backend_search_files (PkBackend *backend, PkBackendJob *job, PkBitfield filte
 	pk_backend_job_set_allow_cancel (job, TRUE);
 	if (!pk_bitfield_contain (filters, PK_FILTER_ENUM_INSTALLED))
 		pk_backend_job_package (job, PK_INFO_ENUM_AVAILABLE,
-					"vips-doc;7.12.4-2.fc8;noarch;linva",
+					"vips-doc;7.12.4-2.fc8;noarch;linva;",
 					"The vips documentation package");
 	else
 		pk_backend_job_package (job, PK_INFO_ENUM_INSTALLED,
-					"vips-doc;7.12.4-2.fc8;noarch;linva",
+					"vips-doc;7.12.4-2.fc8;noarch;linva;",
 					"The vips documentation package");
 	pk_backend_job_finished (job);
 }
@@ -883,10 +883,10 @@ pk_backend_search_groups (PkBackend *backend, PkBackendJob *job, PkBitfield filt
 	pk_backend_job_set_status (job, PK_STATUS_ENUM_QUERY);
 	pk_backend_job_set_allow_cancel (job, TRUE);
 	pk_backend_job_package (job, PK_INFO_ENUM_AVAILABLE,
-				"vips-doc;7.12.4-2.fc8;noarch;linva",
+				"vips-doc;7.12.4-2.fc8;noarch;linva;",
 				"The vips documentation package.");
 	pk_backend_job_package (job, PK_INFO_ENUM_AVAILABLE,
-				"bǣwulf-utf8;0.1;noarch;hughsie",
+				"bǣwulf-utf8;0.1;noarch;hughsie;data",
 				"The bǣwulf server test name.");
 	pk_backend_job_finished (job);
 }
@@ -925,21 +925,21 @@ pk_backend_search_names_thread (PkBackendJob *job, GVariant *params, gpointer us
 	locale = pk_backend_job_get_locale (job);
 	if (g_strcmp0 (locale, "en_GB.utf8") != 0) {
 		pk_backend_job_package (job, PK_INFO_ENUM_INSTALLED,
-					"evince;0.9.3-5.fc8;i386;installed",
+					"evince;0.9.3-5.fc8;i386;installed;",
 					"PDF Dokument Ƥrŏgrȃɱ");
 	} else {
 		pk_backend_job_package (job, PK_INFO_ENUM_INSTALLED,
-					"evince;0.9.3-5.fc8;i386;installed",
+					"evince;0.9.3-5.fc8;i386;installed;",
 					"PDF Document viewer");
 	}
 	pk_backend_job_package (job, PK_INFO_ENUM_INSTALLED,
-				"tetex;3.0-41.fc8;i386;fedora",
+				"tetex;3.0-41.fc8;i386;fedora;",
 				"TeTeX is an implementation of TeX for Linux or UNIX systems.");
 	pk_backend_job_package (job, PK_INFO_ENUM_AVAILABLE,
-				"scribus;1.3.4-1.fc8;i386;fedora",
+				"scribus;1.3.4-1.fc8;i386;fedora;",
 				"Scribus is an desktop open source page layout program");
 	pk_backend_job_package (job, PK_INFO_ENUM_AVAILABLE,
-				"vips-doc;7.12.4-2.fc8;noarch;linva",
+				"vips-doc;7.12.4-2.fc8;noarch;linva;",
 				"The vips documentation package.");
 }
 
@@ -977,7 +977,7 @@ pk_backend_update_packages_download_thread (PkBackendJob *job, GVariant *params,
 		if (job_data->progress_percentage == 100) {
 			if (priv->use_blocked) {
 				pk_backend_job_package (job, PK_INFO_ENUM_BLOCKED,
-							"gtkhtml2;2.19.1-4.fc8;i386;fedora",
+							"gtkhtml2;2.19.1-4.fc8;i386;fedora;",
 							"An HTML widget for GTK+ 2.0");
 				priv->updated_gtkhtml = FALSE;
 			}
@@ -985,7 +985,7 @@ pk_backend_update_packages_download_thread (PkBackendJob *job, GVariant *params,
 		}
 		if (job_data->progress_percentage == 0 && !priv->updated_powertop) {
 			pk_backend_job_package (job, PK_INFO_ENUM_DOWNLOADING,
-						"powertop;1.8-1.fc8;i386;fedora",
+						"powertop;1.8-1.fc8;i386;fedora;",
 						"Power consumption monitor");
 			pk_backend_job_set_item_progress (job,
 							"powertop;1.8-1.fc8;i386;fedora",
@@ -994,22 +994,22 @@ pk_backend_update_packages_download_thread (PkBackendJob *job, GVariant *params,
 		}
 		if (job_data->progress_percentage == 20 && !priv->updated_kernel) {
 			pk_backend_job_package (job, PK_INFO_ENUM_DOWNLOADING,
-						"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed",
+						"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed;",
 						"The Linux kernel (the core of the Linux operating system)");
 			pk_backend_job_set_item_progress (job,
-							"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed",
+							"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed;",
 							PK_STATUS_ENUM_DOWNLOAD,
 							0);
 		}
 		if (job_data->progress_percentage == 30 && !priv->updated_gtkhtml) {
 			if (!priv->use_blocked) {
 				pk_backend_job_package (job, PK_INFO_ENUM_INSTALLING,
-							"gtkhtml2;2.19.1-4.fc8;i386;fedora",
+							"gtkhtml2;2.19.1-4.fc8;i386;fedora;",
 							"An HTML widget for GTK+ 2.0");
 				priv->updated_gtkhtml = TRUE;
 			}
 			pk_backend_job_set_item_progress (job,
-							"gtkhtml2;2.19.1-4.fc8;i386;fedora",
+							"gtkhtml2;2.19.1-4.fc8;i386;fedora;",
 							PK_STATUS_ENUM_DOWNLOAD,
 							0);
 		}
@@ -1017,34 +1017,34 @@ pk_backend_update_packages_download_thread (PkBackendJob *job, GVariant *params,
 			pk_backend_job_set_status (job, PK_STATUS_ENUM_UPDATE);
 			pk_backend_job_set_allow_cancel (job, FALSE);
 			pk_backend_job_package (job, PK_INFO_ENUM_INSTALLING,
-						"powertop;1.8-1.fc8;i386;fedora",
+						"powertop;1.8-1.fc8;i386;fedora;",
 						"Power consumption monitor");
 			pk_backend_job_set_item_progress (job,
-							"powertop;1.8-1.fc8;i386;fedora",
+							"powertop;1.8-1.fc8;i386;fedora;",
 							PK_STATUS_ENUM_DOWNLOAD,
 							0);
 			priv->updated_powertop = TRUE;
 		}
 		if (job_data->progress_percentage == 60 && !priv->updated_kernel) {
 			pk_backend_job_package (job, PK_INFO_ENUM_UPDATING,
-						"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed",
+						"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed;",
 						"The Linux kernel (the core of the Linux operating system)");
 			pk_backend_job_set_item_progress (job,
-							"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed",
+							"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed;",
 							PK_STATUS_ENUM_DOWNLOAD,
 							0);
 			priv->updated_kernel = TRUE;
 			pk_backend_job_set_item_progress (job,
-							"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed",
+							"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed;",
 							PK_STATUS_ENUM_DOWNLOAD,
 							0);
 		}
 		if (job_data->progress_percentage == 80 && !priv->updated_kernel) {
 			pk_backend_job_package (job, PK_INFO_ENUM_CLEANUP,
-						"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed",
+						"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed;",
 						"The Linux kernel (the core of the Linux operating system)");
 			pk_backend_job_set_item_progress (job,
-							"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed",
+							"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed;",
 							PK_STATUS_ENUM_DOWNLOAD,
 							0);
 		}
@@ -1080,23 +1080,23 @@ pk_backend_update_system_thread (PkBackendJob *job, GVariant *params, gpointer u
 		}
 		if (job_data->progress_percentage == 0 && !priv->updated_powertop) {
 			pk_backend_job_package (job, PK_INFO_ENUM_DOWNLOADING,
-						"powertop;1.8-1.fc8;i386;fedora",
+						"powertop;1.8-1.fc8;i386;fedora;",
 						"Power consumption monitor");
 		}
 		if (job_data->progress_percentage == 20 && !priv->updated_kernel) {
 			pk_backend_job_package (job, PK_INFO_ENUM_DOWNLOADING,
-						"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed",
+						"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed;",
 						"The Linux kernel (the core of the Linux operating system)");
 		}
 		if (job_data->progress_percentage == 30 && !priv->updated_gtkhtml) {
 			if (priv->use_blocked) {
 				pk_backend_job_package (job, PK_INFO_ENUM_BLOCKED,
-							"gtkhtml2;2.19.1-4.fc8;i386;fedora",
+							"gtkhtml2;2.19.1-4.fc8;i386;fedora;",
 							"An HTML widget for GTK+ 2.0");
 				priv->updated_gtkhtml = FALSE;
 			} else {
 				pk_backend_job_package (job, PK_INFO_ENUM_INSTALLING,
-							"gtkhtml2;2.19.1-4.fc8;i386;fedora",
+							"gtkhtml2;2.19.1-4.fc8;i386;fedora;",
 							"An HTML widget for GTK+ 2.0");
 				priv->updated_gtkhtml = TRUE;
 			}
@@ -1105,19 +1105,19 @@ pk_backend_update_system_thread (PkBackendJob *job, GVariant *params, gpointer u
 			pk_backend_job_set_status (job, PK_STATUS_ENUM_UPDATE);
 			pk_backend_job_set_allow_cancel (job, FALSE);
 			pk_backend_job_package (job, PK_INFO_ENUM_INSTALLING,
-						"powertop;1.8-1.fc8;i386;fedora",
+						"powertop;1.8-1.fc8;i386;fedora;",
 						"Power consumption monitor");
 			priv->updated_powertop = TRUE;
 		}
 		if (job_data->progress_percentage == 60 && !priv->updated_kernel) {
 			pk_backend_job_package (job, PK_INFO_ENUM_UPDATING,
-						"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed",
+						"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed;",
 						"The Linux kernel (the core of the Linux operating system)");
 			priv->updated_kernel = TRUE;
 		}
 		if (job_data->progress_percentage == 80 && !priv->updated_kernel) {
 			pk_backend_job_package (job, PK_INFO_ENUM_CLEANUP,
-						"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed",
+						"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed;",
 						"The Linux kernel (the core of the Linux operating system)");
 		}
 		job_data->progress_percentage += 1;
@@ -1462,18 +1462,18 @@ pk_backend_download_packages (PkBackend *backend, PkBackendJob *job, gchar **pac
 	filename = g_build_filename (directory, "powertop-1.8-1.fc8.rpm", NULL);
 	g_file_set_contents (filename, "powertop data", -1, NULL);
 	pk_backend_job_package (job, PK_INFO_ENUM_DOWNLOADING,
-				"powertop;1.8-1.fc8;i386;fedora", "Power consumption monitor");
+				"powertop;1.8-1.fc8;i386;fedora;", "Power consumption monitor");
 	to_strv[0] = filename;
-	pk_backend_job_files (job, "powertop;1.8-1.fc8;i386;fedora", to_strv);
+	pk_backend_job_files (job, "powertop;1.8-1.fc8;i386;fedora;", to_strv);
 	g_free (filename);
 
 	/* second package */
 	filename = g_build_filename (directory, "powertop-common-1.8-1.fc8.rpm", NULL);
 	g_file_set_contents (filename, "powertop-common data", -1, NULL);
 	pk_backend_job_package (job, PK_INFO_ENUM_DOWNLOADING,
-				"powertop-common;1.8-1.fc8;i386;fedora", "Power consumption monitor");
+				"powertop-common;1.8-1.fc8;i386;fedora;", "Power consumption monitor");
 	to_strv[0] = filename;
-	pk_backend_job_files (job, "powertop-common;1.8-1.fc8;i386;fedora", to_strv);
+	pk_backend_job_files (job, "powertop-common;1.8-1.fc8;i386;fedora;", to_strv);
 	g_free (filename);
 
 	pk_backend_job_finished (job);
@@ -1507,29 +1507,29 @@ pk_backend_upgrade_system_timeout (gpointer data)
 	}
 	if (job_data->progress_percentage == 20) {
 		pk_backend_job_package (job, PK_INFO_ENUM_DOWNLOADING,
-					"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed",
+					"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed;",
 					"The Linux kernel (the core of the Linux operating system)");
 	}
 	if (job_data->progress_percentage == 30) {
 		pk_backend_job_package (job, PK_INFO_ENUM_DOWNLOADING,
-					"gtkhtml2;2.19.1-4.fc8;i386;fedora",
+					"gtkhtml2;2.19.1-4.fc8;i386;fedora;",
 					"An HTML widget for GTK+ 2.0");
 	}
 	if (job_data->progress_percentage == 40) {
 		pk_backend_job_set_allow_cancel (job, FALSE);
 		pk_backend_job_package (job, PK_INFO_ENUM_DOWNLOADING,
-					"powertop;1.8-1.fc8;i386;fedora",
+					"powertop;1.8-1.fc8;i386;fedora;",
 					"Power consumption monitor");
 	}
 	if (job_data->progress_percentage == 60) {
 		pk_backend_job_set_allow_cancel (job, TRUE);
 		pk_backend_job_package (job, PK_INFO_ENUM_DOWNLOADING,
-					"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed",
+					"kernel;2.6.23-0.115.rc3.git1.fc8;i386;installed;",
 					"The Linux kernel (the core of the Linux operating system)");
 	}
 	if (job_data->progress_percentage == 80) {
 		pk_backend_job_package (job, PK_INFO_ENUM_DOWNLOADING,
-					"powertop;1.8-1.fc8;i386;fedora",
+					"powertop;1.8-1.fc8;i386;fedora;",
 					"Power consumption monitor");
 	}
 	job_data->progress_percentage += 1;

--- a/backends/freebsd/PackageView.hpp
+++ b/backends/freebsd/PackageView.hpp
@@ -154,7 +154,7 @@ public:
 
     const gchar* repository() const {
         if (pk_id_parts)
-            return pk_id_parts.get()[PK_PACKAGE_ID_DATA];
+            return pk_id_parts.get()[PK_PACKAGE_ID_ORIGIN];
         else
             return _reponame.get();
     }
@@ -165,7 +165,7 @@ public:
 
         if (!built_pk_id)
             built_pk_id = g_free_deleted_unique_ptr<gchar> (
-                    pk_package_id_build(name(), version(), arch(), repository()));
+                    pk_package_id_build(name(), version(), arch(), repository(), NULL));
         return built_pk_id.get();
     }
 private:

--- a/backends/freebsd/pk-backend-freebsd.cpp
+++ b/backends/freebsd/pk-backend-freebsd.cpp
@@ -502,7 +502,7 @@ pk_backend_depends_on (PkBackend *backend, PkBackendJob *job, PkBitfield filters
             guint size2 = g_strv_length (dep_namevers);
             size2 -= size % 2;
             for (guint j = 0; j < size2; j+=2) {
-                gchar* dep_id = pk_package_id_build (dep_namevers[j], dep_namevers[j+1], pkgView.arch(), pkgView.repository());
+                gchar* dep_id = pk_package_id_build (dep_namevers[j], dep_namevers[j+1], pkgView.arch(), pkgView.repository(), NULL);
                 pk_backend_job_package (job, pk_type, dep_id, ""); // TODO: we report an empty string instead of comment here
                 g_free (dep_id);
             }

--- a/backends/nix/pk-backend-nix.cc
+++ b/backends/nix/pk-backend-nix.cc
@@ -156,7 +156,7 @@ pk_backend_get_details_thread (PkBackendJob* job, GVariant* params, gpointer p)
 		// we put the attr path in "PK_PACKAGE_ID_NAME" because that’s how we identify it
 		parts = pk_package_id_split (package_ids[i]);
 		std::string attrPath = std::string (parts[PK_PACKAGE_ID_NAME]);
-		std::string flake = std::string (parts[PK_PACKAGE_ID_DATA]);
+		std::string flake = std::string (parts[PK_PACKAGE_ID_ORIGIN]);
 		g_strfreev (parts);
 
 		auto attrOrSuggestions = nix_get_attr_or_suggestions (*priv->state, flake, "legacyPackages." + nix::settings.thisSystem.get () + "." + attrPath);
@@ -386,7 +386,8 @@ nix_search_thread (PkBackendJob* job, GVariant* params, gpointer p)
 								pk_package_id_build (attrPath2.c_str (),
 										     name.version.c_str (),
 										     system.c_str (),
-										     priv->defaultFlake.c_str ()),
+										     priv->defaultFlake.c_str (),
+										     NULL),
 								description.c_str());
 				}
 			}
@@ -467,7 +468,7 @@ nix_install_thread (PkBackendJob* job, GVariant* params, gpointer p)
 		// we put the attr path in "PK_PACKAGE_ID_NAME" because that’s how we identify it
 		parts = pk_package_id_split (package_ids[i]);
 		std::string attrPath = std::string (parts[PK_PACKAGE_ID_NAME]);
-		std::string flake = std::string (parts[PK_PACKAGE_ID_DATA]);
+		std::string flake = std::string (parts[PK_PACKAGE_ID_ORIGIN]);
 		g_strfreev (parts);
 
 		auto attrOrSuggestions = nix_get_attr_or_suggestions (*priv->state, flake, "legacyPackages." + nix::settings.thisSystem.get () + "." + attrPath);
@@ -598,7 +599,7 @@ nix_remove_thread (PkBackendJob* job, GVariant* params, gpointer p)
 		// we put the attr path in "PK_PACKAGE_ID_NAME" because that’s how we identify it
 		parts = pk_package_id_split (package_ids[i]);
 		std::string attrPath = std::string (parts[PK_PACKAGE_ID_NAME]);
-		std::string flake = std::string (parts[PK_PACKAGE_ID_DATA]);
+		std::string flake = std::string (parts[PK_PACKAGE_ID_ORIGIN]);
 		g_strfreev (parts);
 
 		auto attrOrSuggestions = nix_get_attr_or_suggestions (*priv->state, flake, "legacyPackages." + nix::settings.thisSystem.get () + "." + attrPath);
@@ -711,7 +712,8 @@ nix_get_updates_thread (PkBackendJob* job, GVariant* params, gpointer p)
 							pk_package_id_build (drv->attrPath.c_str (),
 									     name.version.c_str (),
 									     drv->querySystem ().c_str (),
-									     priv->defaultFlake.c_str ()),
+									     priv->defaultFlake.c_str (),
+									     NULL),
 							drv->queryMetaString ("description").c_str ());
 			}
 		}

--- a/backends/poldek/pk-backend-poldek.c
+++ b/backends/poldek/pk-backend-poldek.c
@@ -1392,7 +1392,8 @@ package_id_from_pkg (struct pkg *pkg, const gchar *repo, PkBitfield filters)
 	package_id = pk_package_id_build (pkg->name,
 					  evr,
 					  pkg_arch (pkg),
-					  poldek_dir);
+					  poldek_dir,
+					  NULL);
 
 	g_free (evr);
 	g_free (poldek_dir);
@@ -1447,7 +1448,7 @@ poldek_get_pkg_from_package_id (const gchar *package_id)
 
 		vr = poldek_get_vr_from_package_id_evr (parts[PK_PACKAGE_ID_VERSION]);
 
-		if ((packages = execute_packages_command ("cd /%s; ls -q %s-%s.%s", parts[PK_PACKAGE_ID_DATA],
+		if ((packages = execute_packages_command ("cd /%s; ls -q %s-%s.%s", parts[PK_PACKAGE_ID_ORIGIN],
 										    parts[PK_PACKAGE_ID_NAME],
 										    vr,
 										    parts[PK_PACKAGE_ID_ARCH]))) {

--- a/backends/test/helpers/search-name.sh
+++ b/backends/test/helpers/search-name.sh
@@ -15,10 +15,10 @@ echo -e "percentage\t10"
 echo -e "status\tquery"
 sleep 1
 echo -e "percentage\t30"
-echo -e "package\tavailable\tglib2;2.14.0;i386;fedora\tThe GLib library"
+echo -e "package\tavailable\tglib2;2.14.0;i386;fedora;\tThe GLib library"
 sleep 1
 echo -e "percentage\t70"
-echo -e "package\tinstalled\tgtk2;gtk2-2.11.6-6.fc8;i386;fedora\tGTK+ Libraries for GIMP"
+echo -e "package\tinstalled\tgtk2;gtk2-2.11.6-6.fc8;i386;fedora;\tGTK+ Libraries for GIMP"
 sleep 1
 echo -e "percentage\t100"
 exit 0

--- a/backends/test/pk-backend-test-thread.c
+++ b/backends/test/pk-backend-test-thread.c
@@ -51,9 +51,9 @@ pk_backend_search_groups_thread (PkBackendJob *job, GVariant *params, gpointer u
 
 	/* emit */
 	pk_backend_job_package (job, PK_INFO_ENUM_INSTALLED,
-			    "glib2;2.14.0;i386;fedora", "The GLib library");
+			    "glib2;2.14.0;i386;fedora;", "The GLib library");
 	pk_backend_job_package (job, PK_INFO_ENUM_INSTALLED,
-			    "gtk2;gtk2-2.11.6-6.fc8;i386;fedora", "GTK+ Libraries for GIMP");
+			    "gtk2;gtk2-2.11.6-6.fc8;i386;fedora;", "GTK+ Libraries for GIMP");
 }
 
 void
@@ -97,9 +97,9 @@ pk_backend_search_names_thread (PkBackendJob *job, GVariant *params, gpointer us
 	g_debug ("exited task (%p)", job);
 
 	pk_backend_job_package (job, PK_INFO_ENUM_INSTALLED,
-			    "glib2;2.14.0;i386;fedora", "The GLib library");
+			    "glib2;2.14.0;i386;fedora;", "The GLib library");
 	pk_backend_job_package (job, PK_INFO_ENUM_INSTALLED,
-			    "gtk2;gtk2-2.11.6-6.fc8;i386;fedora", "GTK+ Libraries for GIMP");
+			    "gtk2;gtk2-2.11.6-6.fc8;i386;fedora;", "GTK+ Libraries for GIMP");
 }
 
 void

--- a/backends/zypp/pk-backend-zypp.cpp
+++ b/backends/zypp/pk-backend-zypp.cpp
@@ -173,6 +173,7 @@ zypp_build_package_id_from_resolvable (const sat::Solvable &resolvable)
 	gchar *package_id;
 	const char *arch;
 	g_autofree gchar *repo = NULL;
+    g_autofree gchar *data = NULL;
 
 	if (isKind<SrcPackage>(resolvable))
 		arch = "source";
@@ -189,13 +190,14 @@ zypp_build_package_id_from_resolvable (const sat::Solvable &resolvable)
 		else
 			pi = selectable->updateCandidateObj ();
 
-		repo = g_strconcat ("installed:", pi.repository ().alias ().c_str (), NULL);
+	    data = g_strdup ("installed");
+		repo = g_strdup (pi.repository ().alias ().c_str ());
 	} else
 		repo = g_strdup (resolvable.repository ().alias ().c_str ());
 
 	package_id = pk_package_id_build (resolvable.name ().c_str (),
 					  resolvable.edition ().asString ().c_str (),
-					  arch, repo);
+					  arch, repo, data);
 
 	return package_id;
 }
@@ -966,7 +968,7 @@ zypp_package_is_local (const gchar *package_id)
 		return false;
 
 	gchar **id_parts = pk_package_id_split (package_id);
-	if (!strncmp (id_parts[PK_PACKAGE_ID_DATA], "local", 5))
+	if (!strncmp (id_parts[PK_PACKAGE_ID_ORIGIN], "local", 5))
 		ret = true;
 
 	g_strfreev (id_parts);
@@ -1020,15 +1022,15 @@ zypp_get_package_by_id (const gchar *package_id)
 		}
 
 		if (!pkg.isSystem()) {
-			if (!strncmp(id_parts[PK_PACKAGE_ID_DATA], "installed", 9)) {
+			if (!strncmp(id_parts[PK_PACKAGE_ID_ORIGIN], "installed", 9)) {
 				//MIL << "pkg is not installed\n";
 				continue;
 			}
-			if (g_strcmp0(pkg.repository().alias().c_str(), id_parts[PK_PACKAGE_ID_DATA])) {
+			if (g_strcmp0(pkg.repository().alias().c_str(), id_parts[PK_PACKAGE_ID_ORIGIN])) {
 				//MIL << "repo does not match\n";
 				continue;
 			}
-		} else if (strncmp(id_parts[PK_PACKAGE_ID_DATA], "installed", 9)) {
+		} else if (strncmp(id_parts[PK_PACKAGE_ID_ORIGIN], "installed", 9)) {
 			//MIL << "pkg installed\n";
 			continue;
 		}

--- a/client/pkcon/pk-console.c
+++ b/client/pkcon/pk-console.c
@@ -118,7 +118,7 @@ pk_console_package_cb (PkPackage *package, PkConsoleCtx *ctx)
 				     split[PK_PACKAGE_ID_NAME],
 				     split[PK_PACKAGE_ID_VERSION],
 				     split[PK_PACKAGE_ID_ARCH],
-				     split[PK_PACKAGE_ID_DATA]);
+				     split[PK_PACKAGE_ID_ORIGIN]);
 
 	/* don't pretty print */
 	if (!ctx->is_console) {
@@ -937,7 +937,7 @@ pk_console_resolve_package (PkConsoleCtx *ctx, const gchar *package_name, GError
 		package_id_tmp = pk_package_get_id (package);
 		split = pk_package_id_split (package_id_tmp);
 		printable = pk_package_id_to_printable (package_id_tmp);
-		g_print ("%i. %s [%s]\n", i+1, printable, split[PK_PACKAGE_ID_DATA]);
+		g_print ("%i. %s [%s]\n", i+1, printable, split[PK_PACKAGE_ID_ORIGIN]);
 	}
 
 	/* TRANSLATORS: This finds out which package in the list to use */
@@ -2480,4 +2480,3 @@ out_last:
 	g_option_context_free (context);
 	return retval_copy;
 }
-

--- a/client/pkgc-util.c
+++ b/client/pkgc-util.c
@@ -475,7 +475,7 @@ pkgc_print_package (PkgcliContext *ctx, PkPackage *package)
 	const gchar *package_id;
 	PkInfoEnum info;
 	g_auto(GStrv) split = NULL;
-	const gchar *name, *version, *arch, *data;
+	const gchar *name, *version, *arch, *origin, *data;
 	const gchar *info_color = COLOR_RESET;
 	const gchar *info_symbol = SYMBOL_PACKAGE;
 
@@ -492,6 +492,7 @@ pkgc_print_package (PkgcliContext *ctx, PkPackage *package)
 	name = split[PK_PACKAGE_ID_NAME];
 	version = split[PK_PACKAGE_ID_VERSION];
 	arch = split[PK_PACKAGE_ID_ARCH];
+	origin = split[PK_PACKAGE_ID_ORIGIN];
 	data = split[PK_PACKAGE_ID_DATA];
 
 	/* set color & symbol based on package state */
@@ -537,7 +538,8 @@ pkgc_print_package (PkgcliContext *ctx, PkPackage *package)
 		json_object_set_new (root, "name", json_string (name));
 		json_object_set_new (root, "version", json_string (version));
 		json_object_set_new (root, "arch", json_string (arch));
-		json_object_set_new (root, "repo", json_string (data));
+		json_object_set_new (root, "repo", json_string (origin));
+		json_object_set_new (root, "data", json_string (data));
 		json_object_set_new (root, "state", json_string (pk_info_enum_to_string (info)));
 		pkgc_print_json_decref (root);
 
@@ -555,13 +557,11 @@ pkgc_print_package (PkgcliContext *ctx, PkPackage *package)
 
 	g_print (" %s%s%s", get_color (ctx, COLOR_GRAY), version, get_reset_color (ctx));
 
-	if (arch != NULL && g_strcmp0 (arch, "") != 0) {
+	if (g_strcmp0 (arch, "") != 0)
 		g_print (".%s%s%s", get_color (ctx, COLOR_GRAY), arch, get_reset_color (ctx));
-	}
 
-	if (data != NULL && g_strcmp0 (data, "") != 0) {
-		g_print (" [%s%s%s]", get_color (ctx, COLOR_GRAY), data, get_reset_color (ctx));
-	}
+	if (g_strcmp0 (origin, "") != 0)
+		g_print (" [%s%s%s]", get_color (ctx, COLOR_GRAY), origin, get_reset_color (ctx));
 
 	g_print ("\n");
 }
@@ -1166,7 +1166,7 @@ pkgc_resolve_package (PkgcliContext *ctx,
 		package_id_tmp = pk_package_get_id (package);
 		split = pk_package_id_split (package_id_tmp);
 		printable = pk_package_id_to_printable (package_id_tmp);
-		g_print ("%u. %s [%s]\n", i + 1, printable, split[PK_PACKAGE_ID_DATA]);
+		g_print ("%u. %s [%s]\n", i + 1, printable, split[PK_PACKAGE_ID_ORIGIN]);
 	}
 
 	/* prompt user for selection */

--- a/docs/api/spec/pk-concepts.xml
+++ b/docs/api/spec/pk-concepts.xml
@@ -10,7 +10,7 @@
     <title>Package ID</title>
     <para>
       One important idea is the <literal>package_id</literal>.
-      This is the <literal>name;version;arch;data</literal> in
+      This is the <literal>name;version;arch;origin;data</literal> in
       a single string and is meant to represent a single package.
       This is important when multiple versions of a package are installed and
       only the correct one is removed.
@@ -18,27 +18,28 @@
     <para>
       The <literal>package_id</literal> is parsed and checked carefully in
       the helper code.
-      The package arch and data are optional, but 3 <literal>;</literal>'s must
+      The package arch and data are optional, but 4 <literal>;</literal>'s must
       be present.
-      For instance, <literal>gnome-keyring-manager;2.18.0;;</literal> is
+      For instance, <literal>gnome-keyring-manager;2.18.0;;;</literal> is
       valid but <literal>gnome-keyring-manager;2.18.0</literal> is not.
-      The data field is used for the repository name and/or installation state.
-      It should ideally not be parsed by frontends to extract state data, instead the
-      <code>PkInfoEnum</code> that is often provided alongside a <literal>package_id</literal>
+      The 'origin' field contains the repository name if the package is available in a repository,
+      and if the backend knows its origin. If it is a local package, its value is set to <literal>local</literal>.
+      The data field is used for installation state or state changes, and is backend-specific.
+      It should ideally not be parsed by frontends, especially not for state information.
+      Instead the <code>PkInfoEnum</code> that is often provided alongside a <literal>package_id</literal>
       will provide more accurate state information.
     </para>
     <para>
       The data field for an installed package can either be
       <literal>installed</literal> for installed packages, <literal>auto</literal>
       for automatically installed packages or <literal>manual</literal> for manually
-      installed packages. If the package has a repository origin, the installation state may be
-      prefixed to the origin, divided by a colon, e.g. <literal>auto:fedora-devel</literal>.
-      If a package is not installed, the data field is equal to the package origin.
+      installed packages. State changes may be prefixed with a <literal>+</literal>.
+      The data field may be empty.
     </para>
     <para>
-      The data field for an non-installed local package must be
-      <literal>local</literal> as this signifies a repository name is not available
-      and that package resides locally on the client system.
+      The origin field for a local package must be <literal>local</literal> as this
+      signifies a repository name is not available and that package resides locally
+      on the client system.
     </para>
     <para>
       For example:
@@ -46,23 +47,23 @@
     <itemizedlist>
       <listitem>
         <para>
-          <literal>csup;20060318-5;x86_64;local</literal>: for locally available package file.
+          <literal>csup;20060318-5;x86_64;local;</literal>: for locally available package file.
         </para>
       </listitem>
       <listitem>
         <para>
-          <literal>csup;20060318-5;x86_64;fedora-devel</literal>: for package that is not installed
-          and can be downladed from the Fedora development repostory.
+          <literal>csup;20060318-5;x86_64;fedora-devel;</literal>: for package that is not installed
+          and can be downloaded from the Fedora development repostory.
         </para>
       </listitem>
       <listitem>
         <para>
-          <literal>csup;20060318-5;x86_64;installed:fedora-devel</literal>: for locally installed package
+          <literal>csup;20060318-5;x86_64;fedora-devel;installed</literal>: for locally installed package
         </para>
       </listitem>
       <listitem>
         <para>
-          <literal>csup;20060318-5;x86_64;installed</literal>: for locally installed package without repository information
+          <literal>csup;20060318-5;x86_64;;installed</literal>: for locally installed package without repository information
         </para>
       </listitem>
     </itemizedlist>
@@ -1240,4 +1241,3 @@
   </sect1>
 
 </chapter>
-

--- a/lib/packagekit-glib2/pk-package-id.c
+++ b/lib/packagekit-glib2/pk-package-id.c
@@ -52,7 +52,7 @@ pk_package_id_split (const gchar *package_id)
 
 	/* split by delimeter ';' */
 	sections = g_strsplit (package_id, ";", -1);
-	if (g_strv_length (sections) != 4)
+	if (g_strv_length (sections) != 5)
 		goto out;
 
 	/* name has to be valid */
@@ -96,11 +96,12 @@ pk_package_id_check (const gchar *package_id)
 }
 
 /**
- * pk_package_id_build:
+ * pk_package_id_build_full:
  * @name: the package name
  * @version: the package version
  * @arch: the package architecture
- * @data: the package extra data
+ * @origin: the package origin
+ * @data: additional data
  *
  * Generate a PackageID.
  *
@@ -110,13 +111,15 @@ pk_package_id_check (const gchar *package_id)
  **/
 gchar *
 pk_package_id_build (const gchar *name, const gchar *version,
-		     const gchar *arch, const gchar *data)
+		     const gchar *arch, const gchar *origin,
+		     const gchar *data)
 {
 	g_return_val_if_fail (name != NULL, NULL);
 	return g_strjoin (";",
 			  name,
 			  version != NULL ? version : "",
 			  arch != NULL ? arch : "",
+			  origin != NULL ? origin : "",
 			  data != NULL ? data : "",
 			  NULL);
 }
@@ -181,7 +184,7 @@ pk_package_id_equal_fuzzy_arch (const gchar *package_id1, const gchar *package_i
  *
  * Formats the PackageID to be printable to the user.
  *
- * Return value: the name-version.arch formatted string, use g_free() to free.
+ * Return value: the name_version.arch formatted string, use g_free() to free.
  *
  * Since: 0.5.2
  **/

--- a/lib/packagekit-glib2/pk-package-id.h
+++ b/lib/packagekit-glib2/pk-package-id.h
@@ -52,15 +52,23 @@ G_BEGIN_DECLS
 #define PK_PACKAGE_ID_ARCH	2
 
 /**
+ * PK_PACKAGE_ID_ORIGIN:
+ *
+ * Alias to get the origin field from the result of pk_package_id_split
+ */
+#define PK_PACKAGE_ID_ORIGIN	3
+
+/**
  * PK_PACKAGE_ID_DATA:
  *
- * Alias to get a data field from the result of pk_package_id_split
+ * Alias to get the data field from the result of pk_package_id_split
  */
-#define PK_PACKAGE_ID_DATA	3
+#define PK_PACKAGE_ID_DATA	4
 
 gchar		*pk_package_id_build			(const gchar		*name,
 							 const gchar		*version,
 							 const gchar		*arch,
+							 const gchar		*origin,
 							 const gchar		*data);
 gboolean	 pk_package_id_check			(const gchar		*package_id);
 gchar		**pk_package_id_split			(const gchar		*package_id);
@@ -70,4 +78,3 @@ gboolean	 pk_package_id_equal_fuzzy_arch		(const gchar		*package_id1,
 G_END_DECLS
 
 #endif /* __PK_PACKAGE_ID_H */
-

--- a/lib/packagekit-glib2/pk-package.h
+++ b/lib/packagekit-glib2/pk-package.h
@@ -95,6 +95,7 @@ void		 pk_package_set_summary			(PkPackage	*package,
 const gchar	*pk_package_get_name			(PkPackage	*package);
 const gchar	*pk_package_get_version			(PkPackage	*package);
 const gchar	*pk_package_get_arch			(PkPackage	*package);
+const gchar	*pk_package_get_origin			(PkPackage	*package);
 const gchar	*pk_package_get_data			(PkPackage	*package);
 PkInfoEnum	 pk_package_get_update_severity		(PkPackage	*package);
 void		 pk_package_set_update_severity		(PkPackage	*package,
@@ -102,4 +103,3 @@ void		 pk_package_set_update_severity		(PkPackage	*package,
 G_END_DECLS
 
 #endif /* __PK_PACKAGE_H */
-

--- a/lib/packagekit-glib2/pk-test-daemon.c
+++ b/lib/packagekit-glib2/pk-test-daemon.c
@@ -136,7 +136,7 @@ pk_test_offline_func (void)
 
 	/* set up an offline update */
 	client = pk_client_new ();
-	package_ids = pk_package_ids_from_string ("powertop;1.8-1.fc8;i386;fedora");
+	package_ids = pk_package_ids_from_string ("powertop;1.8-1.fc8;i386;fedora;");
 	pk_client_update_packages_async (client,
 					 pk_bitfield_from_enums (PK_TRANSACTION_FLAG_ENUM_ONLY_DOWNLOAD, -1),
 					 package_ids,
@@ -151,7 +151,7 @@ pk_test_offline_func (void)
 	ret = g_file_get_contents (PK_OFFLINE_PREPARED_FILENAME, &data, NULL, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
-	g_assert_cmpstr (data, ==, "powertop;1.8-1.fc8;i386;fedora");
+	g_assert_cmpstr (data, ==, "powertop;1.8-1.fc8;i386;fedora;");
 
 	/* trigger */
 	ret = pk_offline_trigger_with_flags (PK_OFFLINE_ACTION_REBOOT, PK_OFFLINE_FLAGS_INTERACTIVE, NULL, &error);
@@ -601,7 +601,7 @@ pk_test_client_func (void)
 	g_assert (ret);
 
 	/* resolve package */
-	package_ids = pk_package_ids_from_string ("glib2;2.14.0;i386;fedora&powertop");
+	package_ids = pk_package_ids_from_string ("glib2;2.14.0;i386;fedora;&powertop");
 	pk_client_resolve_async (client, pk_bitfield_value (PK_FILTER_ENUM_INSTALLED), package_ids, NULL,
 		 (PkProgressCallback) pk_test_client_progress_cb, NULL,
 		 (GAsyncReadyCallback) pk_test_client_resolve_cb, NULL);
@@ -1169,7 +1169,7 @@ pk_test_task_func (void)
 	g_assert (task != NULL);
 
 	/* install package */
-	package_ids = pk_package_ids_from_id ("glib2;2.14.0;i386;fedora");
+	package_ids = pk_package_ids_from_id ("glib2;2.14.0;i386;fedora;");
 	pk_task_install_packages_async (task, package_ids, NULL,
 		        (PkProgressCallback) pk_test_task_progress_cb, NULL,
 		        (GAsyncReadyCallback) pk_test_task_install_packages_cb, NULL);
@@ -1238,7 +1238,7 @@ pk_test_task_text_func (void)
 	*/
 
 	/* install package */
-	package_ids = pk_package_ids_from_id ("vips-doc;7.12.4-2.fc8;noarch;linva");
+	package_ids = pk_package_ids_from_id ("vips-doc;7.12.4-2.fc8;noarch;linva;");
 	pk_task_install_packages_async (PK_TASK (task), package_ids, NULL,
 		        (PkProgressCallback) pk_test_task_text_progress_cb, NULL,
 		        (GAsyncReadyCallback) pk_test_task_text_install_packages_cb, NULL);
@@ -1301,7 +1301,7 @@ pk_test_task_wrapper_func (void)
 	g_assert (task != NULL);
 
 	/* install package */
-	package_ids = pk_package_ids_from_id ("vips-doc;7.12.4-2.fc8;noarch;linva");
+	package_ids = pk_package_ids_from_id ("vips-doc;7.12.4-2.fc8;noarch;linva;");
 	pk_task_install_packages_async (PK_TASK (task), package_ids, NULL,
 		        (PkProgressCallback) pk_test_task_wrapper_progress_cb, NULL,
 		        (GAsyncReadyCallback) pk_test_task_wrapper_install_packages_cb, NULL);
@@ -1379,7 +1379,7 @@ pk_test_transaction_list_func (void)
 	g_assert (client != NULL);
 
 	/* resolve package */
-	package_ids = pk_package_ids_from_string ("glib2;2.14.0;i386;fedora&powertop");
+	package_ids = pk_package_ids_from_string ("glib2;2.14.0;i386;fedora;&powertop");
 	_refcount = 2;
 	pk_client_resolve_async (client,
 				 pk_bitfield_value (PK_FILTER_ENUM_INSTALLED),
@@ -1445,4 +1445,3 @@ main (int argc, char **argv)
 
 	return g_test_run ();
 }
-

--- a/lib/packagekit-glib2/pk-test-private.c
+++ b/lib/packagekit-glib2/pk-test-private.c
@@ -344,58 +344,60 @@ pk_test_package_id_func (void)
 	g_assert_true (!ret);
 
 	/* check not valid - no name */
-	ret = pk_package_id_check (";0.0.1;i386;fedora");
+	ret = pk_package_id_check (";0.0.1;i386;fedora;");
 	g_assert_true (!ret);
 
 	/* check not valid - invalid */
-	ret = pk_package_id_check ("moo;0.0.1;i386");
+	ret = pk_package_id_check ("moo;0.0.1;i386;");
 	g_assert_true (!ret);
 
 	/* check valid */
-	ret = pk_package_id_check ("moo;0.0.1;i386;fedora");
+	ret = pk_package_id_check ("moo;0.0.1;i386;fedora;");
 	g_assert_true (ret);
 
 	/* id build */
-	text = pk_package_id_build ("moo", "0.0.1", "i386", "fedora");
-	g_assert_cmpstr (text, ==, "moo;0.0.1;i386;fedora");
+	text = pk_package_id_build ("moo", "0.0.1", "i386", "fedora", NULL);
+	g_assert_cmpstr (text, ==, "moo;0.0.1;i386;fedora;");
 	g_free (text);
 
 	/* id build partial */
-	text = pk_package_id_build ("moo", NULL, NULL, NULL);
-	g_assert_cmpstr (text, ==, "moo;;;");
+	text = pk_package_id_build ("moo", NULL, NULL, NULL, NULL);
+	g_assert_cmpstr (text, ==, "moo;;;;");
 	g_free (text);
 
 	/* test printable */
-	text = pk_package_id_to_printable ("moo;0.0.1;i386;fedora");
+	text = pk_package_id_to_printable ("moo;0.0.1;i386;fedora;");
 	g_assert_cmpstr (text, ==, "moo_0.0.1.i386");
 	g_free (text);
 
 	/* test printable no arch */
-	text = pk_package_id_to_printable ("moo;0.0.1;;");
+	text = pk_package_id_to_printable ("moo;0.0.1;;;");
 	g_assert_cmpstr (text, ==, "moo_0.0.1");
 	g_free (text);
 
 	/* test printable just name */
-	text = pk_package_id_to_printable ("moo;;;");
+	text = pk_package_id_to_printable ("moo;;;;");
 	g_assert_cmpstr (text, ==, "moo");
 	g_free (text);
 
 	/* test on real packageid */
-	sections = pk_package_id_split ("kde-i18n-csb;4:3.5.8~pre20071001-0ubuntu1;all;");
+	sections = pk_package_id_split ("kde-i18n-csb;4:3.5.8~pre20071001-0ubuntu1;all;ubuntu-main;auto");
 	g_assert_true (sections != NULL);
 	g_assert_cmpstr (sections[0], ==, "kde-i18n-csb");
 	g_assert_cmpstr (sections[1], ==, "4:3.5.8~pre20071001-0ubuntu1");
 	g_assert_cmpstr (sections[2], ==, "all");
-	g_assert_cmpstr (sections[3], ==, "");
+	g_assert_cmpstr (sections[3], ==, "ubuntu-main");
+	g_assert_cmpstr (sections[4], ==, "auto");
 	g_strfreev (sections);
 
 	/* test on short packageid */
-	sections = pk_package_id_split ("kde-i18n-csb;4:3.5.8~pre20071001-0ubuntu1;;");
+	sections = pk_package_id_split ("kde-i18n-csb;4:3.5.8~pre20071001-0ubuntu1;;;");
 	g_assert_true (sections != NULL);
 	g_assert_cmpstr (sections[0], ==, "kde-i18n-csb");
 	g_assert_cmpstr (sections[1], ==, "4:3.5.8~pre20071001-0ubuntu1");
 	g_assert_cmpstr (sections[2], ==, "");
 	g_assert_cmpstr (sections[3], ==, "");
+	g_assert_cmpstr (sections[4], ==, "");
 	g_strfreev (sections);
 
 	/* test fail under */
@@ -403,7 +405,7 @@ pk_test_package_id_func (void)
 	g_assert_true (sections == NULL);
 
 	/* test fail over */
-	sections = pk_package_id_split ("foo;moo;dave;clive;dan");
+	sections = pk_package_id_split ("foo;moo;dave;clive;dan;rick");
 	g_assert_true (sections == NULL);
 
 	/* test fail missing first */
@@ -419,7 +421,7 @@ pk_test_package_ids_func (void)
 	gchar **package_ids;
 
 	/* parse va_list */
-	package_ids = pk_package_ids_from_string ("foo;0.0.1;i386;fedora&bar;0.1.1;noarch;livna");
+	package_ids = pk_package_ids_from_string ("foo;0.0.1;i386;fedora;&bar;0.1.1;noarch;livna;");
 	g_assert_true (package_ids != NULL);
 
 	/* verify size */
@@ -477,7 +479,7 @@ pk_test_results_func (void)
 		      "summary", "Power manager for GNOME",
 		      NULL);
 	ret = pk_package_set_id (item,
-				 "gnome-power-manager;0.1.2;i386;fedora",
+				 "gnome-power-manager;0.1.2;i386;fedora;",
 				 &error);
 	g_assert_no_error (error);
 	g_assert_true (ret);
@@ -497,7 +499,7 @@ pk_test_results_func (void)
 		      "summary", &summary,
 		      NULL);
 	g_assert_cmpint (info, ==, PK_INFO_ENUM_AVAILABLE);
-	g_assert_cmpstr ("gnome-power-manager;0.1.2;i386;fedora", ==, package_id);
+	g_assert_cmpstr ("gnome-power-manager;0.1.2;i386;fedora;", ==, package_id);
 	g_assert_cmpstr ("Power manager for GNOME", ==, summary);
 	g_object_ref (item);
 	g_ptr_array_unref (packages);
@@ -511,7 +513,7 @@ pk_test_results_func (void)
 		      "summary", &summary,
 		      NULL);
 	g_assert_cmpint (info, ==, PK_INFO_ENUM_AVAILABLE);
-	g_assert_cmpstr ("gnome-power-manager;0.1.2;i386;fedora", ==, package_id);
+	g_assert_cmpstr ("gnome-power-manager;0.1.2;i386;fedora;", ==, package_id);
 	g_assert_cmpstr ("Power manager for GNOME", ==, summary);
 	g_object_unref (item);
 	g_free (package_id);
@@ -555,29 +557,29 @@ pk_test_package_func (void)
 	g_clear_error (&error);
 
 	/* set invalid id (sections) */
-	ret = pk_package_set_id (package, "gnome-power-manager;0.1.2;i386;fedora;dave", &error);
+	ret = pk_package_set_id (package, "gnome-power-manager;0.1.2;i386;fedora;auto;dave", &error);
 	g_assert_error (error, 1, 0);
 	g_assert_true (!ret);
 	g_clear_error (&error);
 
 	/* set invalid name */
-	ret = pk_package_set_id (package, ";0.1.2;i386;fedora", &error);
+	ret = pk_package_set_id (package, ";0.1.2;i386;fedora;manual", &error);
 	g_assert_error (error, 1, 0);
 	g_assert_true (!ret);
 	g_clear_error (&error);
 
 	/* set valid name */
-	ret = pk_package_set_id (package, "gnome-power-manager;0.1.2;i386;fedora", &error);
+	ret = pk_package_set_id (package, "gnome-power-manager;0.1.2;i386;fedora;", &error);
 	g_assert_no_error (error);
 	g_assert_true (ret);
 
 	/* get id of set package */
 	id = pk_package_get_id (package);
-	g_assert_cmpstr (id, ==, "gnome-power-manager;0.1.2;i386;fedora");
+	g_assert_cmpstr (id, ==, "gnome-power-manager;0.1.2;i386;fedora;");
 
 	/* get name of set package */
 	g_object_get (package, "package-id", &text, NULL);
-	g_assert_cmpstr (text, ==, "gnome-power-manager;0.1.2;i386;fedora");
+	g_assert_cmpstr (text, ==, "gnome-power-manager;0.1.2;i386;fedora;");
 	g_free (text);
 
 	g_object_unref (package);
@@ -586,7 +588,7 @@ pk_test_package_func (void)
 static void
 pk_test_offline_func (void)
 {
-	const gchar *package_ids[] = { "powertop;0.1.3;i386;fedora", NULL };
+	const gchar *package_ids[] = { "powertop;0.1.3;i386;fedora;", NULL };
 	gboolean ret;
 	gchar **package_ids_tmp = NULL;
 	gchar *tmp;
@@ -607,8 +609,8 @@ pk_test_offline_func (void)
 	const gchar *results_success =
 			"[PackageKit Offline Update Results]\n"
 			"Success=true\n"
-			"Packages=upower;0.9.16-1.fc17;x86_64;updates,"
-				 "zif;0.3.0-1.fc17;x86_64;updates\n";
+			"Packages=upower;0.9.16-1.fc17;x86_64;updates;,"
+				 "zif;0.3.0-1.fc17;x86_64;updates;\n";
 
 	/* cleanup */
 	if (g_file_test ("/tmp/PackageKit-self-test", G_FILE_TEST_EXISTS)) {
@@ -660,13 +662,13 @@ pk_test_offline_func (void)
 	package_ids_tmp = pk_offline_get_prepared_ids (&error);
 	g_assert_no_error (error);
 	g_assert_cmpint (g_strv_length (package_ids_tmp), ==, 1);
-	g_assert_cmpstr (package_ids_tmp[0], ==, "powertop;0.1.3;i386;fedora");
+	g_assert_cmpstr (package_ids_tmp[0], ==, "powertop;0.1.3;i386;fedora;");
 	g_strfreev (package_ids_tmp);
 	ret = g_file_get_contents (PK_OFFLINE_PREPARED_FILENAME, &tmp, NULL, &error);
 	g_assert_no_error (error);
 	g_assert_true (ret);
 	g_assert_cmpstr (tmp, ==, "[update]\n"
-	                          "prepared_ids=powertop;0.1.3;i386;fedora,\n");
+	                          "prepared_ids=powertop;0.1.3;i386;fedora;,\n");
 	g_free (tmp);
 	sack = pk_offline_get_prepared_sack (&error);
 	g_assert_no_error (error);
@@ -748,9 +750,9 @@ pk_test_offline_func (void)
 	g_assert_true (packages != NULL);
 	g_assert_cmpint (packages->len, ==, 2);
 	pkg = g_ptr_array_index (packages, 0);
-	g_assert_cmpstr (pk_package_get_id (pkg), ==, "upower;0.9.16-1.fc17;x86_64;updates");
+	g_assert_cmpstr (pk_package_get_id (pkg), ==, "upower;0.9.16-1.fc17;x86_64;updates;");
 	pkg = g_ptr_array_index (packages, 1);
-	g_assert_cmpstr (pk_package_get_id (pkg), ==, "zif;0.3.0-1.fc17;x86_64;updates");
+	g_assert_cmpstr (pk_package_get_id (pkg), ==, "zif;0.3.0-1.fc17;x86_64;updates;");
 	g_object_unref (results);
 
 	/* save some dummy failed results */

--- a/src/pk-self-test.c
+++ b/src/pk-self-test.c
@@ -120,10 +120,10 @@ pk_test_backend_func_true (PkBackendJob *job,
 	/* trigger duplicate test */
 
 	pk_backend_job_package (job, PK_INFO_ENUM_AVAILABLE,
-				"vips-doc;7.12.4-2.fc8;noarch;linva",
+				"vips-doc;7.12.4-2.fc8;noarch;linva;",
 				"The vips documentation package.");
 	pk_backend_job_package (job, PK_INFO_ENUM_AVAILABLE,
-				"vips-doc;7.12.4-2.fc8;noarch;linva",
+				"vips-doc;7.12.4-2.fc8;noarch;linva;",
 				"The vips documentation package.");
 }
 
@@ -396,11 +396,11 @@ pk_test_backend_spawn_func (void)
 	g_assert_true (ret);
 
 	/* test pk_backend_spawn_inject_data RequireRestart */
-	ret = pk_backend_spawn_inject_data (backend_spawn, job, "requirerestart\tsystem\tgnome-power-manager;0.0.1;i386;data", NULL);
+	ret = pk_backend_spawn_inject_data (backend_spawn, job, "requirerestart\tsystem\tgnome-power-manager;0.0.1;i386;origin;data", NULL);
 	g_assert_true (ret);
 
 	/* test pk_backend_spawn_inject_data RequireRestart invalid enum */
-	ret = pk_backend_spawn_inject_data (backend_spawn, job, "requirerestart\tmooville\tgnome-power-manager;0.0.1;i386;data", NULL);
+	ret = pk_backend_spawn_inject_data (backend_spawn, job, "requirerestart\tmooville\tgnome-power-manager;0.0.1;i386;origin;data", NULL);
 	g_assert_true (!ret);
 
 	/* test pk_backend_spawn_inject_data RequireRestart invalid PackageId */
@@ -448,7 +448,7 @@ pk_test_backend_spawn_func (void)
 
 	/* test pk_backend_spawn_parse_common_out Package */
 	ret = pk_backend_spawn_inject_data (backend_spawn, job,
-		"package\tinstalled\tgnome-power-manager;0.0.1;i386;data\tMore useless software", NULL);
+		"package\tinstalled\tgnome-power-manager;0.0.1;i386;origin;data\tMore useless software", NULL);
 	g_assert_true (ret);
 
 	/* manually unlock as we have no engine */
@@ -1315,7 +1315,7 @@ pk_test_scheduler_parallel_func (void)
 	g_strfreev (array);
 
 	/* run a second (and exclusive!) action in parallel */
-	array = g_strsplit ("libawesome;42;i386;debian", " ", -1);
+	array = g_strsplit ("libawesome;42;i386;debian;manual", " ", -1);
 	transaction1 = pk_scheduler_get_transaction (tlist, tid_item2);
 	pk_transaction_skip_auth_checks (transaction1, TRUE);
 	pk_transaction_install_packages (transaction1,
@@ -1336,7 +1336,7 @@ pk_test_scheduler_parallel_func (void)
 	g_strfreev (array);
 
 	/* run a fourth (and exclusive!) action in parallel */
-	array = g_strsplit ("foobar;1.1.0;i386;debian", " ", -1);
+	array = g_strsplit ("foobar;1.1.0;i386;debian;manual", " ", -1);
 	transaction1 = pk_scheduler_get_transaction (tlist, tid_item4);
 	pk_transaction_skip_auth_checks (transaction1, TRUE);
 	pk_transaction_install_packages (transaction1,
@@ -1468,4 +1468,3 @@ main (int argc, char **argv)
 
 	return g_test_run ();
 }
-

--- a/tests/data/pk-spawn-test.sh
+++ b/tests/data/pk-spawn-test.sh
@@ -17,8 +17,8 @@ echo -e "percentage\t30"
 sleep ${time}
 echo -e "percentage\t40"
 sleep ${time}
-echo -e "package\tavailable\tpolkit;0.0.1;i386;data\tPolicyKit daemon"
-echo -e "package\tinstalled\tpolkit-gnome;0.0.1;i386;data\tPolicyKit helper (•) for GNOME"
+echo -e "package\tavailable\tpolkit;0.0.1;i386;origin;data\tPolicyKit daemon"
+echo -e "package\tinstalled\tpolkit-gnome;0.0.1;i386;origin;data\tPolicyKit helper (•) for GNOME"
 sleep ${time}
 printf "package\tavailable\tConsoleKit"
 sleep ${time}
@@ -32,6 +32,6 @@ sleep ${time}
 echo -e "percentage\t80"
 sleep ${time}
 echo -e "percentage\t90"
-echo -e "package\tinstalled\tgnome-power-manager;0.0.1;i386;data\tMore useless software"
+echo -e "package\tinstalled\tgnome-power-manager;0.0.1;i386;origin;data\tMore useless software"
 sleep ${time}
 echo -e "percentage\t100"


### PR DESCRIPTION
Hi!

This is one of the changes I had planned for a potential "PackageKit 2". However, it might be smarter to not wait for a PK2 release that changes everything all at once (and that may never happen because I will never find the time), but to instead make a few useful changes incrementally.

A few years ago, a change was merged that broke the D-Bus API of PackageKit, and while it sucked, there was far less breakage than I would have anticipated. Therefore, we can maybe go ahead with an actually useful change like this one.

**This change is an API/ABI break** and also breaks a few assumptions backends currently make. When merged, it will be accompanied by a library version bump and likely a few other (breaking) changes. I might also add some code that enforces a lockstep upgrade of daemon and library, so they remain compatible.

The patch will expand the package-ID from its current 4-section format of `name;version;arch;dataorigin` to a 5-section format of `name;version;arch;origin;data`.
This will solve a whole bunch of issues at once:
 * Code becomes cleaner as we don't have to do weird parsing of the "data" field to split it into origin and auxiliary data anymore, and we get a clean meaning for both the origin part and data part
 * The `origin` part of a package-ID can finally be used by frontends verbatim to indicate the source of a package directly, without exceptions and heuristics
 * Packages will no longer lose their origin information as soon as they are installed (with the repo info being replaced by just `installed`). This was extremely strange behavior which made the data part of a pkid basically useless for frontends.
 * We can standardize a few naming conventions, and have backends add needed state(change) info to the `data` part of a package-ID that is now no longer parsed at all by frontends.

I do not think this will cause problems for frontends, in fact, it will likely be a good improvement for them once backends have updates as well. However, it is a breaking change and you cannot use a newer daemon with an older library version anymore from that point (but I hope nobody does that anyway).

I am not at all excited about breaking the ossified interfaces of PK, because that's pain now as well as for downstreams. From a "we still need to maintain this in the future, and maintaining hacks is costly" perspective though, I'd rather want to make this change now.

I will leave this in "draft" stage (and the ABI CI failing, as a reminder) so the change can get some feedback, and will likely stage a few other similar "nice, but breaking" changes as well for review - as preview for the 1.4.x series.

Let me know what you think!