### PR TITLE
backends/eopkg: Adjust for v4.5.0 & resolving/filtering fixes

### DIFF
--- a/backends/eopkg/eopkgBackend.py
+++ b/backends/eopkg/eopkgBackend.py
@@ -389,7 +389,7 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
             if FILTER_NOT_FREE in filters:
                 if not any(l in pkg.license for l in nonfree):
                     return
-            if FILTER_DEVELOPMENT in filters and not "-devel" in pkg.name:
+            if FILTER_DEVELOPMENT in filters and "-devel" not in pkg.name:
                 return
             if FILTER_NOT_DEVELOPMENT in filters and "-devel" in pkg.name:
                 return
@@ -763,7 +763,7 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
                 "Could not download package: %s" % e,
                 exit=False,
             )
-        except Exception as e:
+        except Exception:
             self.error(ERROR_INTERNAL_ERROR, _format_str(traceback.format_exc()))
 
     @privileged
@@ -814,7 +814,7 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
             self.error(
                 ERROR_LOCAL_INSTALL_FAILED, "Could not install: %s" % e, exit=False
             )
-        except Exception as e:
+        except Exception:
             self.error(ERROR_INTERNAL_ERROR, _format_str(traceback.format_exc()))
 
     @privileged
@@ -864,7 +864,7 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
             self.error(
                 ERROR_PACKAGE_FAILED_TO_INSTALL, "Could not install: %s" % e, exit=False
             )
-        except Exception as e:
+        except Exception:
             self.error(ERROR_INTERNAL_ERROR, _format_str(traceback.format_exc()))
 
     @privileged
@@ -931,7 +931,7 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
             self.error(
                 ERROR_PACKAGE_FAILED_TO_REMOVE, "Could not remove: %s" % e, exit=False
             )
-        except Exception as e:
+        except Exception:
             self.error(ERROR_INTERNAL_ERROR, _format_str(traceback.format_exc()))
 
     @privileged
@@ -1104,7 +1104,7 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
             self.error(
                 ERROR_PACKAGE_FAILED_TO_INSTALL, "Could not update: %s" % e, exit=False
             )
-        except Exception as e:
+        except Exception:
             self.error(ERROR_INTERNAL_ERROR, _format_str(traceback.format_exc()))
 
 

--- a/backends/eopkg/eopkgBackend.py
+++ b/backends/eopkg/eopkgBackend.py
@@ -52,22 +52,6 @@ from packagekit.enums import *
 from packagekit.package import PackagekitPackage
 from packagekit.progress import *
 
-TransactionsStateMap = {
-    "download_packages": STATUS_DOWNLOAD,
-    "update_packages": STATUS_UPDATE,
-    "remove_packages": STATUS_REMOVE,
-    "install_packages": STATUS_INSTALL,
-    "install_files": STATUS_INSTALL,
-    "refresh_cache": STATUS_REFRESH_CACHE,
-}
-
-TransactionsInfoMap = {
-    "update_packages": INFO_UPDATING,
-    "remove_packages": INFO_REMOVING,
-    "install_packages": INFO_INSTALLING,
-    "install_files": INFO_INSTALLING,
-}
-
 
 def _format_str(text):
     """

--- a/backends/eopkg/eopkgBackend.py
+++ b/backends/eopkg/eopkgBackend.py
@@ -848,7 +848,7 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
         for package_id in package_ids:
             package = self.get_package_from_id(package_id)[0]
             if self.installdb.has_package(package):
-                self.error(ERROR_PACKAGE_NOT_INSTALLED, "Package is already installed")
+                self.error(ERROR_PACKAGE_ALREADY_INSTALLED, "Package is already installed")
             packages.append(package)
 
         if TRANSACTION_FLAG_SIMULATE in transaction_flags:

--- a/backends/eopkg/eopkgBackend.py
+++ b/backends/eopkg/eopkgBackend.py
@@ -34,6 +34,11 @@
 # to see "Bug-SolusOS: T9" for example, on its own line in a package update
 # comment.
 
+import os.path
+import re
+from collections import Counter
+from operator import attrgetter
+
 import pisi
 import pisi.api
 import pisi.config
@@ -42,30 +47,25 @@ import pisi.db
 import pisi.fetcher
 import pisi.ui
 import pisi.util
-from packagekit.package import PackagekitPackage
 from packagekit.backend import *
 from packagekit.enums import *
+from packagekit.package import PackagekitPackage
 from packagekit.progress import *
-import os.path
-import re
-from collections import Counter
-from operator import attrgetter
-
 
 TransactionsStateMap = {
-    "download_packages" : STATUS_DOWNLOAD,
-    "update_packages"   : STATUS_UPDATE,
-    "remove_packages"   : STATUS_REMOVE,
-    "install_packages"  : STATUS_INSTALL,
-    "install_files"     : STATUS_INSTALL,
-    "refresh_cache"     : STATUS_REFRESH_CACHE
+    "download_packages": STATUS_DOWNLOAD,
+    "update_packages": STATUS_UPDATE,
+    "remove_packages": STATUS_REMOVE,
+    "install_packages": STATUS_INSTALL,
+    "install_files": STATUS_INSTALL,
+    "refresh_cache": STATUS_REFRESH_CACHE,
 }
 
 TransactionsInfoMap = {
-    "update_packages"   : INFO_UPDATING,
-    "remove_packages"   : INFO_REMOVING,
-    "install_packages"  : INFO_INSTALLING,
-    "install_files"     : INFO_INSTALLING
+    "update_packages": INFO_UPDATING,
+    "remove_packages": INFO_REMOVING,
+    "install_packages": INFO_INSTALLING,
+    "install_files": INFO_INSTALLING,
 }
 
 
@@ -74,7 +74,7 @@ def _format_str(text):
     Convert a multi line string to a list separated by ';'
     """
     if text:
-        lines = text.split('\n')
+        lines = text.split("\n")
         return ";".join(lines)
     else:
         return ""
@@ -82,7 +82,6 @@ def _format_str(text):
 
 # Override PiSi UI so we can get callbacks for progress and events
 class SimplePisiHandler(pisi.ui.UI):
-
     def __init__(self, base):
         pisi.ui.UI.__init__(self, False, False)
         self.errors = 0
@@ -129,15 +128,15 @@ class SimplePisiHandler(pisi.ui.UI):
         file_name = kw["filename"]
         if not file_name.startswith("eopkg-index.xml"):
             pkg_name = pisi.util.parse_package_name(file_name)[0]
-            self.notify("progress", pkg_name=pkg_name, percent=int(kw['percent']))
+            self.notify("progress", pkg_name=pkg_name, percent=int(kw["percent"]))
         if self.packagestogo > 0:
             # Increase the step offset by 50%
             # e.g. 5 pkgs to install, currentpackage == 3 so update percentage range within 60% to 80%.
-            sliced = (100 / self.packagestogo)
-            slicedpercent = sliced / 100 * int(kw['percent']) + percent - sliced
+            sliced = 100 / self.packagestogo
+            slicedpercent = sliced / 100 * int(kw["percent"]) + percent - sliced
             self.base._set_percent(slicedpercent)
         else:
-            self.base._set_percent(int(kw['percent']))
+            self.base._set_percent(int(kw["percent"]))
 
     def notify(self, event, **keywords):
 
@@ -149,40 +148,65 @@ class SimplePisiHandler(pisi.ui.UI):
         if event == "progress":
             if pisi.db.packagedb.PackageDB().has_package(keywords["pkg_name"]):
                 pkg = pisi.db.packagedb.PackageDB().get_package(keywords["pkg_name"])
-                self.base.item_progress(self.base._pkg_to_id(pkg), STATUS_DOWNLOAD, keywords['percent'])
-        #if event == pisi.ui.cached:
+                self.base.item_progress(
+                    self.base._pkg_to_id(pkg), STATUS_DOWNLOAD, keywords["percent"]
+                )
+        # if event == pisi.ui.cached:
         #   self.base._set_status(keywords["package"], INFO_FINISHED)
         if event == pisi.ui.installing:
             # Pisi doesn't tell us whether it's installing or upgrading in the callback until after it's done it, thanks!
             # This is bad for progress bars, obviously. Set the status based on the called operation.
             self.base.status(TransactionsStateMap[self.base.operation])
 
-            self.base._set_status(keywords["package"], TransactionsInfoMap[self.base.operation])
-            self.base.item_progress(self.base._pkg_to_id(keywords["package"]), TransactionsStateMap[self.base.operation], 0)
+            self.base._set_status(
+                keywords["package"], TransactionsInfoMap[self.base.operation]
+            )
+            self.base.item_progress(
+                self.base._pkg_to_id(keywords["package"]),
+                TransactionsStateMap[self.base.operation],
+                0,
+            )
         if event == pisi.ui.removing:
