### PR TITLE
dnf5: Use RepoConfigOverride API for repo configuration

### DIFF
--- a/backends/dnf5/dnf5-backend-thread.cpp
+++ b/backends/dnf5/dnf5-backend-thread.cpp
@@ -26,8 +26,9 @@
 #include <libdnf5/advisory/advisory_query.hpp>
 #include <libdnf5/rpm/reldep_list.hpp>
 #include <libdnf5/base/transaction.hpp>
+#include <libdnf5/conf/option_bool.hpp>
 #include <libdnf5/repo/package_downloader.hpp>
-#include <libdnf5/conf/config_parser.hpp>
+#include <libdnf5/repo/repo_config_override.hpp>
 #include <pk-common-private.h>
 #include <pk-update-detail.h>
 #include <rpm/rpmlib.h>
@@ -770,11 +771,30 @@ dnf5_repo_thread(PkBackendJob *job, GVariant *params, gpointer user_data)
 				g_variant_get(params, "(&s&s&s)", &repo_id, &parameter, &value);
 			}
 
-			libdnf5::repo::RepoQuery query(*priv->base);
-			query.filter_id(repo_id);
-			for (auto repo : query) {
-				if (g_strcmp0(parameter, "enabled") == 0) {
-					bool enable = (g_strcmp0(value, "1") == 0 || g_strcmp0(value, "true") == 0);
+			// Validate that the repository ID exists
+			{
+				libdnf5::repo::RepoQuery query(*priv->base);
+				query.filter_id(repo_id);
+				if (query.empty()) {
+					pk_backend_job_error_code(
+						job,
+						PK_ERROR_ENUM_REPO_NOT_FOUND,
+						"Repo %s not found",
+						repo_id);
+					pk_backend_job_finished(job);
+					return;
+				}
+			}
+
+			// For "enabled" changes, check if the repo is already in the desired state
+			if (g_strcmp0(parameter, "enabled") == 0) {
+				libdnf5::OptionBool opt(false);
+				opt.set(std::string(value));
+				bool enable = opt.get_value();
+
+				libdnf5::repo::RepoQuery query(*priv->base);
+				query.filter_id(repo_id);
+				for (auto repo : query) {
 					if (repo->is_enabled() == enable) {
 						pk_backend_job_error_code(
 							job,
@@ -783,16 +803,20 @@ dnf5_repo_thread(PkBackendJob *job, GVariant *params, gpointer user_data)
 						pk_backend_job_finished(job);
 						return;
 					}
-					if (enable)
-						repo->enable();
-					else
-						repo->disable();
-					libdnf5::ConfigParser parser;
-					parser.read(repo->get_repo_file_path());
-					parser.set_value(repo_id, "enabled", value);
-					parser.write(repo->get_repo_file_path(), false);
 				}
 			}
+
+			// Use RepoConfigOverride to persistently save the override
+			std::map<std::string, std::map<std::string, std::string>> overrides;
+			if (g_strcmp0(parameter, "enabled") == 0) {
+				libdnf5::OptionBool opt(false);
+				opt.set(std::string(value));
+				overrides[repo_id][parameter] = opt.get_value() ? "1" : "0";
+			} else {
+				overrides[repo_id][parameter] = value;
+			}
+			libdnf5::repo::RepoConfigOverride config_override(*priv->base);
+			config_override.save(overrides);
 			dnf5_setup_base(priv);
 		} else if (role == PK_ROLE_ENUM_REPO_REMOVE) {
 			gchar *repo_id = NULL;

--- a/backends/dnf5/meson.build
+++ b/backends/dnf5/meson.build
@@ -1,7 +1,7 @@
 
 add_languages('cpp', native: false)
 
-dnf5_dep = dependency('libdnf5', version: '>=5.2.17.0')
+dnf5_dep = dependency('libdnf5', version: '>=5.4.3.0')
 libdnf5_version = dnf5_dep.version().split('.')
 
 pk_backend_modules += shared_module(


### PR DESCRIPTION
This ensures PackageKit-driven repository configuration changes work properly in environments where the configuration data is installed into /usr (and thus expected to be read-only).