### PR TITLE
dnf5: Set cacheonly mode when offline at startup

### DIFF
--- a/backends/dnf5/dnf5-backend-thread.cpp
+++ b/backends/dnf5/dnf5-backend-thread.cpp
@@ -41,9 +41,12 @@ dnf5_query_thread (PkBackendJob *job, GVariant *params, gpointer user_data)
 	PkBackend *backend = (PkBackend *) pk_backend_job_get_backend (job);
 	PkBackendDnf5Private *priv = (PkBackendDnf5Private *) pk_backend_get_user_data (backend);
 	PkRoleEnum role = pk_backend_job_get_role (job);
-	
+
 	g_autoptr(GMutexLocker) locker = g_mutex_locker_new (&priv->mutex);
-	
+
+	// Update cache-only mode based on current network state
+	dnf5_update_network_state(priv, pk_backend_is_online(backend));
+
 	try {
 		if (role == PK_ROLE_ENUM_SEARCH_NAME || role == PK_ROLE_ENUM_SEARCH_DETAILS || role == PK_ROLE_ENUM_SEARCH_FILE || role == PK_ROLE_ENUM_RESOLVE || role == PK_ROLE_ENUM_WHAT_PROVIDES) {
 			PkBitfield filters;
@@ -356,9 +359,12 @@ dnf5_transaction_thread (PkBackendJob *job, GVariant *params, gpointer user_data
 	PkBackend *backend = (PkBackend *) pk_backend_job_get_backend (job);
 	PkBackendDnf5Private *priv = (PkBackendDnf5Private *) pk_backend_get_user_data (backend);
 	PkRoleEnum role = pk_backend_job_get_role (job);
-	
+
 	g_autoptr(GMutexLocker) locker = g_mutex_locker_new (&priv->mutex);
-	
+
+	// Update cache-only mode based on current network state
+	dnf5_update_network_state(priv, pk_backend_is_online(backend));
+
 	try {
 		if (role == PK_ROLE_ENUM_UPGRADE_SYSTEM) {
 			gchar *distro_id = NULL;
@@ -570,9 +576,12 @@ dnf5_repo_thread (PkBackendJob *job, GVariant *params, gpointer user_data)
 	PkBackend *backend = (PkBackend *) pk_backend_job_get_backend (job);
 	PkBackendDnf5Private *priv = (PkBackendDnf5Private *) pk_backend_get_user_data (backend);
 	PkRoleEnum role = pk_backend_job_get_role (job);
-	
+
 	g_autoptr(GMutexLocker) locker = g_mutex_locker_new (&priv->mutex);
-	
+
+	// Update cache-only mode based on current network state
+	dnf5_update_network_state(priv, pk_backend_is_online(backend));
+
 	try {
 		if (role == PK_ROLE_ENUM_REPO_ENABLE || role == PK_ROLE_ENUM_REPO_SET_DATA) {
 			gchar *repo_id = NULL;

--- a/backends/dnf5/dnf5-backend-utils.cpp
+++ b/backends/dnf5/dnf5-backend-utils.cpp
@@ -40,7 +40,7 @@
 #include "dnf5-backend-vendor.hpp"
 
 void
-dnf5_setup_base (PkBackendDnf5Private *priv, gboolean refresh, gboolean force, const char *releasever)
+dnf5_setup_base (PkBackendDnf5Private *priv, gboolean refresh, gboolean force, const char *releasever, gboolean online)
 {
 	priv->base = std::make_unique<libdnf5::Base>();
 
@@ -93,7 +93,7 @@ dnf5_setup_base (PkBackendDnf5Private *priv, gboolean refresh, gboolean force, c
 	}
 
 	priv->base->setup();
-	
+
 	// Ensure releasever is set AFTER setup() because setup() might run auto-detection and overwrite it.
 	if (priv->conf != NULL) {
 		g_autofree gchar *distro_version = NULL;
@@ -107,7 +107,14 @@ dnf5_setup_base (PkBackendDnf5Private *priv, gboolean refresh, gboolean force, c
 			priv->base->get_vars()->set("releasever", distro_version);
 		}
 	}
-	
+
+	// online defaults to TRUE. Only change the configuration if the caller passed FALSE
+	if (!online) {
+		// When offline, use cache-only mode to avoid network errors
+		g_debug("Using cache-only mode (not refreshing metadata)");
+		config.get_cacheonly_option().set(libdnf5::Option::Priority::RUNTIME, "all");
+	}
+
 	auto repo_sack = priv->base->get_repo_sack();
 	repo_sack->create_repos_from_system_configuration();
 	repo_sack->get_system_repo();
@@ -129,6 +136,19 @@ dnf5_setup_base (PkBackendDnf5Private *priv, gboolean refresh, gboolean force, c
 	query.filter_enabled(true);
 	for (auto repo : query) {
 		g_debug("Enabled repository: %s", repo->get_id().c_str());
+	}
+}
+
+void
+dnf5_update_network_state(PkBackendDnf5Private *priv, gboolean online)
+{
+	auto &config = priv->base->get_config();
+	if (online) {
+		g_debug("Clearing cache-only mode (online)");
+		config.get_cacheonly_option().set(libdnf5::Option::Priority::RUNTIME, "none");
+	} else {
+		g_debug("Setting cache-only mode (offline)");
+		config.get_cacheonly_option().set(libdnf5::Option::Priority::RUNTIME, "all");
 	}
 }
 

--- a/backends/dnf5/dnf5-backend-utils.hpp
+++ b/backends/dnf5/dnf5-backend-utils.hpp
@@ -40,7 +40,8 @@ typedef struct {
 	gint64 last_notification_timestamp;
 } PkBackendDnf5Private;
 
-void dnf5_setup_base(PkBackendDnf5Private *priv, gboolean refresh = FALSE, gboolean force = FALSE, const char *releasever = nullptr);
+void dnf5_setup_base(PkBackendDnf5Private *priv, gboolean refresh = FALSE, gboolean force = FALSE, const char *releasever = nullptr, gboolean online = TRUE);
+void dnf5_update_network_state(PkBackendDnf5Private *priv, gboolean online);
 void dnf5_refresh_cache(PkBackendDnf5Private *priv, gboolean force);
 PkInfoEnum dnf5_advisory_kind_to_info_enum(const std::string &type);
 PkInfoEnum dnf5_update_severity_to_enum(const std::string &severity);

--- a/backends/dnf5/pk-backend-dnf5.cpp
+++ b/backends/dnf5/pk-backend-dnf5.cpp
@@ -114,8 +114,12 @@ pk_backend_context_invalidate_cb (PkBackend *backend, PkBackend *backend_data)
 	PkBackendDnf5Private *priv = (PkBackendDnf5Private *) pk_backend_get_user_data (backend);
 	g_autoptr(GMutexLocker) locker = g_mutex_locker_new (&priv->mutex);
 
-	dnf5_setup_base (priv);
-	priv->last_notification_timestamp = g_get_monotonic_time ();
+	try {
+		dnf5_setup_base (priv);
+		priv->last_notification_timestamp = g_get_monotonic_time ();
+	} catch (const std::exception &e) {
+		g_warning ("Failed to invalidate dnf5 base: %s", e.what());
+	}
 }
 
 void

--- a/backends/dnf5/pk-backend-dnf5.cpp
+++ b/backends/dnf5/pk-backend-dnf5.cpp
@@ -150,7 +150,7 @@ pk_backend_initialize (GKeyFile *conf, PkBackend *backend)
 	}
 
 	try {
-		dnf5_setup_base (priv);
+		dnf5_setup_base (priv, FALSE, FALSE, nullptr, pk_backend_is_online(backend));
 		g_signal_connect (backend, "updates-changed",
 				  G_CALLBACK (pk_backend_context_invalidate_cb), backend);
 	} catch (const std::exception &e) {


### PR DESCRIPTION
When dnf5_setup_base() is called with refresh=FALSE (e.g., during update application or when invalidating the base), enable cache-only mode to prevent network access attempts. This fixes update failures when the system is offline or when network is not yet available during boot.

This matches the behavior of dnf5's own offline update implementation, which sets cacheonly="all" to work exclusively from cached metadata and downloaded packages.