-            self.base._set_status(keywords["package"], TransactionsInfoMap[self.base.operation])
-            self.base.item_progress(self.base._pkg_to_id(keywords["package"]), TransactionsStateMap[self.base.operation], 0)
+            self.base._set_status(
+                keywords["package"], TransactionsInfoMap[self.base.operation]
+            )
+            self.base.item_progress(
+                self.base._pkg_to_id(keywords["package"]),
+                TransactionsStateMap[self.base.operation],
+                0,
+            )
         if event == pisi.ui.extracting:
             # Increase the step offset by 50% and account for usysconf offset
             # e.g. 5 pkgs to install, currentpackage == 3 so update percentage 50% within 60% to 80%.
-            subpercentage = (100 / (self.packagestogo + (0.1 * self.packagestogo))) / 100 * 50 + self.get_percentage(self.currentpackage, self.packagestogo)
+            subpercentage = (
+                100 / (self.packagestogo + (0.1 * self.packagestogo))
+            ) / 100 * 50 + self.get_percentage(self.currentpackage, self.packagestogo)
             self.base._set_percent(subpercentage)
-            self.base.item_progress(self.base._pkg_to_id(keywords["package"]), TransactionsStateMap[self.base.operation], 50)
+            self.base.item_progress(
+                self.base._pkg_to_id(keywords["package"]),
+                TransactionsStateMap[self.base.operation],
+                50,
+            )
         if event == pisi.ui.installed:
-            self.base.item_progress(self.base._pkg_to_id(keywords["package"]), STATUS_INSTALL, 100)
+            self.base.item_progress(
+                self.base._pkg_to_id(keywords["package"]), STATUS_INSTALL, 100
+            )
             self.update_percentage()
         if event == pisi.ui.removed:
-            self.base.item_progress(self.base._pkg_to_id(keywords["package"]), STATUS_REMOVE, 100)
+            self.base.item_progress(
+                self.base._pkg_to_id(keywords["package"]), STATUS_REMOVE, 100
+            )
             self.update_percentage()
         if event == pisi.ui.upgraded:
-            self.base.item_progress(self.base._pkg_to_id(keywords["package"]), STATUS_UPDATE, 100)
+            self.base.item_progress(
+                self.base._pkg_to_id(keywords["package"]), STATUS_UPDATE, 100
+            )
             self.update_percentage()
         if event == pisi.ui.systemconf:
             self.base._set_percent(90)
 
 
 class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
-
     SETTINGS_FILE = "/etc/PackageKit/eopkg.d/groups.list"
 
     def __init__(self, args):
@@ -209,7 +233,7 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
         self.repodb = pisi.db.repodb.RepoDB()
 
     def _load_settings(self):
-        """ Load the PK Group-> PiSi component mapping """
+        """Load the PK Group-> PiSi component mapping"""
         if os.path.exists(self.SETTINGS_FILE):
             with open(self.SETTINGS_FILE, "r") as mapping:
                 self.groups = {}
@@ -254,15 +278,16 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
             self.finished()
             self.get_db()
             pisi.api.set_userinterface(self.saved_ui)
+
         return wrapper
 
     def _pkg_to_id(self, pkg):
-        """ PiSi pkg to pk id """
+        """PiSi pkg to pk id"""
         # FIXME: when getting repo, we can't use self.packagedb/installdb here
         # as they get invalidated by the pisi.api call.
         if pisi.db.packagedb.PackageDB().has_package(pkg.name):
             repo = pisi.db.packagedb.PackageDB().which_repo(pkg.name)
-            #if pisi.db.installdb.InstallDB().has_package(pkg.name):
+            # if pisi.db.installdb.InstallDB().has_package(pkg.name):
             #    repo = "installed:{}".format(repo)
         else:
             if pisi.db.installdb.InstallDB().has_package(pkg.name):
@@ -277,24 +302,31 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
         self.package(package_id, status, pkg.summary)
 
     def __get_package_version(self, package):
-        """ Returns version string of given package """
+        """Returns version string of given package"""
         # Internal FIXME: PiSi may provide this
         if package.build is not None:
-            version = "%s-%s-%s" % (package.version, package.release,
-                                    package.build)
+            version = "%s-%s-%s" % (package.version, package.release, package.build)
         else:
             version = "%s-%s" % (package.version, package.release)
         return version
 
     def __get_package(self, package, filters=None):
-        """ Returns package object suitable for other methods """
+        """Returns package object suitable for other methods"""
 
         status = INFO_AVAILABLE
         data = "installed"
         pkg = ""
 
-        installed = self.installdb.get_package(package) if self.installdb.has_package(package) else None
-        available, repo = self.packagedb.get_package_repo(package) if self.packagedb.has_package(package) else (None, None)
+        installed = (
+            self.installdb.get_package(package)
+            if self.installdb.has_package(package)
+            else None
+        )
+        available, repo = (
+            self.packagedb.get_package_repo(package)
+            if self.packagedb.has_package(package)
+            else (None, None)
+        )
 
         # Not found
         if installed is None and available is None:
@@ -351,7 +383,7 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
             if FILTER_NOT_GUI in filters and "app:gui" in pkg.isA:
                 return
             # FIXME: To lower
-            nonfree = ['EULA', 'Distributable']
+            nonfree = ["EULA", "Distributable"]
             if FILTER_FREE in filters:
                 if any(l in pkg.license for l in nonfree):
                     return
@@ -375,7 +407,7 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
         return self.package(id, status, pkg.summary)
 
     def depends_on(self, filters, package_ids, recursive):
-        """ Prints a list of depends for a given package """
+        """Prints a list of depends for a given package"""
         self.status(STATUS_QUERY)
         self.allow_cancel(True)
         self.percentage(None)
@@ -391,7 +423,9 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
                 for pkg in self.installdb.get_package(package).runtimeDependencies():
                     self.__get_package(pkg.package)
             else:
-                self.error(ERROR_PACKAGE_NOT_FOUND, "Package %s was not found" % package)
+                self.error(
+                    ERROR_PACKAGE_NOT_FOUND, "Package %s was not found" % package
+                )
 
     def get_categories(self):
         self.status(STATUS_QUERY)
@@ -402,10 +436,16 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
         for p in categories:
             component = self.componentdb.get_component(p)
             cat_id = component.name
-            self.category(component.group, cat_id, component.name, str(component.summary), "image-missing")
+            self.category(
+                component.group,
+                cat_id,
+                component.name,
+                str(component.summary),
+                "image-missing",
+            )
 
     def repair_system(self, transaction_flags):
-        """ Deletes caches, rebuilds filesdb and reinits pisi caches """
+        """Deletes caches, rebuilds filesdb and reinits pisi caches"""
 
         if TRANSACTION_FLAG_SIMULATE in transaction_flags:
             return
@@ -417,7 +457,7 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
         pisi.db.update_caches()
 
     def get_details(self, package_ids):
-        """ Prints a detailed description for a given packages """
+        """Prints a detailed description for a given packages"""
         self.status(STATUS_QUERY)
         self.allow_cancel(True)
         self.percentage(None)
@@ -445,21 +485,32 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
                 size = int(pkg.installedSize)
                 dl_size = int(pkg.packageSize)
             else:
-                self.error(ERROR_PACKAGE_NOT_FOUND, "Package %s was not found" % package)
+                self.error(
+                    ERROR_PACKAGE_NOT_FOUND, "Package %s was not found" % package
+                )
 
-            pkg_id = self.get_package_id(pkg.name, self.__get_package_version(pkg),
-                                         pkg.architecture, data)
+            pkg_id = self.get_package_id(
+                pkg.name, self.__get_package_version(pkg), pkg.architecture, data
+            )
 
             if pkg.partOf in self.groups:
                 group = self.groups[pkg.partOf]
             else:
                 group = GROUP_UNKNOWN
-            homepage = pkg.source.homepage if pkg.source.homepage is not None else ''
+            homepage = pkg.source.homepage if pkg.source.homepage is not None else ""
 
-            description = str(pkg.description).replace('\n', " ")
+            description = str(pkg.description).replace("\n", " ")
 
-            self.details(pkg_id, pkg.summary, ",".join(pkg.license), group, description,
-                            homepage, size, dl_size)
+            self.details(
+                pkg_id,
+                pkg.summary,
+                ",".join(pkg.license),
+                group,
+                description,
+                homepage,
+                size,
+                dl_size,
+            )
 
     def get_details_local(self, files):
 
