### PR TITLE
tests/ci: Fix gstreamer dep for Solus Dockerfile

### DIFF
--- a/tests/ci/Dockerfile-solus
+++ b/tests/ci/Dockerfile-solus
@@ -5,7 +5,7 @@ RUN eopkg -y install \
     packagekit-devel \
     sqlite3-devel \
     vala \
-    gstreamer-1.0-plugins-base-devel \
+    gstreamer-plugins-base-devel \
     libgtk-3-devel \
     jansson-devel \
     docbook-xml


### PR DESCRIPTION
gstreamer 0.10 was deprecated and thus gstreamer 1.0 was renamed