### PR TITLE
apt: Select the new '3.0' solver if available

### DIFF
--- a/backends/apt/pk-backend-apt.cpp
+++ b/backends/apt/pk-backend-apt.cpp
@@ -84,6 +84,10 @@ void pk_backend_initialize(GKeyFile *conf, PkBackend *backend)
     if (!pkgInitSystem(*_config, _system)) {
         g_debug("ERROR initializing backend system");
     }
+
+    // Select the new solver
+    if (APT_PKG_ABI >= 700)
+        _config->Set("APT::Solver", "3.0");
 }
 
 void pk_backend_destroy(PkBackend *backend)


### PR DESCRIPTION
The solver was introduced with libapt-pkg7.0, conditionally enable it when available.

This needs some testing: The new solver behaves _slightly_ different in some cases, and particularly is broken when calling MarkDelete() without Protect() [it always pretends Protect was called]; hence why it is not the default in the library yet.

As far as I can observe from the code, all uses are compatible with the new solver, so it would make sense to opt packageKit in before the solver is more fully API compatible.