@@ -474,7 +525,7 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
                 metadata, files = pisi.api.info_file(f)
             except PkError as e:
                 if e.code == ERROR_PACKAGE_NOT_FOUND:
-                    self.message('COULD_NOT_FIND_PACKAGE', e.details)
+                    self.message("COULD_NOT_FIND_PACKAGE", e.details)
                     continue
                 self.error(e.code, e.details, exit=True)
                 return
@@ -483,24 +534,32 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
 
             data = "local"
 
-            pkg_id = self.get_package_id(pkg.name, self.__get_package_version(pkg),
-                                         pkg.architecture, data)
+            pkg_id = self.get_package_id(
+                pkg.name, self.__get_package_version(pkg), pkg.architecture, data
+            )
 
             if pkg.partOf in self.groups:
                 group = self.groups[pkg.partOf]
             else:
                 group = GROUP_UNKNOWN
-            homepage = pkg.source.homepage if pkg.source.homepage is not None\
-                else ''
+            homepage = pkg.source.homepage if pkg.source.homepage is not None else ""
 
             size = pkg.installedSize
             dl_size = os.path.getsize(f)
 
-            self.details(pkg_id, pkg.summary, ",".join(pkg.license), group,
-                         pkg.description, homepage, size, dl_size)
+            self.details(
+                pkg_id,
+                pkg.summary,
+                ",".join(pkg.license),
+                group,
+                pkg.description,
+                homepage,
+                size,
+                dl_size,
+            )
 
     def get_files(self, package_ids):
-        """ Prints a file list for a given packages """
+        """Prints a file list for a given packages"""
         self.allow_cancel(True)
         self.percentage(None)
 
@@ -510,9 +569,9 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
             if self.installdb.has_package(package):
                 pkg = self.packagedb.get_package(package)
                 repo = self.packagedb.get_package_repo(pkg.name, None)
-                pkg_id = self.get_package_id(pkg.name,
-                                             self.__get_package_version(pkg),
-                                             pkg.architecture, repo[1])
+                pkg_id = self.get_package_id(
+                    pkg.name, self.__get_package_version(pkg), pkg.architecture, repo[1]
+                )
 
                 pkg = self.installdb.get_files(package)
 
@@ -521,8 +580,11 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
                 file_list = ";".join(files)
                 self.files(pkg_id, file_list)
             else:
-                self.error(ERROR_PACKAGE_NOT_FOUND,
-                           "Package %s must be installed to get file list" % package_id.split(";"))
+                self.error(
+                    ERROR_PACKAGE_NOT_FOUND,
+                    "Package %s must be installed to get file list"
+                    % package_id.split(";"),
+                )
 
     def get_packages(self, filters):
         self.status(STATUS_QUERY)
@@ -549,7 +611,7 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
             self.__get_package(package)
 
     def get_repo_list(self, filters):
-        """ Prints available repositories """
+        """Prints available repositories"""
         self.allow_cancel(True)
         self.percentage(None)
         self.status(STATUS_INFO)
@@ -562,7 +624,7 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
             self.repo_detail(repo, uri, enabled)
 
     def required_by(self, filters, package_ids, recursive):
-        """ Prints a list of requires for a given package """
+        """Prints a list of requires for a given package"""
         self.status(STATUS_QUERY)
         self.allow_cancel(True)
         self.percentage(None)
@@ -577,10 +639,12 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
                 for pkg in self.installdb.get_rev_deps(package):
                     self.__get_package(pkg[0])
             else:
-                self.error(ERROR_PACKAGE_NOT_FOUND, "Package %s was not found" % package.name)
+                self.error(
+                    ERROR_PACKAGE_NOT_FOUND, "Package %s was not found" % package.name
+                )
 
     def get_updates(self, filters):
-        """ Prints available updates and types """
+        """Prints available updates and types"""
         self.allow_cancel(True)
         self.percentage(None)
 
@@ -604,14 +668,14 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
                 self.package(id, INFO_NORMAL, pkg.summary)
 
     def _get_history_between(self, old_release, new):
-        """ Get the history items between the old release and new pkg """
+        """Get the history items between the old release and new pkg"""
         ret = list()
 
         for i in new.history:
             if int(i.release) <= int(old_release):
                 continue
             ret.append(i)
-        return sorted(ret, key=attrgetter('release'), reverse=True)
+        return sorted(ret, key=attrgetter("release"), reverse=True)
 
     def get_update_detail(self, package_ids):
         self.status(STATUS_INFO)
@@ -639,7 +703,7 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
 
             changelog = ""
             # FIXME: Works but output is fugly
-            #for i in pkg.history:
+            # for i in pkg.history:
             #    comment = i.comment
             #    comment = comment.replace("\n", ";")
             #    changelog.append(comment)
@@ -647,7 +711,7 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
             cves = re.findall(r" (CVE\-[0-9]+\-[0-9]+)", str(update_message))
             cve_url = ""
             if cves is not None:
-                #cve_url = "https://cve.mitre.org/cgi-bin/cvename.cgi?name={}".format(cves[0])
+                # cve_url = "https://cve.mitre.org/cgi-bin/cvename.cgi?name={}".format(cves[0])
                 cve_url = cves
 
             # TODO: If repo is unstable and package.release not in shannon then UNSTABLE
@@ -656,18 +720,31 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
 
             # TODO: Eopkg doesn't provide any time
             split_date = updated_date.split("-")
-            updated = "{}-{}-{}T00:00:00".format(split_date[0], split_date[1], split_date[2])
+            updated = "{}-{}-{}T00:00:00".format(
+                split_date[0], split_date[1], split_date[2]
+            )
             # TODO: The index only stores the last 10 history entries.
             #       What is the difference between issued and updated?
             issued = ""
 
-            self.update_detail(package_id, updates, obsoletes, vendor_url,
-                               bugURI, cve_url, reboot, update_message,
-                               changelog, state, issued, updated)
+            self.update_detail(
+                package_id,
+                updates,
+                obsoletes,
+                vendor_url,
+                bugURI,
+                cve_url,
+                reboot,
+                update_message,
+                changelog,
+                state,
+                issued,
+                updated,
+            )
 
     @privileged
     def download_packages(self, directory, package_ids):
-        """ Download the given packages to a directory """
+        """Download the given packages to a directory"""
         self.allow_cancel(True)
         self.percentage(0)
         self.status(STATUS_DOWNLOAD)
@@ -692,32 +769,51 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
                 location = os.path.join(directory, uri)
                 self.files(package_id, location)
         except pisi.fetcher.FetchError as e:
-            self.error(ERROR_PACKAGE_DOWNLOAD_FAILED, "Could not download package: %s" % e, exit=False)
+            self.error(
+                ERROR_PACKAGE_DOWNLOAD_FAILED,
+                "Could not download package: %s" % e,
+                exit=False,
+            )
         except IOError as e:
             self.error(ERROR_NO_SPACE_ON_DEVICE, "Disk error: %s" % e)
         except pisi.Error as e:
-            self.error(ERROR_PACKAGE_DOWNLOAD_FAILED, "Could not download package: %s" % e, exit=False)
+            self.error(
+                ERROR_PACKAGE_DOWNLOAD_FAILED,
+                "Could not download package: %s" % e,
+                exit=False,
+            )
         except Exception as e:
             self.error(ERROR_INTERNAL_ERROR, _format_str(traceback.format_exc()))
 
     @privileged
     def install_files(self, transaction_flags, inst_files):
-        """ Installs given package into system"""
+        """Installs given package into system"""
 
         # FIXME: use only_trusted
 
         if TRANSACTION_FLAG_SIMULATE in transaction_flags:
             for f in inst_files:
                 metadata, _ = pisi.api.info_file(f)
-                pkg_id = self.get_package_id(metadata.package.name, metadata.package.version, metadata.package.architecture, "local")
+                pkg_id = self.get_package_id(
+                    metadata.package.name,
+                    metadata.package.version,
+                    metadata.package.architecture,
+                    "local",
+                )
                 self.package(pkg_id, INFO_INSTALL, metadata.package.summary)
                 for dep in metadata.package.runtimeDependencies():
                     if not dep.satisfied_by_installed():
                         if not self.packagedb.has_package(dep.package):
