### PR TITLE
apt: Implement allow_deps in RemovePackages transaction

### DIFF
--- a/backends/apt/apt-job.cpp
+++ b/backends/apt/apt-job.cpp
@@ -2369,7 +2369,8 @@ bool AptJob::runTransaction(
     const PkgList &update,
     bool fixBroken,
     PkBitfield flags,
-    bool autoremove)
+    bool autoremove,
+    bool allowRemoveDeps)
 {
     pk_backend_job_set_status(m_job, PK_STATUS_ENUM_RUNNING);
 
@@ -2392,6 +2393,14 @@ bool AptJob::runTransaction(
 
     // Calculate existing garbage before the transaction
     PkgList initial_garbage;
+    std::vector<unsigned int> explicitRemovalPkgIds;
+    explicitRemovalPkgIds.reserve(remove.size());
+
+    for (const PkgInfo &pkInfo : remove) {
+        if (!pkInfo.ver.end())
+            explicitRemovalPkgIds.push_back(pkInfo.ver.ParentPkg()->ID);
+    }
+
     if (autoremove) {
         for (pkgCache::PkgIterator pkg = (*m_cache)->PkgBegin(); !pkg.end(); ++pkg) {
             const pkgCache::VerIterator &ver = pkg.CurrentVer();
@@ -2447,6 +2456,42 @@ bool AptJob::runTransaction(
             // did not finish well
             m_cache->ShowBroken(false, PK_ERROR_ENUM_DEP_RESOLUTION_FAILED);
             return false;
+        }
+
+        if (!allowRemoveDeps) {
+            std::vector<std::string> implicitRemovals;
+            for (pkgCache::PkgIterator pkg = (*m_cache)->PkgBegin(); !pkg.end(); ++pkg) {
+                if (pkg->CurrentVer == 0 || !(*m_cache)[pkg].Delete())
+                    continue;
+
+                if (std::find(explicitRemovalPkgIds.begin(), explicitRemovalPkgIds.end(), pkg->ID)
+                    != explicitRemovalPkgIds.end()) {
+                    continue;
+                }
+
+                implicitRemovals.push_back(pkg.Name());
+            }
+
+            if (!implicitRemovals.empty()) {
+                std::string removalList;
+                for (size_t i = 0; i < implicitRemovals.size(); i++) {
+                    const auto &name = implicitRemovals[i];
+                    if (!removalList.empty())
+                        removalList += ", ";
+                    if (i >= 10) {
+                        removalList += "and more...";
+                        break;
+                    }
+                    removalList += name;
+                }
+
+                pk_backend_job_error_code(
+                    m_job,
+                    PK_ERROR_ENUM_DEP_RESOLUTION_FAILED,
+                    "The requested operation would remove dependent package(s): %s",
+                    removalList.c_str());
+                return false;
+            }
         }
     }
 

--- a/backends/apt/apt-job.h
+++ b/backends/apt/apt-job.h
@@ -110,6 +110,7 @@ public:
      * @param fixBroken whether to automatically fix broken packages
      * @param flags operation flags as per public API
      * @param autoremove whether to autoremove dangling packages
+     * @param allowRemoveDeps whether to allow removal of dependent packages
      */
     bool runTransaction(
         const PkgList &install,
@@ -117,7 +118,8 @@ public:
         const PkgList &update,
         bool fixBroken,
         PkBitfield flags,
-        bool autoremove);
+        bool autoremove,
+        bool allowRemoveDeps);
 
     /**
      *  Get package depends

--- a/backends/apt/pk-backend-apt.cpp
+++ b/backends/apt/pk-backend-apt.cpp
@@ -687,7 +687,7 @@ static void backend_manage_packages_thread(PkBackendJob *job, GVariant *params, 
 {
     // Transaction flags
     PkBitfield transaction_flags = 0;
-    gboolean allow_deps = false;
+    gboolean allowRemoveDeps = true;
     gboolean autoremove = false;
     gchar **full_paths = NULL;
     gchar **package_ids = NULL;
@@ -697,7 +697,7 @@ static void backend_manage_packages_thread(PkBackendJob *job, GVariant *params, 
     if (role == PK_ROLE_ENUM_INSTALL_FILES) {
         g_variant_get(params, "(t^a&s)", &transaction_flags, &full_paths);
     } else if (role == PK_ROLE_ENUM_REMOVE_PACKAGES) {
-        g_variant_get(params, "(t^a&sbb)", &transaction_flags, &package_ids, &allow_deps, &autoremove);
+        g_variant_get(params, "(t^a&sbb)", &transaction_flags, &package_ids, &allowRemoveDeps, &autoremove);
     } else if (role == PK_ROLE_ENUM_INSTALL_PACKAGES) {
         g_variant_get(params, "(t^a&s)", &transaction_flags, &package_ids);
     } else if (role == PK_ROLE_ENUM_UPDATE_PACKAGES) {
@@ -751,7 +751,14 @@ static void backend_manage_packages_thread(PkBackendJob *job, GVariant *params, 
     }
 
     // Install/Update/Remove packages, or just simulate
-    bool ret = apt->runTransaction(installPkgs, removePkgs, updatePkgs, fixBroken, transaction_flags, autoremove);
+    bool ret = apt->runTransaction(
+        installPkgs,
+        removePkgs,
+        updatePkgs,
+        fixBroken,
+        transaction_flags,
+        autoremove,
+        allowRemoveDeps);
     if (!ret) {
         // Print transaction errors
         g_debug("AptJob::runTransaction() failed: %i", _error->PendingError());
@@ -880,7 +887,7 @@ static void backend_repo_manager_thread(PkBackendJob *job, GVariant *params, gpo
                     if (removePkgs.size() > 0) {
                         // Install/Update/Remove packages, or just simulate
                         bool ret;
-                        ret = apt->runTransaction(PkgList(), removePkgs, PkgList(), false, transaction_flags, false);
+                        ret = apt->runTransaction(PkgList(), removePkgs, PkgList(), false, transaction_flags, false, true);
                         if (!ret) {
                             // Print transaction errors
                             g_debug("AptJob::runTransaction() failed: %i", _error->PendingError());


### PR DESCRIPTION
The allow_deps parameter of RemovePackages was being ignored, by always allowing dependencies to be removed (allow_deps=True). Implement allow_deps=False by looking at the package cache state after having marked packages for removal.

For all other transactions, the behaviour depends on apt internal policies.

Assisted-by: GitHub Copilot (GPT-5.3-Codex)