### PR TITLE
pkgcli: Add TRANSLATORS comments for commands

### DIFF
--- a/client/pkgc-manage.c
+++ b/client/pkgc-manage.c
@@ -1028,59 +1028,69 @@ pkgc_register_manage_commands (PkgcliContext *ctx)
 		ctx,
        "refresh",
        pkgc_refresh,
+       /* TRANSLATORS: Description for refresh command in pkgcli help */
        _("Refresh package metadata"));
 
 	pkgc_context_register_command (
 		ctx,
 		"install",
 		pkgc_install,
+		/* TRANSLATORS: Description for install command in pkgcli help */
 		_("Install packages"));
 
 	pkgc_context_register_command (
 		ctx,
 		"remove",
 		pkgc_remove,
+		/* TRANSLATORS: Description for remove command in pkgcli help */
 		_("Remove packages"));
 
 	pkgc_context_register_command (
 	    ctx,
 	    "update",
 	    pkgc_update,
+	    /* TRANSLATORS: Description for update command in pkgcli help */
 	    _("Update packages"));
 
 	pkgc_context_register_command (
 	    ctx,
 	    "upgrade",
 	    pkgc_upgrade,
+	    /* TRANSLATORS: Description for upgrade command in pkgcli help */
 	    _("Upgrade the system"));
 
 	pkgc_context_register_command (
 	    ctx,
 	    "download",
 	    pkgc_download,
+	    /* TRANSLATORS: Description for download command in pkgcli help */
 	    _("Download packages"));
 
 	pkgc_context_register_command (
 		ctx,
 		"offline-update",
 		pkgc_offline_update,
+		/* TRANSLATORS: Description for offline-update command in pkgcli help */
 		_("Manage offline system updates"));
 
 	pkgc_context_register_command (
 		ctx,
 		"install-sig",
 		pkgc_install_sig,
+		/* TRANSLATORS: Description for install-sig command in pkgcli help */
 		_("Install package signature"));
 
 	pkgc_context_register_command (
 		ctx,
 		"repair",
 		pkgc_repair,
+		/* TRANSLATORS: Description for repair command in pkgcli help */
 		_("Repair package system"));
 
 	pkgc_context_register_command (
 		ctx,
 		"quit",
 		pkgc_suggest_quit,
+		/* TRANSLATORS: Description for quit command in pkgcli help */
 		_("Safely stop the PackageKit daemon"));
 }

--- a/client/pkgc-monitor.c
+++ b/client/pkgc-monitor.c
@@ -622,6 +622,6 @@ pkgc_register_monitor_commands (PkgcliContext *ctx)
 	    ctx,
 	    "monitor",
 	    pkgc_cmd_monitor,
-	    /* TRANSLATORS: Summary for pkgcli monitor, the PK D-Bus monitor */
+	    /* TRANSLATORS: Description for monitor command in pkgcli help */
 	    _("Monitor PackageKit bus events"));
 }

--- a/client/pkgc-query.c
+++ b/client/pkgc-query.c
@@ -982,89 +982,104 @@ pkgc_register_query_commands (PkgcliContext *ctx)
 		ctx,
 		"backend",
 		pkgc_backend_info,
+		/* TRANSLATORS: Description for backend command in pkgcli help */
 		_("Show backend information"));
 
 	pkgc_context_register_command (
 		ctx,
 		"history",
 		pkgc_history,
+		/* TRANSLATORS: Description for history command in pkgcli help */
 		_("Show transaction history"));
 
 	pkgc_context_register_command (
 		ctx,
 		"search",
 		pkgc_query_search,
+		/* TRANSLATORS: Description for search command in pkgcli help */
 		_("Search for packages"));
 
 	pkgc_context_register_command (
 		ctx,
 		"list",
 		pkgc_query_list,
+		/* TRANSLATORS: Description for list command in pkgcli help */
 		_("List packages"));
 
 	pkgc_context_register_command (
 		ctx,
 		"show",
 		pkgc_query_show,
+		/* TRANSLATORS: Description for show command in pkgcli help */
 		_("Show package information"));
 
 	pkgc_context_register_command (
 		ctx,
 		"list-depends",
 		pkgc_query_depends_on,
+		/* TRANSLATORS: Description for list-depends command in pkgcli help */
 		_("List package dependencies"));
 
 	pkgc_context_register_command (
 		ctx,
 		"list-required-by",
 		pkgc_query_required_by,
+		/* TRANSLATORS: Description for list-required-by command in pkgcli help */
 		_("List packages requiring this package"));
 
 	pkgc_context_register_command (
 		ctx,
 		"what-provides",
 		pkgc_query_what_provides,
+		/* TRANSLATORS: Description for what-provides command in pkgcli help */
 		_("List packages providing a capability"));
 
 	pkgc_context_register_command (
 		ctx,
 		"files",
 		pkgc_query_files,
+		/* TRANSLATORS: Description for files command in pkgcli help */
 		_("Show files in package"));
 
 	pkgc_context_register_command (
 		ctx,
 		"list-updates",
 		pkgc_updates_list_updates,
+		/* TRANSLATORS: Description for list-updates command in pkgcli help */
 		_("Get available updates"));
 
 	pkgc_context_register_command (
 		ctx,
 		"show-update",
 		pkgc_updates_show_update,
+		/* TRANSLATORS: Description for show-update command in pkgcli help */
 		_("Get update details"));
 
 	pkgc_context_register_command (
 		ctx,
 		"resolve",
 		pkgc_query_resolve,
+		/* TRANSLATORS: Description for resolve command in pkgcli help */
 		_("Resolve package names"));
 
 	pkgc_context_register_command (
 		ctx,
 		"organization",
 		pkgc_query_organization,
+		/* TRANSLATORS: Description for organization command in pkgcli help */
 		_("List available filters and categories"));
 
 	pkgc_context_register_command (
 		ctx,
 		"show-os-upgrade",
 		pkgc_query_show_os_upgrade,
+		/* TRANSLATORS: Description for show-os-upgrade command in pkgcli help */
 		_("Show available distribution upgrades"));
 
 	pkgc_context_register_command (
 		ctx,
 		"last-time",
 		pkgc_query_last_time,
+		/* TRANSLATORS: Description for last-time command in pkgcli help */
 		_("Get time since last action"));
 }

--- a/client/pkgc-repo.c
+++ b/client/pkgc-repo.c
@@ -241,23 +241,27 @@ pkgc_register_repo_commands (PkgcliContext *ctx)
 		ctx,
 		"repo-list",
 		pkgc_repo_list,
+		/* TRANSLATORS: Description for repo-list command in pkgcli help */
 		_("List repositories"));
 
 	pkgc_context_register_command (
 		ctx,
 		"repo-enable",
 		pkgc_repo_enable,
+		/* TRANSLATORS: Description for repo-enable command in pkgcli help */
 		_("Enable a repository"));
 
 	pkgc_context_register_command (
 		ctx,
 		"repo-disable",
 		pkgc_repo_disable,
+		/* TRANSLATORS: Description for repo-disable command in pkgcli help */
 		_("Disable a repository"));
 
 	pkgc_context_register_command (
 		ctx,
 		"repo-remove",
 		pkgc_repo_remove,
+		/* TRANSLATORS: Description for repo-remove command in pkgcli help */
 		_("Remove a repository"));
 }


### PR DESCRIPTION
These are for the descriptions for commands under "Available Commands" section of `pkgcli --help`.

Confirmed it is extracted to POT files via `meson setup . build && ninja -C build/ PackageKit-pot`