-                            self.error(ERROR_DEP_RESOLUTION_FAILED, "Cannot install: %s. Can't resolve dependency %s" % (f, dep.package))
+                            self.error(
+                                ERROR_DEP_RESOLUTION_FAILED,
+                                "Cannot install: %s. Can't resolve dependency %s"
+                                % (f, dep.package),
+                            )
                         dep_pkg = self.packagedb.get_package(dep.package)
                         repo = self.packagedb.get_package_repo(dep_pkg.name, None)
-                        dep_id = self.get_package_id(dep_pkg.name, dep_pkg.version, dep_pkg.architecture, repo)
+                        dep_id = self.get_package_id(
+                            dep_pkg.name, dep_pkg.version, dep_pkg.architecture, repo
+                        )
                         self.package(dep_id, INFO_INSTALL, dep_pkg.summary)
             return
 
@@ -726,17 +822,23 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
             # Actually install
             pisi.api.install(inst_files)
         except pisi.fetcher.FetchError as e:
-            self.error(ERROR_PACKAGE_DOWNLOAD_FAILED, "Could not download package: %s" % e, exit=False)
+            self.error(
+                ERROR_PACKAGE_DOWNLOAD_FAILED,
+                "Could not download package: %s" % e,
+                exit=False,
+            )
         except IOError as e:
             self.error(ERROR_NO_SPACE_ON_DEVICE, "Disk error: %s" % e)
         except pisi.Error as e:
-            self.error(ERROR_LOCAL_INSTALL_FAILED, "Could not install: %s" % e, exit=False)
+            self.error(
+                ERROR_LOCAL_INSTALL_FAILED, "Could not install: %s" % e, exit=False
+            )
         except Exception as e:
             self.error(ERROR_INTERNAL_ERROR, _format_str(traceback.format_exc()))
 
     @privileged
     def install_packages(self, transaction_flags, package_ids):
-        """ Installs given package into system"""
+        """Installs given package into system"""
         self.allow_cancel(False)
         self.percentage(0)
         packages = list()
@@ -745,8 +847,7 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
         for package_id in package_ids:
             package = self.get_package_from_id(package_id)[0]
             if self.installdb.has_package(package):
-                self.error(ERROR_PACKAGE_NOT_INSTALLED,
-                           "Package is already installed")
+                self.error(ERROR_PACKAGE_NOT_INSTALLED, "Package is already installed")
             packages.append(package)
 
         if TRANSACTION_FLAG_SIMULATE in transaction_flags:
@@ -759,8 +860,9 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
                 dep_pkg = self.packagedb.get_package(dep)
                 repo = self.packagedb.get_package_repo(dep_pkg.name, None)
                 version = self.__get_package_version(dep_pkg)
-                pkg_id = self.get_package_id(dep_pkg.name, version,
-                                                dep_pkg.architecture, repo[1])
+                pkg_id = self.get_package_id(
+                    dep_pkg.name, version, dep_pkg.architecture, repo[1]
+                )
                 self.package(pkg_id, INFO_INSTALL, dep_pkg.summary)
             return
 
@@ -770,17 +872,23 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
         try:
             pisi.api.install(packages)
         except pisi.fetcher.FetchError as e:
-            self.error(ERROR_PACKAGE_DOWNLOAD_FAILED, "Could not download package: %s" % e, exit=False)
+            self.error(
+                ERROR_PACKAGE_DOWNLOAD_FAILED,
+                "Could not download package: %s" % e,
+                exit=False,
+            )
         except IOError as e:
             self.error(ERROR_NO_SPACE_ON_DEVICE, "Disk error: %s" % e)
         except pisi.Error as e:
-            self.error(ERROR_PACKAGE_FAILED_TO_INSTALL, "Could not install: %s" % e, exit=False)
+            self.error(
+                ERROR_PACKAGE_FAILED_TO_INSTALL, "Could not install: %s" % e, exit=False
+            )
         except Exception as e:
             self.error(ERROR_INTERNAL_ERROR, _format_str(traceback.format_exc()))
 
     @privileged
     def refresh_cache(self, force):
-        """ Updates repository indexes """
+        """Updates repository indexes"""
         # TODO: use force ?
         self.allow_cancel(False)
         self.percentage(0)
@@ -795,9 +903,8 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
             self.percentage(percentage)
 
     @privileged
-    def remove_packages(self, transaction_flags, package_ids,
-                        allowdep, autoremove):
-        """ Removes given package from system"""
+    def remove_packages(self, transaction_flags, package_ids, allowdep, autoremove):
+        """Removes given package from system"""
         self.allow_cancel(False)
         self.percentage(0)
         packages = list()
@@ -805,8 +912,7 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
         for package_id in package_ids:
             package = self.get_package_from_id(package_id)[0]
             if not self.installdb.has_package(package):
-                self.error(ERROR_PACKAGE_NOT_INSTALLED,
-                           "Package is not installed")
+                self.error(ERROR_PACKAGE_NOT_INSTALLED, "Package is not installed")
             packages.append(package)
 
         if TRANSACTION_FLAG_SIMULATE in transaction_flags:
@@ -815,11 +921,15 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
             for dep in order:
                 dep_pkg = self.packagedb.get_package(dep)
                 if dep_pkg.partOf == "system.base":
-                    self.error(ERROR_CANNOT_REMOVE_SYSTEM_PACKAGE, "Cannot remove system.base package: %s" % dep_pkg.name)
+                    self.error(
+                        ERROR_CANNOT_REMOVE_SYSTEM_PACKAGE,
+                        "Cannot remove system.base package: %s" % dep_pkg.name,
+                    )
                 repo = self.packagedb.get_package_repo(dep_pkg.name, None)
                 version = self.__get_package_version(dep_pkg)
-                pkg_id = self.get_package_id(dep_pkg.name, version,
-                                             dep_pkg.architecture, repo[1])
+                pkg_id = self.get_package_id(
+                    dep_pkg.name, version, dep_pkg.architecture, repo[1]
+                )
                 self.package(pkg_id, INFO_REMOVE, dep_pkg.summary)
             return
 
@@ -829,11 +939,17 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
             else:
                 pisi.api.remove(packages)
         except pisi.fetcher.FetchError as e:
-            self.error(ERROR_PACKAGE_DOWNLOAD_FAILED, "Could not download package: %s" % e, exit=False)
+            self.error(
+                ERROR_PACKAGE_DOWNLOAD_FAILED,
+                "Could not download package: %s" % e,
+                exit=False,
+            )
         except IOError as e:
             self.error(ERROR_NO_SPACE_ON_DEVICE, "Disk error: %s" % e)
         except pisi.Error as e:
-            self.error(ERROR_PACKAGE_FAILED_TO_REMOVE, "Could not remove: %s" % e, exit=False)
+            self.error(
+                ERROR_PACKAGE_FAILED_TO_REMOVE, "Could not remove: %s" % e, exit=False
+            )
         except Exception as e:
             self.error(ERROR_INTERNAL_ERROR, _format_str(traceback.format_exc()))
 
@@ -850,7 +966,7 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
 
     @privileged
     def repo_set_data(self, repoid, parameter, value):
-        """ Sets a parameter for the repository specified """
+        """Sets a parameter for the repository specified"""
         self.allow_cancel(False)
         self.percentage(None)
 
@@ -872,11 +988,13 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
             except pisi.Error:
                 self.error(ERROR_REPO_NOT_FOUND, "Repository does not exist")
         else:
-            self.error(ERROR_NOT_SUPPORTED, "Valid parameters are add-repo and remove-repo")
+            self.error(
+                ERROR_NOT_SUPPORTED, "Valid parameters are add-repo and remove-repo"
+            )
 
     def resolve(self, filters, values):
-        """ Turns a single package name into a package_id
-        suitable for the other methods """
+        """Turns a single package name into a package_id
+        suitable for the other methods"""
         self.allow_cancel(True)
         self.percentage(None)
         self.status(STATUS_QUERY)
@@ -895,7 +1013,7 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
                 return
 
     def search_details(self, filters, values):
-        """ Prints a detailed list of packages contains search term """
+        """Prints a detailed list of packages contains search term"""
         self.allow_cancel(True)
         self.percentage(None)
         self.status(STATUS_INFO)
@@ -906,7 +1024,7 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
             self.__get_package(pkg, filters)
 
     def search_file(self, filters, values):
-        """ Prints the installed package which contains the specified file """
+        """Prints the installed package which contains the specified file"""
         self.allow_cancel(True)
         self.percentage(None)
         self.status(STATUS_INFO)
@@ -919,7 +1037,7 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
                 self.__get_package(pkg)
 
     def search_group(self, filters, values):
