### PR TITLE
dnf5: Fix thinko in query filter for forcing distrosync on upgrade

### DIFF
--- a/backends/dnf5/dnf5-backend-utils.cpp
+++ b/backends/dnf5/dnf5-backend-utils.cpp
@@ -194,7 +194,7 @@ dnf5_force_distupgrade_on_upgrade (libdnf5::Base &base)
 
 	libdnf5::rpm::PackageQuery query(base);
 	query.filter_installed();
-	query.filter_name(distroverpkg_names);
+	query.filter_provides(distroverpkg_names);
 	query.filter_provides(distupgrade_provides);
 
 	return !query.empty();


### PR DESCRIPTION
The query filter mistakenly used query.filter_name() instead of query.filter_provides() which causes this filter to zero out the package set. Consequently, this check always fails and it never gets applied properly.

Fix it so that the check actually works like the original version in the old DNF backend.