### PR TITLE
daemon: stop idle progress timer after flushing updates

### DIFF
--- a/src/pk-transaction.c
+++ b/src/pk-transaction.c
@@ -370,6 +370,8 @@ flush_progress_changed (PkTransaction *transaction)
 	if (!transaction->progress_changed)
 		return;
 
+	transaction->progress_changed = FALSE;
+
 	/* Emit a D-Bus signal to notify of the progress changes. */
 	pk_transaction_emit_properties_changed (transaction,
 						"Percentage", g_variant_new_uint32 (transaction->percentage),
@@ -378,8 +380,6 @@ flush_progress_changed (PkTransaction *transaction)
 						"Speed", g_variant_new_uint32 (transaction->speed),
 						"DownloadSizeRemaining", g_variant_new_uint64 (transaction->download_size_remaining),
 						NULL);
-
-	transaction->progress_changed = FALSE;
 }
 
 static gboolean
@@ -387,9 +387,12 @@ progress_timeout_cb (gpointer user_data)
 {
 	PkTransaction *transaction = PK_TRANSACTION (user_data);
 
+	/* The timeout is one-shot: clear our source ref before flushing so any
+	 * progress change queued during signal emission can schedule a new one. */
+	g_clear_pointer (&transaction->progress_timeout_source, g_source_unref);
 	flush_progress_changed (transaction);
 
-	return G_SOURCE_CONTINUE;
+	return G_SOURCE_REMOVE;
 }
 
 /* Aggregate progress-related property notifications so that the transaction


### PR DESCRIPTION
## Summary

Make the transaction progress timer a one-shot source. After pending progress properties are emitted on D-Bus, the timeout drops its stored source reference and removes itself, so idle transactions do not keep waking every 100 ms.

The pending-progress flag is cleared before emitting the signal, so any progress update queued during signal emission is treated as a new batch and can schedule a fresh timeout.

## Validation

- `git diff --check`
- Checked progress timeout and flush references with `rg`
- Attempted local Meson setup with:

  `meson setup build/fixer -Dlocal_checkout=true -Dsystemd=false -Doffline_update=false -Dgobject_introspection=false -Dbash_completion=false -Dbash_command_not_found=false -Dgstreamer_plugin=false -Dgtk_module=false -Dcron=false -Dpython_backend=false -Dman_pages=false`

  The local setup stopped before compilation because `polkit-gobject-1` development files were not installed.
- GitHub/Cirrus `Build & Test (freebsd)` check passed on this PR.