-        """ Prints a list of packages belongs to searched group """
+        """Prints a list of packages belongs to searched group"""
         self.allow_cancel(True)
         self.percentage(None)
         self.status(STATUS_INFO)
@@ -932,13 +1050,14 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
                         pkgs = self.componentdb.get_packages(item, walk=False)
                         packages.extend(pkgs)
                     except:
-                        self.error(ERROR_GROUP_NOT_FOUND,
-                                   "Component %s was not found" % value)
+                        self.error(
+                            ERROR_GROUP_NOT_FOUND, "Component %s was not found" % value
+                        )
             for pkg in packages:
                 self.__get_package(pkg, filters)
 
     def search_name(self, filters, values):
-        """ Prints a list of packages contains search term in its name """
+        """Prints a list of packages contains search term in its name"""
         self.allow_cancel(True)
         self.percentage(None)
         self.status(STATUS_INFO)
@@ -949,7 +1068,7 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
 
     @privileged
     def update_packages(self, transaction_flags, package_ids):
-        """ Updates given package to its latest version """
+        """Updates given package to its latest version"""
 
         # FIXME: use only_trusted
         # FIXME: install progress
@@ -961,8 +1080,10 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
         for package_id in package_ids:
             package = self.get_package_from_id(package_id)[0]
             if not self.installdb.has_package(package):
-                self.error(ERROR_PACKAGE_NOT_INSTALLED,
-                           "Cannot update a package that is not installed")
+                self.error(
+                    ERROR_PACKAGE_NOT_INSTALLED,
+                    "Cannot update a package that is not installed",
+                )
             packages.append(package)
 
         if TRANSACTION_FLAG_SIMULATE in transaction_flags:
@@ -975,8 +1096,9 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
                 dep_pkg = self.packagedb.get_package(dep)
                 repo = self.packagedb.get_package_repo(dep_pkg.name, None)
                 version = self.__get_package_version(dep_pkg)
-                pkg_id = self.get_package_id(dep_pkg.name, version,
-                                                dep_pkg.architecture, repo[1])
+                pkg_id = self.get_package_id(
+                    dep_pkg.name, version, dep_pkg.architecture, repo[1]
+                )
                 self.package(pkg_id, INFO_INSTALL, dep_pkg.summary)
             return
 
@@ -987,18 +1109,25 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
             # Actually upgrade
             pisi.api.upgrade(packages)
         except pisi.fetcher.FetchError as e:
-            self.error(ERROR_PACKAGE_DOWNLOAD_FAILED, "Could not download package: %s" % e, exit=False)
+            self.error(
+                ERROR_PACKAGE_DOWNLOAD_FAILED,
+                "Could not download package: %s" % e,
+                exit=False,
+            )
         except IOError as e:
             self.error(ERROR_NO_SPACE_ON_DEVICE, "Disk error: %s" % e)
         except pisi.Error as e:
-            self.error(ERROR_PACKAGE_FAILED_TO_INSTALL, "Could not update: %s" % e, exit=False)
+            self.error(
+                ERROR_PACKAGE_FAILED_TO_INSTALL, "Could not update: %s" % e, exit=False
+            )
         except Exception as e:
             self.error(ERROR_INTERNAL_ERROR, _format_str(traceback.format_exc()))
 
 
 def main():
-    backend = PackageKitEopkgBackend('')
+    backend = PackageKitEopkgBackend("")
     backend.dispatcher(sys.argv[1:])
+
 
 if __name__ == "__main__":
     main()

--- a/backends/eopkg/eopkgBackend.py
+++ b/backends/eopkg/eopkgBackend.py
@@ -484,32 +484,15 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
         self.allow_cancel(True)
         self.percentage(None)
 
-        for package in package_ids:
-            package = self.get_package_from_id(package)[0]
+        for package_id in package_ids:
+            try:
+                pkg, data = self._get_package_obj_from_id(package_id)
+            except PkError as e:
+                self.error(e.code, e.details)
+                continue
 
-            pkg = ""
-            size = 0
-            dl_size = 0
-            data = "installed"
-
-            # FIXME: There is duplication here from __get_package
-            if self.packagedb.has_package(package):
-                pkg, repo = self.packagedb.get_package_repo(package, None)
-                size = int(pkg.installedSize)
-                dl_size = int(pkg.packageSize)
-                if self.installdb.has_package(package):
-                    data = "installed:{}".format(repo)
-                else:
-                    data = repo
-            elif self.installdb.has_package(package):
-                pkg = self.installdb.get_package(package)
-                data = "local"
-                size = int(pkg.installedSize)
-                dl_size = int(pkg.packageSize)
-            else:
-                self.error(
-                    ERROR_PACKAGE_NOT_FOUND, "Package %s was not found" % package
-                )
+            size = pkg.installedSize
+            dl_size = pkg.packageSize
 
             pkg_id = self.get_package_id(
                 pkg.name, self.__get_package_version(pkg), pkg.architecture, data

--- a/backends/eopkg/eopkgBackend.py
+++ b/backends/eopkg/eopkgBackend.py
@@ -811,7 +811,7 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
                                 % (f, dep.package),
                             )
                         dep_pkg = self.packagedb.get_package(dep.package)
-                        repo = self.packagedb.get_package_repo(dep_pkg.name, None)
+                        pkg, repo = self.packagedb.get_package_repo(dep_pkg.name, None)
                         dep_id = self.get_package_id(
                             dep_pkg.name, dep_pkg.version, dep_pkg.architecture, repo
                         )

--- a/backends/eopkg/eopkgBackend.py
+++ b/backends/eopkg/eopkgBackend.py
@@ -428,19 +428,15 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
         self.percentage(None)
 
         for package_id in package_ids:
-            package = self.get_package_from_id(package_id)[0]
+            try:
+                pkg, data = self._get_package_obj_from_id(package_id)
+            except PkError as e:
+                self.error(e.code, e.details)
+                continue
 
             # FIXME: PiSi API has really inconsistent for return types and arguments!
-            if self.packagedb.has_package(package):
-                for pkg in self.packagedb.get_package(package).runtimeDependencies():
-                    self.__get_package(pkg.package)
-            elif self.installdb.has_package(package):
-                for pkg in self.installdb.get_package(package).runtimeDependencies():
-                    self.__get_package(pkg.package)
-            else:
-                self.error(
-                    ERROR_PACKAGE_NOT_FOUND, "Package %s was not found" % package
-                )
+            for dep in pkg.runtimeDependencies():
+                self.__get_package(dep.package)
 
     def get_categories(self):
         self.status(STATUS_QUERY)
@@ -629,18 +625,15 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
         self.percentage(None)
 
         for package_id in package_ids:
-            package = self.get_package_from_id(package_id)[0]
+            try:
+                pkg, data = self._get_package_obj_from_id(package_id)
+            except PkError as e:
+                self.error(e.code, e.details)
+                continue
 
-            if self.packagedb.has_package(package):
-                for pkg in self.packagedb.get_rev_deps(package):
-                    self.__get_package(pkg[0])
-            elif self.installdb.has_package(package):
-                for pkg in self.installdb.get_rev_deps(package):
-                    self.__get_package(pkg[0])
-            else:
-                self.error(
-                    ERROR_PACKAGE_NOT_FOUND, "Package %s was not found" % package.name
-                )
+            # FIXME: PiSi API has really inconsistent for return types and arguments!
+            for dep in self.packagedb.get_rev_deps(pkg.name):
+                self.__get_package(dep[0])
 
     def get_updates(self, filters):
         """Prints available updates and types"""

--- a/backends/eopkg/eopkgBackend.py
+++ b/backends/eopkg/eopkgBackend.py
@@ -434,7 +434,6 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
                 self.error(e.code, e.details)
                 continue
 
-            # FIXME: PiSi API has really inconsistent for return types and arguments!
             for dep in pkg.runtimeDependencies():
                 self.__get_package(dep.package)
 
@@ -631,7 +630,6 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
                 self.error(e.code, e.details)
                 continue
 
-            # FIXME: PiSi API has really inconsistent for return types and arguments!
             for dep in self.packagedb.get_rev_deps(pkg.name):
                 self.__get_package(dep[0])
 

--- a/backends/eopkg/eopkgBackend.py
+++ b/backends/eopkg/eopkgBackend.py
@@ -1007,12 +1007,15 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
         self.status(STATUS_QUERY)
 
         for package in values:
-            pkg = self.get_package_from_id(package)[0]
+            name = self.get_package_from_id(package)[0]
             try:
