### PR TITLE
alpm: fix segfault and abort on invalid-arch error

### DIFF
--- a/backends/alpm/pk-alpm-transaction.c
+++ b/backends/alpm/pk-alpm-transaction.c
@@ -26,6 +26,7 @@
 #include "pk-alpm-packages.h"
 #include "pk-alpm-transaction.h"
 
+#include <stdlib.h>
 #include <syslog.h>
 
 static off_t transaction_dcomplete = 0;
@@ -792,8 +793,10 @@ pk_alpm_transaction_initialize (PkBackendJob* job, alpm_transflag_t flags, const
 	return TRUE;
 }
 
+/* joins a list of strings, as returned by libalpm for
+ * ALPM_ERR_PKG_INVALID_ARCH and ALPM_ERR_PKG_INVALID */
 static gchar *
-pk_alpm_pkg_build_list (const alpm_list_t *i)
+pk_alpm_string_build_list (const alpm_list_t *i)
 {
 	GString *list;
 
@@ -803,8 +806,7 @@ pk_alpm_pkg_build_list (const alpm_list_t *i)
 	for (; i != NULL; i = i->next) {
 		if (i->data == NULL)
 			continue;
-		g_string_append_printf (list, "%s, ",
-					alpm_pkg_get_name (i->data));
+		g_string_append_printf (list, "%s, ", (const gchar *) i->data);
 	}
 
 	if (list->len > 2)
@@ -947,7 +949,11 @@ pk_alpm_transaction_simulate (PkBackendJob *job, GError **error)
 
 	switch (alpm_errno (priv->alpm)) {
 	case ALPM_ERR_PKG_INVALID_ARCH:
-		prefix = pk_alpm_pkg_build_list (data);
+		/* libalpm fills this list with malloc'd "name-version-arch"
+		 * strings (check_arch() in lib/libalpm/trans.c), not
+		 * alpm_pkg_t pointers */
+		prefix = pk_alpm_string_build_list (data);
+		alpm_list_free_inner (data, free);
 		alpm_list_free (data);
 		break;
 	case ALPM_ERR_UNSATISFIED_DEPS:
@@ -1027,21 +1033,6 @@ pk_alpm_transaction_packages (PkBackendJob *job)
 	}
 }
 
-static gchar *
-pk_alpm_string_build_list (const alpm_list_t *i)
-{
-	GString *list;
-
-	if (i == NULL)
-		return NULL;
-	list = g_string_new ("");
-	for (; i != NULL; i = i->next)
-		g_string_append_printf (list, "%s, ", (const gchar *) i->data);
-
-	g_string_truncate (list, list->len - 2);
-	return g_string_free (list, FALSE);
-}
-
 gboolean
 pk_alpm_transaction_commit (PkBackendJob *job, GError **error)
 {
@@ -1071,6 +1062,7 @@ pk_alpm_transaction_commit (PkBackendJob *job, GError **error)
 		break;
 	case ALPM_ERR_PKG_INVALID:
 		prefix = pk_alpm_string_build_list (data);
+		alpm_list_free_inner (data, free);
 		alpm_list_free (data);
 		break;
 	default:
@@ -1112,7 +1104,13 @@ pk_alpm_transaction_end (PkBackendJob *job, GError **error)
 	if (tpkg != NULL)
 		pk_alpm_transaction_output_end ();
 
-	g_assert (pkalpm_current_job);
+	/* pk_alpm_transaction_initialize() may have failed, e.g. because
+	 * the pacman database is locked (ALPM_ERR_HANDLE_LOCK), and callers
+	 * still reach here to clean up.  That must not abort the daemon, and
+	 * alpm_trans_release() must always be attempted so a transaction is
+	 * never left holding the database lock. */
+	if (pkalpm_current_job == NULL)
+		syslog (LOG_DAEMON | LOG_WARNING, "transaction end without an active transaction");
 	pkalpm_current_job = NULL;
 
 	if (alpm_trans_release (priv->alpm) < 0) {


### PR DESCRIPTION
As with the issue, I had help from Claude/AI on this.
But I ran all these tests on my machine and confirmed everything so it's not automated slop.
I confirmed everything follows the contribution rules (had to force push a change to conform).

Fixes #1009, fixes #757, and the remaining transaction-assert half of #399.

`pk_alpm_transaction_simulate()` type-confuses the `ALPM_ERR_PKG_INVALID_ARCH`
error list: libalpm fills it with malloc'd `name-version-arch` strings
(`check_arch()` in `lib/libalpm/trans.c`), but the backend passed it to
`pk_alpm_pkg_build_list()`, which calls `alpm_pkg_get_name()` on each entry.
The wild pointer is dereferenced by `g_string_append_printf()` and the daemon
segfaults mid-transaction, leaving `/var/lib/pacman/db.lck` behind.

From then on every transaction fails in `alpm_trans_init()` with
`ALPM_ERR_HANDLE_LOCK`. `pk_alpm_transaction_initialize()` returns before
setting `pkalpm_current_job`, callers still reach `pk_alpm_transaction_end()`
for cleanup, and its `g_assert (pkalpm_current_job)` aborts the daemon on
every later operation. That is the sequence in #757.

Changes, all in `backends/alpm/pk-alpm-transaction.c`:

- Use the existing string-joining helper for the INVALID_ARCH list. It is
  moved above the new caller, gains NULL-element and empty-list guards, and
  the strings are freed afterwards as pacman does.
- Free the strings for `ALPM_ERR_PKG_INVALID` in the commit path as well;
  libalpm hands over malloc'd filenames there too.
- Replace the `g_assert` in `pk_alpm_transaction_end()` with a syslog warning,
  so a failed initialize is reported instead of aborting the daemon, and
  `alpm_trans_release()` is always attempted.

### Testing

PackageKit 1.3.6 (patch applied to the v1.3.6 tag, identical file), pacman
7.1.0, libalpm 16.0.1, CachyOS x86_64_v4.

PackageKit resolves `Architecture = auto` to `x86_64` via `uname()`, so on a
system with `x86_64_v4` packages any install reaches the error path. The
synthetic case from #1009 also works: `Architecture = x86_64_v4` plus an
install of any `x86_64` package (`figlet`). Note the transaction must add at
least one package; when nothing is pending, `alpm_trans_prepare()` returns
before `check_arch()` runs, so `update` on an up-to-date system does not
trigger it.

Before the patch:

- `pkgcli install sl`: "The daemon crashed mid-transaction!", SIGSEGV with
  `g_string_append_printf` <- `pk_alpm_transaction_simulate` on the stack,
  `db.lck` left behind.
- Same command again: SIGABRT,
  `pk-alpm-transaction.c:1115:pk_alpm_transaction_end: assertion failed:
  (pkalpm_current_job)`.

After the patch:

- `pkgcli install sl`: `Error: sl-5.05-6.1-x86_64_v4: package architecture
  is not valid`. No coredump, no `db.lck`.
- With a stale `db.lck` present: `Error: unable to lock database`, a
  "transaction end without an active transaction" warning in the journal,
  no coredump.
