### PR TITLE
pkgcli: Skip blocked updates in full upgrade too

### DIFF
--- a/client/pkgc-manage.c
+++ b/client/pkgc-manage.c
@@ -652,6 +652,8 @@ pkgc_upgrade (PkgcliContext *ctx, PkgcliCommand *cmd, gint argc, gchar **argv)
 		}
 
 		sack = pk_results_get_package_sack (results);
+		pk_package_sack_remove_by_filter (sack, &pkgc_update_system_filter_helper, NULL);
+
 		package_ids = pk_package_sack_get_ids (sack);
 
 		if (package_ids == NULL || g_strv_length (package_ids) == 0) {


### PR DESCRIPTION
The backend may return some blocked updates.
Passing those ids to the UpdatePackages transaction will make it fail.

We already handle this correctly in `pkgcli update`, since commit 35b203da.