### PR TITLE
spawned: Add support for emitting update severity

### DIFF
--- a/backends/eopkg/eopkgBackend.py
+++ b/backends/eopkg/eopkgBackend.py
@@ -654,9 +654,8 @@ class PackageKitEopkgBackend(PackageKitBaseBackend, PackagekitPackage):
             histories = self._get_history_between(oldRelease, pkg)
 
             securities = [x for x in histories if x.type == "security"]
-            # FIXME: INFO_BUGFIX Support? We would have to match against #123 Github issues
             if len(securities) > 0:
-                self.package(id, INFO_SECURITY, pkg.summary)
+                self.package(id, INFO_SECURITY, pkg.summary, INFO_CRITICAL)
             else:
                 self.package(id, INFO_NORMAL, pkg.summary)
 

--- a/backends/test/helpers/search-name.sh
+++ b/backends/test/helpers/search-name.sh
@@ -15,10 +15,10 @@ echo -e "percentage\t10"
 echo -e "status\tquery"
 sleep 1
 echo -e "percentage\t30"
-echo -e "package\tavailable\tglib2;2.14.0;i386;fedora\tThe GLib library"
+echo -e "package\tavailable\tglib2;2.14.0;i386;fedora\tThe GLib library\tunknown"
 sleep 1
 echo -e "percentage\t70"
-echo -e "package\tinstalled\tgtk2;gtk2-2.11.6-6.fc8;i386;fedora\tGTK+ Libraries for GIMP"
+echo -e "package\tinstalled\tgtk2;gtk2-2.11.6-6.fc8;i386;fedora\tGTK+ Libraries for GIMP\tunknown"
 sleep 1
 echo -e "percentage\t100"
 exit 0

--- a/lib/python/packagekit/backend.py
+++ b/lib/python/packagekit/backend.py
@@ -179,14 +179,17 @@ class PackageKitBaseBackend:
         sys.stdout.write(_to_utf8("message\t%s\t%s\n" % (typ, msg)))
         sys.stdout.flush()
 
-    def package(self, package_id, status, summary):
+    def package(self, package_id, status, summary, severity: str | None = None):
         '''
         send 'package' signal
         @param info: the enumerated INFO_* string
         @param package_id: The package ID name, e.g. openoffice-clipart;2.6.22;ppc64;fedora
         @param summary: The package Summary
+        @param severity: enumerated INFO_* string for update severity (optional)
         '''
-        sys.stdout.write(_to_utf8("package\t%s\t%s\t%s\n" % (status, package_id, summary)))
+        if severity is None:
+            severity = INFO_UNKNOWN
+        sys.stdout.write(_to_utf8("package\t%s\t%s\t%s\t%s\n" % (status, package_id, summary, severity)))
         sys.stdout.flush()
 
     def media_change_required(self, mtype, id, text):