-                # FIXME: Hack for newest filter to work correctly (i think)
-                if filters is not None and FILTER_NEWEST in filters:
-                    self.__get_package(pkg, FILTER_NOT_INSTALLED)
-                self.__get_package(pkg, filters)
+                if filters is not None:
+                    self.__get_package(name, filters)
+                else:
+                    # If no filters, show both installed and available if they exist
+                    # we should really fix __get_package to allow emitting multiple results
+                    self.__get_package(name, [FILTER_INSTALLED])
+                    self.__get_package(name, [FILTER_NOT_INSTALLED])
             except PkError as e:
                 if e.code == ERROR_PACKAGE_NOT_FOUND:
                     continue

--- a/backends/eopkg/eopkgBackend.py
+++ b/backends/eopkg/eopkgBackend.py
@@ -717,7 +717,7 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
 
             # TODO: Eopkg doesn't provide any time
             split_date = updated_date.split("-")
-            updated = "{}-{}-{}T00:00:00".format(
+            updated = "{}-{}-{}T00:00:00Z".format(
                 split_date[0], split_date[1], split_date[2]
             )
             # TODO: The index only stores the last 10 history entries.

--- a/backends/eopkg/eopkgBackend.py
+++ b/backends/eopkg/eopkgBackend.py
@@ -569,26 +569,27 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
         self.percentage(None)
 
         for package_id in package_ids:
-            package = self.get_package_from_id(package_id)[0]
+            try:
+                pkg, data = self._get_package_obj_from_id(package_id)
+            except PkError as e:
+                self.error(e.code, e.details)
+                continue
 
-            if self.installdb.has_package(package):
-                pkg = self.packagedb.get_package(package)
-                repo = self.packagedb.get_package_repo(pkg.name, None)
+            if self.installdb.has_package(pkg.name):
                 pkg_id = self.get_package_id(
-                    pkg.name, self.__get_package_version(pkg), pkg.architecture, repo[1]
+                    pkg.name, self.__get_package_version(pkg), pkg.architecture, data
                 )
 
-                pkg = self.installdb.get_files(package)
+                pkg_files = self.installdb.get_files(pkg.name)
 
-                files = ["/%s" % y.path for y in pkg.list]
+                files = ["/%s" % y.path for y in pkg_files.list]
 
                 file_list = ";".join(files)
                 self.files(pkg_id, file_list)
             else:
                 self.error(
                     ERROR_PACKAGE_NOT_FOUND,
-                    "Package %s must be installed to get file list"
-                    % package_id.split(";"),
+                    "Package %s must be installed to get file list" % pkg.name,
                 )
 
     def get_packages(self, filters):

--- a/backends/eopkg/eopkgBackend.py
+++ b/backends/eopkg/eopkgBackend.py
@@ -688,11 +688,19 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
         self.allow_cancel(True)
         self.percentage(None)
 
+        upgradables = pisi.api.list_upgradable()
+
         for package_id in package_ids:
-            package = self.get_package_from_id(package_id)[0]
-            pkg, repo = self.packagedb.get_package_repo(package, None)
+            try:
+                pkg, data = self._get_package_obj_from_id(package_id)
+            except PkError:
+                continue
+
+            if pkg.name not in upgradables:
+                continue
+
             version = self.__get_package_version(pkg)
-            id = self.get_package_id(pkg.name, version, pkg.architecture, repo)
+            id = self.get_package_id(pkg.name, version, pkg.architecture, data)
 
             updates = [package_id]
             obsoletes = ""

--- a/backends/eopkg/eopkgBackend.py
+++ b/backends/eopkg/eopkgBackend.py
@@ -93,116 +93,118 @@ class SimplePisiHandler(pisi.ui.UI):
         # Progress bar helpers
         self.packagestogo = 0
         self.currentpackage = 0
+        self.cur_pkg = None
+        self.cur_status = None
+        self.is_downloading = False
 
-    @staticmethod
-    def get_percentage(count, max_count):
-        """
-        Prepare percentage value used to feed self.percentage()
-        """
-        if count == 0 or max_count == 0:
-            return 0
-        percent = int((float(count) / max_count) * 100)
-        if percent > 100:
-            return 100
-        return percent
+    def _update_global_progress(self, item_percent):
+        if self.packagestogo <= 0:
+            self.base._set_percent(item_percent)
+            return
 
-    def update_percentage(self, downloading=False):
-        # Reset counter when switching state i.e. from downloading to installing
-        # FIXME: If we get forced upgrades i.e. partial upgrades as part of a pkg
-        #        installation, it breaks the progress bar as we switch from INFO_INSTALLING
-        #        to INFO_UPDATING and doesn't match up with packagestogo.
-        if self.currentpackage == self.packagestogo:
-            self.currentpackage = 0
-        self.currentpackage += 1
-        percent = self.get_percentage(self.currentpackage, self.packagestogo)
-        if downloading is False:
-            # Reserve 10% of progress to account for usysconf to run triggers
-            usysconf_offset = 0.1 * self.packagestogo
-            total_percent = percent + usysconf_offset
-            self.base._set_percent(total_percent)
-        else:
-            self.base._set_percent(percent)
+        # Weight global progress: 90% for packages (allowing for usysconf), 100% if just downloading
+        weight = 100.0 if self.is_downloading else 90.0
+        slice_size = weight / self.packagestogo
+
+        # currentpackage is 1-indexed (1..N)
+        base_percent = (self.currentpackage - 1) * slice_size
+        progress = base_percent + (item_percent / 100.0) * slice_size
+        self.base._set_percent(progress)
 
     def display_progress(self, **kw):
-        percent = self.get_percentage(self.currentpackage, self.packagestogo)
-        file_name = kw["filename"]
-        if not file_name.startswith("eopkg-index.xml"):
-            pkg_name = pisi.util.parse_package_name(file_name)[0]
-            self.notify("progress", pkg_name=pkg_name, percent=int(kw["percent"]))
-        if self.packagestogo > 0:
-            # Increase the step offset by 50%
-            # e.g. 5 pkgs to install, currentpackage == 3 so update percentage range within 60% to 80%.
-            sliced = 100 / self.packagestogo
-            slicedpercent = sliced / 100 * int(kw["percent"]) + percent - sliced
-            self.base._set_percent(slicedpercent)
+        operation = kw.get("operation")
+        percent = int(kw.get("percent", 0))
+
+        if operation == "fetching":
+            filename = kw.get("filename")
+            if filename and not filename.startswith("eopkg-index.xml"):
+                pkg_name = pisi.util.parse_package_name(filename)[0]
+                if pisi.db.packagedb.PackageDB().has_package(pkg_name):
+                    pkg = pisi.db.packagedb.PackageDB().get_package(pkg_name)
+                    self.base.item_progress(
+                        self.base._pkg_to_id(pkg), STATUS_DOWNLOAD, percent
+                    )
+            self._update_global_progress(percent)
+
+        elif operation == "extracting":
+            if self.cur_pkg and self.cur_status:
+                self.base.item_progress(
+                    self.base._pkg_to_id(self.cur_pkg), self.cur_status, percent
+                )
+            self._update_global_progress(percent)
+
+        elif operation == "indexing":
+            self.base._set_percent(percent)
+
         else:
-            self.base._set_percent(int(kw["percent"]))
+            # Fallback for other operations
+            if self.packagestogo > 0:
+                self._update_global_progress(percent)
+            else:
+                self.base._set_percent(percent)
 
     def notify(self, event, **keywords):
-
         if event == pisi.ui.packagestogo:
             self.packagestogo = len(keywords["order"])
-        if event == pisi.ui.downloading:
-            self.base._set_status(keywords["package"], INFO_DOWNLOADING)
-            self.update_percentage(downloading=True)
-        if event == "progress":
-            if pisi.db.packagedb.PackageDB().has_package(keywords["pkg_name"]):
-                pkg = pisi.db.packagedb.PackageDB().get_package(keywords["pkg_name"])
-                self.base.item_progress(
-                    self.base._pkg_to_id(pkg), STATUS_DOWNLOAD, keywords["percent"]
-                )
-        # if event == pisi.ui.cached:
-        #   self.base._set_status(keywords["package"], INFO_FINISHED)
-        if event == pisi.ui.installing:
-            # Pisi doesn't tell us whether it's installing or upgrading in the callback until after it's done it, thanks!
-            # This is bad for progress bars, obviously. Set the status based on the called operation.
-            self.base.status(TransactionsStateMap[self.base.operation])
+            self.currentpackage = 0
 
-            self.base._set_status(
-                keywords["package"], TransactionsInfoMap[self.base.operation]
-            )
+        elif event == pisi.ui.downloading:
+            if not self.is_downloading:
+                self.is_downloading = True
+                self.currentpackage = 0
+            self.currentpackage += 1
+            self.cur_pkg = keywords["package"]
             self.base.item_progress(
-                self.base._pkg_to_id(keywords["package"]),
-                TransactionsStateMap[self.base.operation],
-                0,
+                self.base._pkg_to_id(self.cur_pkg), STATUS_DOWNLOAD, 0
             )
-        if event == pisi.ui.removing:
-            self.base._set_status(
-                keywords["package"], TransactionsInfoMap[self.base.operation]
+
+        elif event in (pisi.ui.installing, pisi.ui.upgrading):
+            if self.is_downloading:
+                self.is_downloading = False
+                self.currentpackage = 0
+
+            self.currentpackage += 1
+            self.cur_pkg = keywords["package"]
+            self.cur_status = (
+                STATUS_INSTALL if event == pisi.ui.installing else STATUS_UPDATE
             )
+            info = INFO_INSTALLING if event == pisi.ui.installing else INFO_UPDATING
+
+            self.base.status(self.cur_status)
+            self.base._set_status(self.cur_pkg, info)
             self.base.item_progress(
-                self.base._pkg_to_id(keywords["package"]),
-                TransactionsStateMap[self.base.operation],
-                0,
+                self.base._pkg_to_id(self.cur_pkg), self.cur_status, 0
             )
-        if event == pisi.ui.extracting:
-            # Increase the step offset by 50% and account for usysconf offset
-            # e.g. 5 pkgs to install, currentpackage == 3 so update percentage 50% within 60% to 80%.
-            subpercentage = (
-                100 / (self.packagestogo + (0.1 * self.packagestogo))
-            ) / 100 * 50 + self.get_percentage(self.currentpackage, self.packagestogo)
-            self.base._set_percent(subpercentage)
+
+        elif event == pisi.ui.removing:
+            self.is_downloading = False
+            if self.currentpackage >= self.packagestogo:
+                self.currentpackage = 0
+            self.currentpackage += 1
+            self.cur_pkg = keywords["package"]
+            self.cur_status = STATUS_REMOVE
+            self.base.status(self.cur_status)
+            self.base._set_status(self.cur_pkg, INFO_REMOVING)
             self.base.item_progress(
-                self.base._pkg_to_id(keywords["package"]),
-                TransactionsStateMap[self.base.operation],
-                50,
+                self.base._pkg_to_id(self.cur_pkg), self.cur_status, 0
             )
-        if event == pisi.ui.installed:
-            self.base.item_progress(
-                self.base._pkg_to_id(keywords["package"]), STATUS_INSTALL, 100
-            )
-            self.update_percentage()
-        if event == pisi.ui.removed:
-            self.base.item_progress(
-                self.base._pkg_to_id(keywords["package"]), STATUS_REMOVE, 100
-            )
-            self.update_percentage()
-        if event == pisi.ui.upgraded:
-            self.base.item_progress(
-                self.base._pkg_to_id(keywords["package"]), STATUS_UPDATE, 100
-            )
-            self.update_percentage()
-        if event == pisi.ui.systemconf:
+
+        elif event == pisi.ui.extracting:
+            self.cur_pkg = keywords.get("package", self.cur_pkg)
+            # Item progress and global percentage are now handled live in display_progress
+
+        elif event in (pisi.ui.installed, pisi.ui.upgraded, pisi.ui.removed):
+            status = STATUS_INSTALL
+            if event == pisi.ui.upgraded:
+                status = STATUS_UPDATE
+            if event == pisi.ui.removed:
+                status = STATUS_REMOVE
+
+            if self.cur_pkg:
+                self.base.item_progress(self.base._pkg_to_id(self.cur_pkg), status, 100)
+            self._update_global_progress(100)
+
+        elif event == pisi.ui.systemconf:
             self.base._set_percent(90)
 
 
@@ -213,7 +215,6 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
         self.bug_regex = None
         self.bug_uri = None
         self._load_settings()
-        self.operation = None
         PackageKitBaseBackend.__init__(self, args)
 
         self.get_db()
@@ -268,7 +269,6 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
 
         def wrapper(self, *__args, **__kw):
             ui = SimplePisiHandler(self)
-            self.operation = func.__name__
             pisi.api.set_userinterface(ui)
             try:
                 func(self, *__args, **__kw)

--- a/backends/eopkg/eopkgBackend.py
+++ b/backends/eopkg/eopkgBackend.py
@@ -334,76 +334,96 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
         if installed is None and available is None:
             raise PkError(ERROR_PACKAGE_NOT_FOUND, "Package %s not found" % package)
 
-        pkg = None
-        status = None
-        data = None
+        # We will collect candidate packages here: (pkg, status, data)
+        candidates = []
 
-        if filters is not None:
+        # Check if we have any status filters
+        status_filters = [FILTER_INSTALLED, FILTER_NOT_INSTALLED, FILTER_NEWEST]
+        has_status_filter = filters and any(f in status_filters for f in filters)
+
+        if has_status_filter:
             if FILTER_INSTALLED in filters:
                 if installed:
-                    pkg = installed
-                    status = INFO_INSTALLED
                     data = "installed:{}".format(repo) if repo else "installed"
-                else:
-                    return
+                    candidates.append((installed, INFO_INSTALLED, data))
             elif FILTER_NOT_INSTALLED in filters:
                 if available:
-                    pkg = available
-                    status = INFO_AVAILABLE
-                    data = repo
-                else:
-                    return
+                    candidates.append((available, INFO_AVAILABLE, repo))
             elif FILTER_NEWEST in filters:
-                if available:
-                    pkg = available
-                    status = INFO_AVAILABLE
-                    data = repo
+                if installed and available:
+                    # Compare versions/releases
+                    v_inst = self.installdb.get_version_and_distro_release(package)
+                    v_avail = self.packagedb.get_version_and_distro_release(
+                        package, repo
+                    )
+
+                    # (version, release, build, distro, distro_release)
+                    # If version is different, we should probably compare versions.
+                    # But if they are the same, release comparison is sufficient.
+                    # In Solus/eopkg, release is the primary versioning for updates.
+                    if v_inst[0] == v_avail[0]:
+                        if int(v_avail[1]) > int(v_inst[1]):
+                            candidates.append((available, INFO_AVAILABLE, repo))
+                        elif int(v_avail[1]) == int(v_inst[1]):
+                            # Same version, show both
+                            data = "installed:{}".format(repo) if repo else "installed"
+                            candidates.append((installed, INFO_INSTALLED, data))
+                            candidates.append((available, INFO_AVAILABLE, repo))
+                        else:
+                            # Installed is newer
+                            data = "installed:{}".format(repo) if repo else "installed"
+                            candidates.append((installed, INFO_INSTALLED, data))
+                    else:
+                        # Versions differ, we'd need a version comparison tool here.
+                        # For now, if versions differ, we'll just show both or available
+                        # if it looks newer (e.g. higher release).
+                        # Most often, version is the same.
+                        if int(v_avail[1]) > int(v_inst[1]):
+                            candidates.append((available, INFO_AVAILABLE, repo))
+                        else:
+                            data = "installed:{}".format(repo) if repo else "installed"
+                            candidates.append((installed, INFO_INSTALLED, data))
+                elif available:
+                    candidates.append((available, INFO_AVAILABLE, repo))
                 elif installed:
-                    pkg = installed
-                    status = INFO_INSTALLED
-                    data = "installed"
-                else:
-                    return
-
-        # Fallback if no filter matched or no filters provided
-        if pkg is None:
+                    candidates.append((installed, INFO_INSTALLED, "installed"))
+        else:
+            # No status filters, show both if they exist
             if installed:
-                pkg = installed
-                status = INFO_INSTALLED
                 data = "installed:{}".format(repo) if repo else "installed"
-            else:
-                pkg = available
-                status = INFO_AVAILABLE
-                data = repo
+                candidates.append((installed, INFO_INSTALLED, data))
+            if available:
+                candidates.append((available, INFO_AVAILABLE, repo))
 
-        if filters is not None:
-            if FILTER_GUI in filters and "app:gui" not in pkg.isA:
-                return
-            if FILTER_NOT_GUI in filters and "app:gui" in pkg.isA:
-                return
-            # FIXME: To lower
-            nonfree = ["EULA", "Distributable"]
-            if FILTER_FREE in filters:
-                if any(l in pkg.license for l in nonfree):
-                    return
-            if FILTER_NOT_FREE in filters:
-                if not any(l in pkg.license for l in nonfree):
-                    return
-            if FILTER_DEVELOPMENT in filters and "-devel" not in pkg.name:
-                return
-            if FILTER_NOT_DEVELOPMENT in filters and "-devel" in pkg.name:
-                return
-            pkg_subtypes = ["-devel", "-dbginfo", "-32bit", "-docs"]
-            if FILTER_BASENAME in filters:
-                if any(suffix in pkg.name for suffix in pkg_subtypes):
-                    return
-            if FILTER_NOT_BASENAME in filters:
-                if not any(suffix in pkg.name for suffix in pkg_subtypes):
-                    return
+        for pkg, status, data in candidates:
+            if filters is not None:
+                if FILTER_GUI in filters and "app:gui" not in pkg.isA:
+                    continue
+                if FILTER_NOT_GUI in filters and "app:gui" in pkg.isA:
+                    continue
+                # FIXME: To lower
+                nonfree = ["EULA", "Distributable"]
+                if FILTER_FREE in filters:
+                    if any(l in pkg.license for l in nonfree):
+                        continue
+                if FILTER_NOT_FREE in filters:
+                    if not any(l in pkg.license for l in nonfree):
+                        continue
+                if FILTER_DEVELOPMENT in filters and "-devel" not in pkg.name:
+                    continue
+                if FILTER_NOT_DEVELOPMENT in filters and "-devel" in pkg.name:
+                    continue
+                pkg_subtypes = ["-devel", "-dbginfo", "-32bit", "-docs"]
+                if FILTER_BASENAME in filters:
+                    if any(suffix in pkg.name for suffix in pkg_subtypes):
+                        continue
+                if FILTER_NOT_BASENAME in filters:
+                    if not any(suffix in pkg.name for suffix in pkg_subtypes):
+                        continue
 
-        version = self.__get_package_version(pkg)
-        id = self.get_package_id(pkg.name, version, pkg.architecture, data)
-        return self.package(id, status, pkg.summary)
+            version = self.__get_package_version(pkg)
+            pkg_id = self.get_package_id(pkg.name, version, pkg.architecture, data)
+            self.package(pkg_id, status, pkg.summary)
 
     def depends_on(self, filters, package_ids, recursive):
         """Prints a list of depends for a given package"""
@@ -983,13 +1003,7 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
         for package in values:
             name = self.get_package_from_id(package)[0]
             try:
-                if filters is not None:
-                    self.__get_package(name, filters)
-                else:
-                    # If no filters, show both installed and available if they exist
-                    # we should really fix __get_package to allow emitting multiple results
-                    self.__get_package(name, [FILTER_INSTALLED])
-                    self.__get_package(name, [FILTER_NOT_INSTALLED])
+                self.__get_package(name, filters)
             except PkError as e:
                 if e.code == ERROR_PACKAGE_NOT_FOUND:
                     continue

--- a/backends/eopkg/eopkgBackend.py
+++ b/backends/eopkg/eopkgBackend.py
@@ -297,6 +297,28 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
         pkg_id = self.get_package_id(pkg.name, pkg.version, pkg.architecture, repo)
         return pkg_id
 
+    def _get_package_obj_from_id(self, package_id):
+        """Centralized helper to get package object and data from id"""
+        name, version, arch, data = self.get_package_from_id(package_id)
+        pkg = None
+
+        if data == "local" or data.startswith("installed"):
+            if self.installdb.has_package(name):
+                pkg = self.installdb.get_package(name)
+
+        if pkg is None and self.packagedb.has_package(name):
+            pkg, repo = self.packagedb.get_package_repo(name, None)
+            data = repo
+
+        if pkg is None and self.installdb.has_package(name):
+            pkg = self.installdb.get_package(name)
+            data = "local"
+
+        if pkg is None:
+            raise PkError(ERROR_PACKAGE_NOT_FOUND, "Package %s was not found" % name)
+
+        return pkg, data
+
     def _set_status(self, pkg, status):
         package_id = self._pkg_to_id(pkg)
         self.package(package_id, status, pkg.summary)

--- a/backends/eopkg/eopkgBackend.py
+++ b/backends/eopkg/eopkgBackend.py
@@ -335,10 +335,6 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
     def __get_package(self, package, filters=None):
         """Returns package object suitable for other methods"""
 
-        status = INFO_AVAILABLE
-        data = "installed"
-        pkg = ""
-
         installed = (
             self.installdb.get_package(package)
             if self.installdb.has_package(package)
@@ -354,50 +350,47 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
         if installed is None and available is None:
             raise PkError(ERROR_PACKAGE_NOT_FOUND, "Package %s not found" % package)
 
-        # Unholy matrimony of irish priests who got a deal with the catholic church
-        fltred = None
-        fltr_status = None
-        fltr_data = None
+        pkg = None
+        status = None
+        data = None
+
         if filters is not None:
-            if FILTER_NOT_INSTALLED in filters:
-                fltred = available if available is not None else None
-                if fltred is None:
-                    return
-                fltr_status = INFO_AVAILABLE if fltred is not None else None
-                fltr_data = repo if fltred is not None else None
             if FILTER_INSTALLED in filters:
-                fltred = installed if installed is not None else None
-                if fltred is None:
+                if installed:
+                    pkg = installed
+                    status = INFO_INSTALLED
+                    data = "installed:{}".format(repo) if repo else "installed"
+                else:
                     return
-                fltr_status = INFO_INSTALLED if fltred is not None else None
-                fltr_data = "installed:{}".format(repo) if repo is not None else data
-            # FIXME: Newest should be able to show the newest local version as well as remote version
-            if FILTER_NEWEST in filters:
-                fltred = available if available is not None else installed
-                fltr_status = INFO_AVAILABLE if fltred is not None else None
-                fltr_data = repo if fltred is not None else None
-            if FILTER_NEWEST in filters and FILTER_INSTALLED in filters:
-                fltred = installed if installed is not None else None
-                fltr_status = INFO_INSTALLED if fltred is not None else None
-                fltr_data = "installed:{}".format(repo) if repo is not None else data
+            elif FILTER_NOT_INSTALLED in filters:
+                if available:
+                    pkg = available
+                    status = INFO_AVAILABLE
+                    data = repo
+                else:
+                    return
+            elif FILTER_NEWEST in filters:
+                if available:
+                    pkg = available
+                    status = INFO_AVAILABLE
+                    data = repo
+                elif installed:
+                    pkg = installed
+                    status = INFO_INSTALLED
+                    data = "installed"
+                else:
+                    return
 
-        # Installed and has repo origin
-        if available is not None and installed is not None:
-            pkg = fltred if fltred is not None else installed
-            status = fltr_status if fltr_status is not None else INFO_INSTALLED
-            data = fltr_data if fltr_data is not None else "installed:{}".format(repo)
-
-        # Available but not installed
-        if available is not None and installed is None:
-            pkg = fltred if fltred is not None else available
-            status = fltr_status if fltr_status is not None else INFO_AVAILABLE
-            data = fltr_data if fltr_data is not None else repo
-
-        # Installed but has no repo origin
-        if installed is not None and available is None:
-            pkg = fltred if fltred is not None else installed
-            status = fltr_status if fltr_status is not None else INFO_INSTALLED
-            data = fltr_data if fltr_data is not None else "installed"
+        # Fallback if no filter matched or no filters provided
+        if pkg is None:
+            if installed:
+                pkg = installed
+                status = INFO_INSTALLED
+                data = "installed:{}".format(repo) if repo else "installed"
+            else:
+                pkg = available
+                status = INFO_AVAILABLE
+                data = repo
 
         if filters is not None:
             if FILTER_GUI in filters and "app:gui" not in pkg.isA:

--- a/backends/eopkg/eopkgBackend.py
+++ b/backends/eopkg/eopkgBackend.py
@@ -586,7 +586,6 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
         self.percentage(None)
 
         packages = list()
-        all_pkgs = False
         installed = self.installdb.list_installed()
         available = self.packagedb.list_packages(None)
 


### PR DESCRIPTION
- Adjust percentage callbacks for eopkg v4.5.0, an upgrading or installing event is emitted instead of just an installing event and live extraction percentage updates are emitted. This allows us to clean up some of the percentage callback hacks that were employed to workaround this limited callback system
- Fix a bunch of minor filtering and resolving issues, behaviour was observed like for a like on a known good backend (dnf) across a bunch of scenarios. This fixed some minor niggles such as package id mismatches in the discover updates view causing package sizes to report as unknown.