--- a/src/pk-backend-spawn.c
+++ b/src/pk-backend-spawn.c
@@ -164,7 +164,9 @@ pk_backend_spawn_parse_stdout (PkBackendSpawn *backend_spawn,
 	size = g_strv_length (sections);
 
 	if (g_strcmp0 (command, "package") == 0) {
-		if (size != 4) {
+		PkInfoEnum severity;
+
+		if (size != 5) {
 			g_set_error (error, 1, 0, "invalid command'%s', size %i", command, size);
 			return FALSE;
 		}
@@ -177,6 +179,7 @@ pk_backend_spawn_parse_stdout (PkBackendSpawn *backend_spawn,
 			g_set_error (error, 1, 0, "Info enum not recognised, and hence ignored: '%s'", sections[1]);
 			return FALSE;
 		}
+		severity = pk_info_enum_from_string (sections[4]);
 		g_strdelimit (sections[3], PK_UNSAFE_DELIMITERS, ' ');
 		if (!g_utf8_validate (sections[3], -1, NULL)) {
 			g_set_error (error, 1, 0,
@@ -184,7 +187,7 @@ pk_backend_spawn_parse_stdout (PkBackendSpawn *backend_spawn,
 				     sections[3]);
 			return FALSE;
 		}
-		pk_backend_job_package (job, info, sections[2], sections[3]);
+		pk_backend_job_package_full (job, info, sections[2], sections[3], severity);
 	} else if (g_strcmp0 (command, "details") == 0) {
 		if (size != 9) {
 			g_set_error (error, 1, 0,

--- a/tests/pk-test-daemon-internal.c
+++ b/tests/pk-test-daemon-internal.c
@@ -39,6 +39,7 @@
 
 #define PK_TRANSACTION_ERROR_INPUT_INVALID	14
 #define GET_DETAILS_TEST_DATA "details\tgimp;3.0.4-84;x86_64;Solus\tGNU Image Manipulation Program\tGPL-3.0-or-later\tmultimedia\tGIMP is a mature image editor.\thttps://www.gimp.org/\t"
+#define GET_PACKAGE_TEST_DATA "package\tinstalled\tgnome-power-manager;0.0.1;i386;data\tMore useless software\t"
 
 /** ver:1.0 ***********************************************************/
 static GMainLoop *_test_loop = NULL;
@@ -446,10 +447,55 @@ pk_test_backend_spawn_func (void)
 	g_assert_cmpstr (uri, ==, "ftp://username:password@server:port/");
 	g_free (uri);
 
-	/* test pk_backend_spawn_parse_common_out Package */
+	/* test pk_backend_spawn_inject_data Package - valid (no severity, defaults to unknown) */
+	ret = pk_backend_spawn_inject_data (backend_spawn, job,
+		GET_PACKAGE_TEST_DATA "unknown", NULL);
+	g_assert_true (ret);
+
+	/* test pk_backend_spawn_inject_data Package - valid (normal severity) */
+	ret = pk_backend_spawn_inject_data (backend_spawn, job,
+		GET_PACKAGE_TEST_DATA "normal", NULL);
+	g_assert_true (ret);
+
+	/* test pk_backend_spawn_inject_data Package - valid (important severity) */
+	ret = pk_backend_spawn_inject_data (backend_spawn, job,
+		GET_PACKAGE_TEST_DATA "important", NULL);
+	g_assert_true (ret);
+
+	/* test pk_backend_spawn_inject_data Package - valid (critical severity) */
+	ret = pk_backend_spawn_inject_data (backend_spawn, job,
+		GET_PACKAGE_TEST_DATA "critical", NULL);
+	g_assert_true (ret);
+
+	/* test pk_backend_spawn_inject_data Package - valid (low severity) */
+	ret = pk_backend_spawn_inject_data (backend_spawn, job,
+		GET_PACKAGE_TEST_DATA "low", NULL);
+	g_assert_true (ret);
+
+	/* test pk_backend_spawn_inject_data Package - valid (security) */
+	ret = pk_backend_spawn_inject_data (backend_spawn, job,
+		GET_PACKAGE_TEST_DATA "security", NULL);
+	g_assert_true (ret);
+
+	/* test pk_backend_spawn_inject_data Package - valid (unrecognised severity string defaults to unknown) */
+	ret = pk_backend_spawn_inject_data (backend_spawn, job,
+		GET_PACKAGE_TEST_DATA "totally-legit-severity", NULL);
+	g_assert_true (ret);
+
+	/* test pk_backend_spawn_inject_data Package - invalid (old 4-field format, missing severity) */
 	ret = pk_backend_spawn_inject_data (backend_spawn, job,
 		"package\tinstalled\tgnome-power-manager;0.0.1;i386;data\tMore useless software", NULL);
-	g_assert_true (ret);
+	g_assert_true (!ret);
+
+	/* test pk_backend_spawn_inject_data Package - invalid (wrong number of fields, too few) */
+	ret = pk_backend_spawn_inject_data (backend_spawn, job,
+		"package\tinstalled\tgnome-power-manager;0.0.1;i386;data", NULL);
+	g_assert_true (!ret);
+
+	/* test pk_backend_spawn_inject_data Package - invalid (wrong number of fields, too many) */
+	ret = pk_backend_spawn_inject_data (backend_spawn, job,
+		"package\tinstalled\tgnome-power-manager;0.0.1;i386;data\tsummary\tunknown\textra", NULL);
+	g_assert_true (!ret);
 
 	/* manually unlock as we have no engine */
 	ret = pk_backend_unload (backend);


### PR DESCRIPTION
Allow spawned backends to also emit update severity originally added in commit b30ab47408a4e888c1d4e75319ce272e83b6d8ae.

This follows the same pattern of how "download_size" was hooked up to details().